### PR TITLE
Mini OCP

### DIFF
--- a/cdvae/common/data_utils.py
+++ b/cdvae/common/data_utils.py
@@ -5,22 +5,27 @@ import torch
 import copy
 import itertools
 
+from ase import Atoms
 from pymatgen.core.structure import Structure
 from pymatgen.core.lattice import Lattice
 from pymatgen.analysis.graphs import StructureGraph
 from pymatgen.analysis import local_env
 
 from networkx.algorithms.components import is_connected
+from pymatgen.io.ase import AseAtomsAdaptor
 
 from sklearn.metrics import accuracy_score, recall_score, precision_score
 
 from torch_scatter import scatter
 
 from p_tqdm import p_umap
+import pyarrow as pa
 
 
 # Tensor of unit cells. Assumes 27 cells in -1, 0, 1 offsets in the x and y dimensions
 # Note that differing from OCP, we have 27 offsets here because we are in 3D
+from common.parse import atoms_json_loads
+
 OFFSET_LIST = [
     [-1, -1, -1],
     [-1, -1, 0],
@@ -87,7 +92,11 @@ CrystalNN = local_env.CrystalNN(
 def build_crystal(crystal_str, niggli=True, primitive=False):
     """Build crystal from cif string."""
     crystal = Structure.from_str(crystal_str, fmt='cif')
+    return get_crystal_from_structure(crystal, niggli, primitive)
 
+
+def get_crystal_from_structure(crystal, niggli=True, primitive=False):
+    """Build crystal from cif string."""
     if primitive:
         crystal = crystal.get_primitive_structure()
 
@@ -659,6 +668,43 @@ def preprocess(input_file, num_workers, niggli, primitive, graph_method,
         properties = {k: row[k] for k in prop_list if k in row.keys()}
         result_dict = {
             'mp_id': row['material_id'],
+            'cif': crystal_str,
+            'graph_arrays': graph_arrays,
+        }
+        result_dict.update(properties)
+        return result_dict
+
+    unordered_results = p_umap(
+        process_one,
+        [df.iloc[idx] for idx in range(len(df))],
+        [niggli] * len(df),
+        [primitive] * len(df),
+        [graph_method] * len(df),
+        [prop_list] * len(df),
+        num_cpus=num_workers)
+
+    mpid_to_results = {result['mp_id']: result for result in unordered_results}
+    ordered_results = [mpid_to_results[df.iloc[idx]['material_id']]
+                       for idx in range(len(df))]
+
+    return ordered_results
+
+
+def preprocess_arrow(input_file, num_workers, niggli, primitive, graph_method,
+               prop_list):
+    table = pa.RecordBatchFileReader(pa.OSFile(input_file, 'rb')).read_all()
+    df = table.to_pandas()
+
+    def process_one(row, niggli, primitive, graph_method, prop_list):
+        crystal_str = row['atoms_json']
+        atoms = Atoms.fromdict(atoms_json_loads(crystal_str))
+        structure = AseAtomsAdaptor.get_structure(atoms)
+        crystal = get_crystal_from_structure(
+            structure, niggli=niggli, primitive=primitive)
+        graph_arrays = build_crystal_graph(crystal, graph_method)
+        properties = {k: row[k] for k in prop_list if k in row.keys()}
+        result_dict = {
+            'mp_id': row['key'],
             'cif': crystal_str,
             'graph_arrays': graph_arrays,
         }

--- a/cdvae/common/data_utils.py
+++ b/cdvae/common/data_utils.py
@@ -707,6 +707,7 @@ def preprocess_arrow(input_file, num_workers, niggli, primitive, graph_method,
             'mp_id': row['key'],
             'cif': crystal_str,
             'graph_arrays': graph_arrays,
+            'energy_per_atom': atoms.info['energy'] / len(atoms)
         }
         result_dict.update(properties)
         return result_dict
@@ -721,7 +722,7 @@ def preprocess_arrow(input_file, num_workers, niggli, primitive, graph_method,
         num_cpus=num_workers)
 
     mpid_to_results = {result['mp_id']: result for result in unordered_results}
-    ordered_results = [mpid_to_results[df.iloc[idx]['material_id']]
+    ordered_results = [mpid_to_results[df.iloc[idx]['key']]
                        for idx in range(len(df))]
 
     return ordered_results

--- a/cdvae/common/parse.py
+++ b/cdvae/common/parse.py
@@ -1,0 +1,36 @@
+from typing import Any, Dict, TextIO
+
+import numpy as np
+import json
+
+from ase import Atoms
+
+
+def atom_json_default(obj: Any) -> Dict:
+    if hasattr(obj, "todict"):
+        return obj.todict()
+    if isinstance(obj, np.ndarray):
+        return {"_np": True, "_d": obj.tolist()}
+    raise TypeError
+
+
+def atom_object_hook(dct: Dict) -> Any:
+    if "_np" in dct:
+        return np.array(dct["_d"])
+    return dct
+
+
+def atoms_json_dump(atoms: Atoms, file_obj: TextIO) -> None:
+    return json.dump(atoms, file_obj, default=atom_json_default)
+
+
+def atoms_json_dumps(atoms: Atoms) -> str:
+    return json.dumps(atoms, default=atom_json_default)
+
+
+def atoms_json_load(file_obj: TextIO) -> Atoms:
+    return Atoms.fromdict(json.load(file_obj, object_hook=atom_object_hook))
+
+
+def atoms_json_loads(s: str) -> Atoms:
+    return json.loads(s, object_hook=atom_object_hook)

--- a/conf/data/ocp.yaml
+++ b/conf/data/ocp.yaml
@@ -1,0 +1,67 @@
+root_path: ${oc.env:PROJECT_ROOT}/data/ocp
+prop: energy_per_atom
+num_targets: 1
+# prop: scaled_lattice
+# num_targets: 6
+niggli: true
+primitive: false
+graph_method: crystalnn
+lattice_scale_method: scale_length
+preprocess_workers: 3
+readout: mean
+max_atoms: 24
+otf_graph: false
+eval_model_name: carbon
+
+
+train_max_epochs: 80
+early_stopping_patience: 100000
+teacher_forcing_max_epoch: 1000
+
+
+datamodule:
+  _target_: cdvae.pl_data.datamodule.CrystDataModule
+
+  datasets:
+    train:
+      _target_: cdvae.pl_data.dataset.ArrowCrystDataset
+      name: Formation energy train
+      path: ${data.root_path}/train.arrow
+      prop: ${data.prop}
+      niggli: ${data.niggli}
+      primitive: ${data.primitive}
+      graph_method: ${data.graph_method}
+      lattice_scale_method: ${data.lattice_scale_method}
+      preprocess_workers: ${data.preprocess_workers}
+
+    val:
+      - _target_: cdvae.pl_data.dataset.CrystDataset
+        name: Formation energy val
+        path: ${data.root_path}/val.csv
+        prop: ${data.prop}
+        niggli: ${data.niggli}
+        primitive: ${data.primitive}
+        graph_method: ${data.graph_method}
+        lattice_scale_method: ${data.lattice_scale_method}
+        preprocess_workers: ${data.preprocess_workers}
+
+    test:
+      - _target_: cdvae.pl_data.dataset.CrystDataset
+        name: Formation energy test
+        path: ${data.root_path}/test.csv
+        prop: ${data.prop}
+        niggli: ${data.niggli}
+        primitive: ${data.primitive}
+        graph_method: ${data.graph_method}
+        lattice_scale_method: ${data.lattice_scale_method}
+        preprocess_workers: ${data.preprocess_workers}
+
+  num_workers:
+    train: 2
+    val: 2
+    test: 2
+
+  batch_size:
+    train: 32
+    val: 32
+    test: 32

--- a/conf/data/ocp.yaml
+++ b/conf/data/ocp.yaml
@@ -9,7 +9,7 @@ graph_method: crystalnn
 lattice_scale_method: scale_length
 preprocess_workers: 3
 readout: mean
-max_atoms: 24
+max_atoms: 240
 otf_graph: false
 eval_model_name: carbon
 

--- a/conf/ocp.yaml
+++ b/conf/ocp.yaml
@@ -1,0 +1,29 @@
+expname: test
+
+# metadata specialised for each experiment
+core:
+  version: 0.0.1
+  tags:
+    - ${now:%Y-%m-%d}
+
+hydra:
+  run:
+    dir: ${oc.env:HYDRA_JOBS}/singlerun/${now:%Y-%m-%d}/${expname}/
+
+  sweep:
+    dir: ${oc.env:HYDRA_JOBS}/multirun/${now:%Y-%m-%d}/${expname}/
+    subdir: ${hydra.job.num}_${hydra.job.id}
+
+  job:
+    env_set:
+      WANDB_START_METHOD: thread
+      WANDB_DIR: ${oc.env:WABDB_DIR}
+
+defaults:
+  - data: ocp
+  - model: vae_mini
+  - logging: offline
+  - optim: default
+  - train: cpu
+#    Decomment this parameter to get parallel job running
+  # - override hydra/launcher: joblib

--- a/data/ocp/README.md
+++ b/data/ocp/README.md
@@ -1,0 +1,36 @@
+# Carbon-24
+
+Carbon-24 contains 10k carbon materials, which share the same composition, but have different structures. There is 1 element and the materials have 6 - 24 atoms in the unit cells.
+
+## What is in the dataset?
+
+Carbon-24 includes various carbon structures obtained via *ab initio* random structure searching (AIRSS) (Pickard & Needs, 2006; 2011) performed at 10 GPa.
+
+## Stabiity of curated materials
+
+The original dataset includes 101529 carbon structures, and we selected the 10% of the carbon structure with the lowest energy per atom to create Carbon-24. All 10153 structures are at local energy minimum after DFT relaxation. The most stable structure is diamond at 10 GPa. All remaining structures are thermodynamically unstable but may be kinetically stable.
+
+## Visualization of structures
+
+<p align="center">
+  <img src="../../assets/carbon_24.png" />
+</p>
+
+## Citation
+
+Please consider citing the following paper:
+
+```
+@misc{carbon2020data,
+  doi = {10.24435/MATERIALSCLOUD:2020.0026/V1},
+  url = {https://archive.materialscloud.org/record/2020.0026/v1},
+  author = {Pickard,  Chris J.},
+  keywords = {DFT,  ab initio random structure searching,  carbon},
+  language = {en},
+  title = {AIRSS data for carbon at 10GPa and the C+N+H+O system at 1GPa},
+  publisher = {Materials Cloud},
+  year = {2020},
+  copyright = {info:eu-repo/semantics/openAccess}
+}
+```
+

--- a/data/ocp/test.csv
+++ b/data/ocp/test.csv
@@ -1,0 +1,14285 @@
+,material_id,cif,energy_per_atom
+56,C-13927-8536-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48771000
+_cell_length_b   4.30363000
+_cell_length_c   5.56016000
+_cell_angle_alpha   104.97964000
+_cell_angle_beta   77.06501000
+_cell_angle_gamma   106.79140000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   54.33243883
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.86007107  0.12297792  0.62914364  1
+  C  C1  1  0.65759914  0.77315032  0.68003876  1
+  C  C2  1  0.86114629  0.37275763  0.87869956  1
+  C  C3  1  0.45811255  0.92338138  0.23013042  1
+  C  C4  1  0.05744759  0.72325121  0.83012158  1
+  C  C5  1  0.45920134  0.17311819  0.47941115  1
+  C  C6  1  0.25925505  0.57275469  0.27909055  1
+  C  C7  1  0.65814689  0.52269627  0.42920289  1
+  C  C8  1  0.26090263  0.32259584  0.02859926  1
+  C  C9  1  1.05746626  -0.02664955  0.08029058  1
+",-154.546684
+3900,C-72728-4135-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46118000
+_cell_length_b   3.39244000
+_cell_length_c   6.05929000
+_cell_angle_alpha   109.90329000
+_cell_angle_beta   101.73976000
+_cell_angle_gamma   111.21257000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.15237126
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.84733713  0.43336565  0.57499431  1
+  C  C1  1  0.31560848  0.49825035  0.44827578  1
+  C  C2  1  0.21879144  -0.01900675  0.77050618  1
+  C  C3  1  0.46091828  0.19097412  0.04609510  1
+  C  C4  1  0.68900580  0.04670480  0.64431275  1
+  C  C5  1  0.07267587  0.28879942  0.17280926  1
+",-154.1593995
+863,C-92152-5470-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48213000
+_cell_length_b   3.84597000
+_cell_length_c   4.48941000
+_cell_angle_alpha   89.94619000
+_cell_angle_beta   56.43797000
+_cell_angle_gamma   89.99924000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.71202137
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.62733303  0.08132258  0.43140573  1
+  C  C1  1  0.62729416  0.49146159  0.43184836  1
+  C  C2  1  0.89450393  0.78624597  0.16449912  1
+  C  C3  1  0.89053700  0.49121148  0.66853868  1
+  C  C4  1  0.62369749  0.78584823  0.93544367  1
+  C  C5  1  -0.10953841  0.08108264  0.66817004  1
+",-154.15883866666667
+4676,C-170380-2255-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48146000
+_cell_length_b   3.68944000
+_cell_length_c   4.84116000
+_cell_angle_alpha   111.46932000
+_cell_angle_beta   104.84280000
+_cell_angle_gamma   109.66017000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.01530735
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.57771759  0.23640335  0.38553361  1
+  C  C1  1  0.55454255  0.89186096  0.68282885  1
+  C  C2  1  0.59454512  0.47546081  0.17884258  1
+  C  C3  1  0.30300806  0.76278953  0.30932290  1
+  C  C4  1  0.26406766  0.17964345  0.81386444  1
+  C  C5  1  0.27983642  0.41867700  0.60717941  1
+",-154.31335816666666
+1157,C-193944-7687-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.39803000
+_cell_length_b   3.31211000
+_cell_length_c   5.33433000
+_cell_angle_alpha   81.62724000
+_cell_angle_beta   81.13780000
+_cell_angle_gamma   92.59687000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.54595642
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64978876  0.41003733  0.15457070  1
+  C  C1  1  0.82541939  0.28700003  0.72446888  1
+  C  C2  1  0.41806264  0.20403550  0.40644851  1
+  C  C3  1  1.01138337  0.76351775  1.13670866  1
+  C  C4  1  0.42394323  0.71707928  0.99929501  1
+  C  C5  1  0.08466865  0.86698593  0.39941688  1
+  C  C6  1  0.71261822  -0.00716241  0.55641372  1
+  C  C7  1  0.75509326  1.07516690  -0.00024515  1
+  C  C8  1  0.20729906  0.49160718  0.57408803  1
+  C  C9  1  0.51415604  0.61894840  0.72575196  1
+",-154.305662
+7189,C-145323-1843-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.96269000
+_cell_length_b   3.97234000
+_cell_length_c   4.25525000
+_cell_angle_alpha   94.59596000
+_cell_angle_beta   68.60786000
+_cell_angle_gamma   117.86036000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   68.63623235
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.84591804  0.48159465  0.22676639  1
+  C  C1  1  0.19333364  0.45774036  0.39300683  1
+  C  C2  1  0.88338195  0.49173080  0.57886480  1
+  C  C3  1  0.57366599  0.81476711  0.68558575  1
+  C  C4  1  0.90139689  0.84786298  0.71097830  1
+  C  C5  1  0.23790296  0.17991601  0.52872221  1
+  C  C6  1  0.85150453  0.84493262  0.09440008  1
+  C  C7  1  0.36067560  0.37020217  0.80087814  1
+  C  C8  1  0.07937328  0.29343067  0.10520697  1
+  C  C9  1  0.55871103  0.17596048  0.85090470  1
+  C  C10  1  0.52805644  0.81382425  0.33534113  1
+  C  C11  1  0.52491763  0.15761190  0.23295339  1
+",-154.08878833333333
+666,C-34623-4-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.39359000
+_cell_length_b   3.35675000
+_cell_length_c   5.73051000
+_cell_angle_alpha   108.27090000
+_cell_angle_beta   126.91852000
+_cell_angle_gamma   87.89646000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.56025477
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79790531  0.16201359  0.95244707  1
+  C  C1  1  0.17747796  0.60068424  0.16599495  1
+  C  C2  1  0.32154670  0.67414975  0.97583526  1
+  C  C3  1  0.65157270  0.56068019  0.45210538  1
+  C  C4  1  0.84445798  -0.06466839  0.16576116  1
+  C  C5  1  0.27097468  0.24001053  0.77101889  1
+  C  C6  1  0.94224030  0.26219830  0.45160505  1
+  C  C7  1  0.96286567  0.90370108  0.77088615  1
+",-154.20003125
+4631,C-73665-9416-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47580000
+_cell_length_b   4.18437000
+_cell_length_c   5.39280000
+_cell_angle_alpha   112.80279000
+_cell_angle_beta   117.33662000
+_cell_angle_gamma   90.00369000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   44.65541458
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.43453636  0.43336320  0.21883186  1
+  C  C1  1  -0.23159428  0.47012092  0.55262568  1
+  C  C2  1  0.77950777  0.22625698  1.06415090  1
+  C  C3  1  0.42298787  0.04722050  0.70743597  1
+  C  C4  1  0.77988247  0.85645504  0.06443857  1
+  C  C5  1  -0.23170579  0.10018272  0.55245144  1
+  C  C6  1  0.43481744  0.80363056  0.21910407  1
+  C  C7  1  0.42301406  0.67719698  0.70752852  1
+",-154.4044075
+779,C-134173-4385-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43272000
+_cell_length_b   5.94168000
+_cell_length_c   6.42147000
+_cell_angle_alpha   98.26568000
+_cell_angle_beta   79.09601000
+_cell_angle_gamma   114.21849000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   82.89410179
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20591480  0.42138707  0.35319521  1
+  C  C1  1  0.73596688  0.68974133  0.82585859  1
+  C  C2  1  0.15047495  0.67672571  0.97070590  1
+  C  C3  1  0.65191817  0.04892966  0.71285986  1
+  C  C4  1  1.21596445  0.31897175  0.12804424  1
+  C  C5  1  0.31319627  0.91100023  0.11653154  1
+  C  C6  1  -0.10766364  0.31622099  0.76613189  1
+  C  C7  1  0.67798698  0.44585557  0.45775912  1
+  C  C8  1  0.02452346  0.92621103  0.72372420  1
+  C  C9  1  0.85442221  0.39897592  1.01167145  1
+  C  C10  1  0.56001265  0.44635042  0.69123923  1
+  C  C11  1  0.93074183  0.03832573  0.13711687  1
+",-154.21265250000002
+10116,C-170378-1288-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46048000
+_cell_length_b   3.39136000
+_cell_length_c   6.02985000
+_cell_angle_alpha   61.36061000
+_cell_angle_beta   78.19894000
+_cell_angle_gamma   68.79017000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.13836930
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.19938973  0.61353469  0.55353839  1
+  C  C1  1  0.74191678  -0.07298768  0.15124869  1
+  C  C2  1  0.16435414  0.40398205  0.82920161  1
+  C  C3  1  0.56671430  0.47150019  -0.04418122  1
+  C  C4  1  0.71206438  0.71464254  0.42672168  1
+  C  C5  1  0.33903997  0.86014331  1.02441255  1
+",-154.15372566666667
+8273,C-96676-423-51,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43158000
+_cell_length_b   4.61919000
+_cell_length_c   4.02212000
+_cell_angle_alpha   84.22965000
+_cell_angle_beta   91.43712000
+_cell_angle_gamma   73.21275000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.96226713
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.42985311  0.32452251  0.52563492  1
+  C  C1  1  0.64855744  0.88326425  0.07717034  1
+  C  C2  1  0.98316745  0.21497583  0.41268312  1
+  C  C3  1  0.76303380  0.65796694  0.85913778  1
+  C  C4  1  0.31603449  0.54893637  0.74492788  1
+  C  C5  1  0.09519341  0.99288630  0.19012925  1
+",-154.4508985
+8618,C-176687-5509-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48109000
+_cell_length_b   3.68943000
+_cell_length_c   4.84299000
+_cell_angle_alpha   57.37235000
+_cell_angle_beta   75.19026000
+_cell_angle_gamma   70.32609000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.00262147
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.68316953  0.36329055  0.10384485  1
+  C  C1  1  0.64431162  1.06848048  0.46899385  1
+  C  C2  1  0.10467535  0.65090808  0.97301816  1
+  C  C3  1  0.42290637  0.30722063  0.67533648  1
+  C  C4  1  0.22277668  0.78066932  0.60003611  1
+  C  C5  1  0.90341415  0.12472724  0.89700425  1
+",-154.3105075
+5557,C-157685-398-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48679000
+_cell_length_b   2.51547000
+_cell_length_c   10.79912000
+_cell_angle_alpha   110.22984000
+_cell_angle_beta   102.73381000
+_cell_angle_gamma   90.15350000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   61.59698856
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.07711349  0.11927885  0.74768078  1
+  C  C1  1  0.70747396  0.04748377  0.36932832  1
+  C  C2  1  0.54695407  0.84538734  0.23268195  1
+  C  C3  1  0.46421355  0.22579976  0.15204118  1
+  C  C4  1  0.21030865  0.32992896  0.88669728  1
+  C  C5  1  0.50854640  1.01008277  0.67568809  1
+  C  C6  1  0.78938600  0.45296297  -0.03107934  1
+  C  C7  1  0.79350189  0.67129936  0.45252160  1
+  C  C8  1  0.87720704  0.08909372  0.06032184  1
+  C  C9  1  0.37384016  0.79703219  0.53608040  1
+",-154.156844
+9287,C-176654-3153-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.61101000
+_cell_length_b   4.67002000
+_cell_length_c   3.67694000
+_cell_angle_alpha   66.61217000
+_cell_angle_beta   90.70358000
+_cell_angle_gamma   106.30151000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.24571561
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.49526862  -0.07488728  0.23137856  1
+  C  C1  1  1.21502735  0.36951147  0.69608474  1
+  C  C2  1  0.33107917  0.60211354  0.89236887  1
+  C  C3  1  0.61109163  0.15731085  0.80267441  1
+  C  C4  1  0.49363468  0.92529279  0.60586419  1
+  C  C5  1  0.32923026  0.60230212  0.26702852  1
+",-154.09159483333335
+8862,C-136247-3248-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45350000
+_cell_length_b   3.41332000
+_cell_length_c   6.72471000
+_cell_angle_alpha   95.04477000
+_cell_angle_beta   57.02444000
+_cell_angle_gamma   68.66647000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.95479066
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17547307  0.42055114  0.35546351  1
+  C  C1  1  0.35506627  0.28011198  0.94877818  1
+  C  C2  1  0.70183275  0.19841133  0.07916597  1
+  C  C3  1  0.90005331  0.76652885  0.75744254  1
+  C  C4  1  0.24617082  0.68579004  0.88808385  1
+  C  C5  1  0.42650578  0.54293767  0.48124285  1
+",-154.11608883333335
+174,C-53804-8031-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.37277000
+_cell_length_b   3.40857000
+_cell_length_c   4.27761000
+_cell_angle_alpha   76.79826000
+_cell_angle_beta   102.76194000
+_cell_angle_gamma   114.87932000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.99802399
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.07350811  -0.13448464  0.71304720  1
+  C  C1  1  0.47361167  0.07989550  -0.09699271  1
+  C  C2  1  0.85810396  0.46502236  0.90308089  1
+  C  C3  1  0.51535759  0.80812976  0.21033367  1
+  C  C4  1  -0.08492296  1.02277035  0.40063795  1
+  C  C5  1  0.12991423  0.42334346  0.21045509  1
+",-154.10693949999998
+2210,C-96669-7803-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42565000
+_cell_length_b   4.21448000
+_cell_length_c   4.21605000
+_cell_angle_alpha   89.93533000
+_cell_angle_beta   90.00287000
+_cell_angle_gamma   89.97897000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.10003072
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.09015120  0.71995730  0.89742031  1
+  C  C1  1  0.58634798  0.28328807  0.46122143  1
+  C  C2  1  0.08638187  0.12760578  0.48859837  1
+  C  C3  1  0.59022349  0.69170749  0.05334127  1
+  C  C4  1  0.08815117  0.77955166  0.54951367  1
+  C  C5  1  0.58821910  0.63160501  0.40105155  1
+",-154.30385016666665
+8045,C-47644-8979-54,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46632000
+_cell_length_b   3.62566000
+_cell_length_c   6.63884000
+_cell_angle_alpha   94.29801000
+_cell_angle_beta   104.11976000
+_cell_angle_gamma   117.66355000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.75109985
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.45915361  0.13498878  0.37137232  1
+  C  C1  1  0.96514771  0.16072848  0.74398466  1
+  C  C2  1  0.76364690  0.56818804  0.53077441  1
+  C  C3  1  0.46115946  0.84061873  0.53136593  1
+  C  C4  1  0.59907178  0.93383247  0.03301094  1
+  C  C5  1  -0.03177531  0.86658746  0.90402187  1
+  C  C6  1  0.66356396  0.43338310  0.74469948  1
+  C  C7  1  -0.17041461  0.06902474  0.24247490  1
+",-154.173385
+7138,C-134208-315-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48460000
+_cell_length_b   4.08676000
+_cell_length_c   4.67938000
+_cell_angle_alpha   96.68737000
+_cell_angle_beta   74.52731000
+_cell_angle_gamma   90.00781000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.45692522
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.92829528  0.61064932  0.45142589  1
+  C  C1  1  0.04110868  0.30414820  0.22072348  1
+  C  C2  1  0.75655144  0.54177268  0.79305287  1
+  C  C3  1  0.54038856  0.07791301  0.22245181  1
+  C  C4  1  0.21256676  0.37252390  0.87959251  1
+  C  C5  1  0.42966821  0.83550372  0.44901898  1
+  C  C6  1  0.70005325  0.89770748  0.90759404  1
+  C  C7  1  0.27251602  0.01699200  0.76388623  1
+",-154.36726875
+10131,C-157668-5131-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.07397000
+_cell_length_b   5.09630000
+_cell_length_c   5.57638000
+_cell_angle_alpha   79.56277000
+_cell_angle_beta   99.05648000
+_cell_angle_gamma   61.88295000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   72.74572411
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63705710  -0.01878030  0.59994655  1
+  C  C1  1  0.00458649  0.18404207  0.16939567  1
+  C  C2  1  0.43466416  0.95082358  0.37007278  1
+  C  C3  1  1.05899706  0.70737229  0.75265137  1
+  C  C4  1  0.26376109  0.73913266  0.98099377  1
+  C  C5  1  0.69497839  0.50605663  0.18078916  1
+  C  C6  1  0.55031666  0.19827436  0.72716095  1
+  C  C7  1  -0.06495401  1.06039164  -0.03066186  1
+  C  C8  1  0.15191351  0.49290362  0.62189758  1
+  C  C9  1  0.76502435  0.62970416  0.38142713  1
+",-154.182377
+9219,C-47620-4862-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43099000
+_cell_length_b   6.41497000
+_cell_length_c   5.76515000
+_cell_angle_alpha   85.43291000
+_cell_angle_beta   81.61679000
+_cell_angle_gamma   79.21357000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   87.24697324
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.30584829  0.61605967  0.39089376  1
+  C  C1  1  0.46185350  0.13519234  -0.10988358  1
+  C  C2  1  -0.31435777  0.69030525  0.89038601  1
+  C  C3  1  0.12917159  0.80133028  -0.10980934  1
+  C  C4  1  1.19610478  0.83794572  0.39153263  1
+  C  C5  1  0.79556186  0.46838537  0.88982369  1
+  C  C6  1  0.35213482  0.35713183  -0.10994146  1
+  C  C7  1  0.63899232  0.94983759  0.39103072  1
+  C  C8  1  -0.02777451  0.28324124  0.39104610  1
+  C  C9  1  0.86248638  0.50512902  0.39128702  1
+  C  C10  1  0.52921672  0.17175763  0.39152156  1
+  C  C11  1  1.01890703  1.02327215  0.89067579  1
+",-154.46039333333331
+6936,C-176673-628-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.64185000
+_cell_length_b   3.49470000
+_cell_length_c   6.17106000
+_cell_angle_alpha   114.09937000
+_cell_angle_beta   72.82000000
+_cell_angle_gamma   121.45606000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   60.81580795
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.75203756  0.78388509  0.81595222  1
+  C  C1  1  0.48058377  0.67161873  0.62365593  1
+  C  C2  1  0.21920257  0.96042718  0.72210546  1
+  C  C3  1  0.87056470  0.44592687  0.22606487  1
+  C  C4  1  0.81590223  -0.14349414  0.42477547  1
+  C  C5  1  0.60843227  0.13551228  1.01950900  1
+  C  C6  1  0.61953970  1.03429569  0.33168685  1
+  C  C7  1  0.48587826  0.37122222  0.92095476  1
+  C  C8  1  0.32736243  0.68142510  0.12762796  1
+  C  C9  1  0.26778071  0.14526350  0.52339039  1
+",-154.13897500000002
+243,C-96698-840-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46816000
+_cell_length_b   4.24270000
+_cell_length_c   8.46932000
+_cell_angle_alpha   100.28145000
+_cell_angle_beta   98.40140000
+_cell_angle_gamma   90.04600000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   86.29441579
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.95909437  0.74962692  0.82735387  1
+  C  C1  1  -0.23894107  0.22374186  0.42144517  1
+  C  C2  1  0.18172999  0.79482408  0.27214631  1
+  C  C3  1  0.46311010  0.54228074  0.83659205  1
+  C  C4  1  0.55406743  0.65370849  0.02967537  1
+  C  C5  1  0.04769184  0.85872524  1.01582991  1
+  C  C6  1  0.38311649  0.32315216  0.67209752  1
+  C  C7  1  0.26677538  0.01392579  0.43262374  1
+  C  C8  1  0.35359429  -0.03395324  0.60830657  1
+  C  C9  1  0.84340372  0.44074312  0.58935978  1
+  C  C10  1  0.64833894  0.60491122  0.20979386  1
+  C  C11  1  0.13085009  1.08389825  0.17437621  1
+  C  C12  1  0.66424871  0.26928712  0.23936071  1
+  C  C13  1  0.87512884  0.80507836  0.65318372  1
+",-154.0863
+6591,C-104299-1094-60,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44845000
+_cell_length_b   6.14422000
+_cell_length_c   10.63927000
+_cell_angle_alpha   102.08650000
+_cell_angle_beta   76.42911000
+_cell_angle_gamma   101.55182000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C22
+_cell_volume   150.20250864
+_cell_formula_units_Z   22
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.99677897  0.84693696  0.00202087  1
+  C  C1  1  1.04919736  0.39095019  0.21023345  1
+  C  C2  1  0.53703939  0.59228988  0.83927975  1
+  C  C3  1  0.15786316  1.01973272  0.42806052  1
+  C  C4  1  0.80320832  0.69548962  0.11461006  1
+  C  C5  1  0.87881036  0.02017637  0.71354621  1
+  C  C6  1  0.39758927  0.03215867  0.18693461  1
+  C  C7  1  0.25851351  0.34611254  0.99316042  1
+  C  C8  1  0.53494503  -0.01163395  0.03466301  1
+  C  C9  1  0.70292679  0.19866235  0.97523558  1
+  C  C10  1  0.79460044  0.58232537  0.57676640  1
+  C  C11  1  0.41795062  0.35321800  0.84047206  1
+  C  C12  1  0.79935449  0.90780906  0.22387424  1
+  C  C13  1  0.17897966  0.23029886  0.51505922  1
+  C  C14  1  0.48122704  0.28368382  0.22395527  1
+  C  C15  1  1.23305885  0.54960850  0.11131052  1
+  C  C16  1  0.71518655  0.34784798  0.53771264  1
+  C  C17  1  1.05004796  0.69571742  0.87638825  1
+  C  C18  1  0.36960524  0.91839383  0.67178775  1
+  C  C19  1  0.33270317  0.69924854  0.59774416  1
+  C  C20  1  -0.32300467  0.94271063  0.37013850  1
+  C  C21  1  0.86863320  0.21232047  0.81965531  1
+",-154.13362
+1688,C-148275-4529-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51094000
+_cell_length_b   5.42003000
+_cell_length_c   4.93418000
+_cell_angle_alpha   55.04208000
+_cell_angle_beta   59.40217000
+_cell_angle_gamma   62.38662000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.94506035
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79195771  0.10457719  0.51518778  1
+  C  C1  1  0.05019737  0.58797056  0.27318507  1
+  C  C2  1  0.49849991  0.42491161  0.48821872  1
+  C  C3  1  0.41660504  0.58809841  -0.09348225  1
+  C  C4  1  1.15915082  0.10455860  0.14801782  1
+  C  C5  1  0.75754227  0.90818374  0.24618229  1
+  C  C6  1  0.13150342  0.42476051  0.85476153  1
+  C  C7  1  0.38971075  0.90835817  0.61348005  1
+",-154.24254
+3992,C-34660-1476-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45971000
+_cell_length_b   8.17935000
+_cell_length_c   5.65883000
+_cell_angle_alpha   60.28588000
+_cell_angle_beta   89.95012000
+_cell_angle_gamma   72.46943000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   92.75989371
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.57494329  0.92761924  1.01208160  1
+  C  C1  1  -0.08838883  0.09102465  0.31280989  1
+  C  C2  1  -0.23799363  0.74310890  0.80532345  1
+  C  C3  1  1.18400529  0.81852142  0.17668260  1
+  C  C4  1  -0.06796131  1.07264466  0.59589191  1
+  C  C5  1  0.55385194  0.94968432  0.74161622  1
+  C  C6  1  0.41704460  0.58626980  0.25357070  1
+  C  C7  1  0.55953763  0.44332020  0.56245422  1
+  C  C8  1  1.08558410  0.41925880  0.98205618  1
+  C  C9  1  0.93774007  0.56694779  1.10365172  1
+  C  C10  1  0.35790410  0.14689957  0.90596006  1
+  C  C11  1  0.78326958  0.22218091  0.71152503  1
+  C  C12  1  0.30900538  0.19391852  0.13562829  1
+  C  C13  1  0.51090424  0.49520384  0.78326218  1
+  C  C14  1  0.29155182  0.71411525  0.67844886  1
+  C  C15  1  0.13415972  0.86827154  0.39126208  1
+",-154.177805
+7802,C-184035-5891-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48065000
+_cell_length_b   3.83786000
+_cell_length_c   3.74829000
+_cell_angle_alpha   89.95518000
+_cell_angle_beta   89.99948000
+_cell_angle_gamma   89.99992000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.68516200
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.33658271  0.55365042  0.16611418  1
+  C  C1  1  0.83659396  0.55332487  0.93701316  1
+  C  C2  1  0.83640378  0.84775084  0.66967421  1
+  C  C3  1  0.33639986  0.84814124  0.43298831  1
+  C  C4  1  0.83651024  0.25866407  0.67013438  1
+  C  C5  1  0.33650845  0.25901566  0.43336976  1
+",-154.1494375
+4593,C-28266-8419-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47280000
+_cell_length_b   5.92214000
+_cell_length_c   7.39967000
+_cell_angle_alpha   119.69667000
+_cell_angle_beta   81.92205000
+_cell_angle_gamma   118.79999000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   81.79864293
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.31006171  1.15300119  0.82029595  1
+  C  C1  1  0.74120383  0.06306169  0.67507437  1
+  C  C2  1  0.66732071  -0.08386639  0.26661595  1
+  C  C3  1  0.33832873  0.57983945  0.14577198  1
+  C  C4  1  0.57312569  0.31649514  0.30263365  1
+  C  C5  1  0.24778175  0.48705561  0.31071135  1
+  C  C6  1  -0.16816644  0.15548313  0.50968919  1
+  C  C7  1  0.41188251  0.72598421  0.55335278  1
+  C  C8  1  0.50621087  0.32546345  0.51701563  1
+  C  C9  1  0.76881983  0.48941851  1.00038915  1
+  C  C10  1  0.22345589  0.79614122  0.95859623  1
+  C  C11  1  0.77897516  0.64742887  0.63454691  1
+  C  C12  1  0.30022745  0.99459689  0.18507401  1
+  C  C13  1  0.85506840  0.84587943  0.86128296  1
+",-154.10055214285714
+5141,C-176683-1873-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48661000
+_cell_length_b   5.55974000
+_cell_length_c   4.30535000
+_cell_angle_alpha   130.19694000
+_cell_angle_beta   73.21325000
+_cell_angle_gamma   132.15038000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.59348224
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.31817834  0.53818358  0.69581316  1
+  C  C1  1  0.40178437  0.45490251  0.27923155  1
+  C  C2  1  -0.26497079  0.12158699  0.61255427  1
+  C  C3  1  0.98493350  0.87149911  0.36249044  1
+  C  C4  1  0.06823775  0.78822079  -0.05415853  1
+  C  C5  1  0.65172496  0.20486531  1.02920324  1
+",-154.5492
+10046,C-172965-3737-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48457000
+_cell_length_b   4.59539000
+_cell_length_c   6.02235000
+_cell_angle_alpha   101.91366000
+_cell_angle_beta   114.36518000
+_cell_angle_gamma   105.67365000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.20662799
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.13599702  0.49841294  0.69052237  1
+  C  C1  1  0.16556923  0.26776915  0.83471738  1
+  C  C2  1  0.47474133  0.31639897  0.11944385  1
+  C  C3  1  0.42896240  0.85238230  0.30456032  1
+  C  C4  1  0.46716697  0.06543037  0.73718505  1
+  C  C5  1  0.21938726  -0.06681254  0.05522691  1
+  C  C6  1  0.49563069  0.83444813  0.88096826  1
+  C  C7  1  0.20496680  0.48076588  0.26739768  1
+  C  C8  1  0.41264936  0.39947063  0.51628424  1
+  C  C9  1  0.15839103  1.01661017  0.45213505  1
+",-154.38272
+1834,C-13927-8536-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48483000
+_cell_length_b   5.48828000
+_cell_length_c   4.59642000
+_cell_angle_alpha   69.55427000
+_cell_angle_beta   74.30567000
+_cell_angle_gamma   89.98074000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.23599823
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17446667  0.92033302  0.20682460  1
+  C  C1  1  0.56392697  0.48824478  0.42041268  1
+  C  C2  1  0.77600302  0.01832902  0.00459206  1
+  C  C3  1  0.60715840  0.23880725  0.33911030  1
+  C  C4  1  0.37947919  0.45154642  0.79141716  1
+  C  C5  1  -0.11127741  0.87403566  0.77401281  1
+  C  C6  1  0.33987439  0.69983164  -0.12747018  1
+  C  C7  1  0.14627533  0.63582949  0.25613823  1
+  C  C8  1  0.79768727  0.30372700  -0.04428801  1
+  C  C9  1  1.05677397  0.06395621  0.43815565  1
+",-154.383298
+2250,C-41306-4542-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47843000
+_cell_length_b   4.26160000
+_cell_length_c   7.60534000
+_cell_angle_alpha   95.30148000
+_cell_angle_beta   99.34045000
+_cell_angle_gamma   89.97837000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   78.91534875
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.08446285  0.86634212  0.92003533  1
+  C  C1  1  -0.14577711  0.31422507  0.45865704  1
+  C  C2  1  0.71888380  -0.06509405  0.19002102  1
+  C  C3  1  0.44960111  0.84159257  0.65085924  1
+  C  C4  1  0.98763347  0.69786407  0.72859654  1
+  C  C5  1  -0.04191551  0.34835704  0.67023629  1
+  C  C6  1  0.67882229  0.24901444  0.10764240  1
+  C  C7  1  1.18121865  0.76411023  0.11223270  1
+  C  C8  1  0.48815015  0.18490949  0.73124244  1
+  C  C9  1  0.31605392  0.46627222  0.38460866  1
+  C  C10  1  0.35154577  0.81022988  0.45365401  1
+  C  C11  1  0.58413410  0.08460411  0.91950085  1
+  C  C12  1  0.81859994  0.96889646  0.39009353  1
+  C  C13  1  0.20894986  0.43156183  0.16892873  1
+",-154.42271571428572
+8495,C-170362-9529-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51144000
+_cell_length_b   4.40608000
+_cell_length_c   5.54363000
+_cell_angle_alpha   77.36482000
+_cell_angle_beta   85.16105000
+_cell_angle_gamma   83.96682000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   59.40735753
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.78273624  0.89253073  0.24796730  1
+  C  C1  1  -0.02117340  0.39931313  1.01322924  1
+  C  C2  1  0.59161878  0.78004140  0.69232850  1
+  C  C3  1  0.71128453  0.66122469  0.48497016  1
+  C  C4  1  0.72094563  0.34087550  0.47959907  1
+  C  C5  1  0.29981636  0.86175071  0.09022747  1
+  C  C6  1  1.13250268  0.13991606  0.87423049  1
+  C  C7  1  0.64876273  0.10939545  0.71639999  1
+  C  C8  1  0.45337162  0.60231247  -0.04880431  1
+  C  C9  1  -0.15998957  0.22191645  0.27212659  1
+",-154.069941
+1245,C-56518-9542-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.06570000
+_cell_length_b   5.59840000
+_cell_length_c   3.97694000
+_cell_angle_alpha   82.24188000
+_cell_angle_beta   108.08905000
+_cell_angle_gamma   120.02362000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.15950160
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.11928393  0.72056932  -0.04116957  1
+  C  C1  1  0.53473154  -0.02885792  0.12695034  1
+  C  C2  1  0.86990999  -0.02916049  0.45856679  1
+  C  C3  1  0.62101537  0.22048436  0.95809847  1
+  C  C4  1  0.36928433  0.47031119  0.45858095  1
+  C  C5  1  0.78428482  0.72078560  0.62689539  1
+  C  C6  1  0.28626252  0.22069240  0.62649287  1
+  C  C7  1  1.03413792  0.47060494  0.12688178  1
+",-154.42442875
+7326,C-141026-3786-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42985000
+_cell_length_b   2.43000000
+_cell_length_c   8.47233000
+_cell_angle_alpha   89.71975000
+_cell_angle_beta   98.60234000
+_cell_angle_gamma   120.01244000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.68724609
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36847944  0.71176620  0.53890689  1
+  C  C1  1  0.47172069  0.27411463  0.20566222  1
+  C  C2  1  0.90004588  0.52282497  0.87077194  1
+  C  C3  1  0.70172702  0.37843314  0.53885381  1
+  C  C4  1  0.80498459  0.94062603  0.20554544  1
+  C  C5  1  0.23381739  0.18977443  0.87158090  1
+",-154.457093
+1052,C-73651-4102-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   5.19115000
+_cell_length_b   2.58844000
+_cell_length_c   5.06345000
+_cell_angle_alpha   120.90561000
+_cell_angle_beta   117.99052000
+_cell_angle_gamma   77.60607000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   51.51713462
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79390957  0.19032228  0.26329346  1
+  C  C1  1  0.04508535  0.35128620  0.56882325  1
+  C  C2  1  0.51448951  0.70726794  0.64203368  1
+  C  C3  1  0.51423506  0.34887681  0.28475638  1
+  C  C4  1  0.32478142  0.19270439  0.54740162  1
+  C  C5  1  0.04498720  0.67102724  0.88898294  1
+  C  C6  1  0.79396705  0.87057145  0.94315753  1
+  C  C7  1  0.32447884  0.83445497  0.19013594  1
+",-154.06706875
+5705,C-40118-1783-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.97609000
+_cell_length_b   3.92344000
+_cell_length_c   4.52460000
+_cell_angle_alpha   79.65532000
+_cell_angle_beta   64.38591000
+_cell_angle_gamma   68.53378000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   59.21285407
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.07910879  0.54392963  0.94196521  1
+  C  C1  1  0.10286403  -0.08215863  0.89391167  1
+  C  C2  1  0.71372630  0.59359629  0.57591288  1
+  C  C3  1  0.36419083  1.10352959  0.27995103  1
+  C  C4  1  0.72057099  0.54605214  0.92167991  1
+  C  C5  1  0.69637861  0.17281041  0.97034472  1
+  C  C6  1  0.49750763  0.28915466  0.71655323  1
+  C  C7  1  1.08599580  0.49588889  0.28742412  1
+  C  C8  1  0.30211031  0.80060013  0.14733600  1
+  C  C9  1  0.43537140  0.98633007  0.58369403  1
+",-154.090654
+7143,C-142789-7601-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48492000
+_cell_length_b   4.78195000
+_cell_length_c   6.56049000
+_cell_angle_alpha   45.45395000
+_cell_angle_beta   79.06427000
+_cell_angle_gamma   58.67721000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.45903933
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.42785494  0.39931256  0.49798758  1
+  C  C1  1  0.29866301  0.41410547  0.72540768  1
+  C  C2  1  0.63696231  0.91944805  0.03962537  1
+  C  C3  1  -0.32214019  0.36436851  1.06887284  1
+  C  C4  1  1.05056162  0.44853187  0.15463801  1
+  C  C5  1  1.09087052  -0.10613385  0.18387185  1
+  C  C6  1  0.57403786  0.63775739  0.72753691  1
+  C  C7  1  1.15186473  0.17589411  0.49570347  1
+",-154.36734875
+0,C-104307-940-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   5.02193000
+_cell_length_b   4.77019000
+_cell_length_c   5.98336000
+_cell_angle_alpha   95.28908000
+_cell_angle_beta   119.76741000
+_cell_angle_gamma   73.70916000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   119.23505657
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.85227656  0.79157805  0.38941888  1
+  C  C1  1  0.34304160  -0.04696373  0.70417373  1
+  C  C2  1  0.82914686  0.55074521  0.87738898  1
+  C  C3  1  0.17998803  0.97985241  0.11376144  1
+  C  C4  1  0.18448768  0.23046480  0.63170652  1
+  C  C5  1  0.35138871  0.16778058  0.14783317  1
+  C  C6  1  0.68899226  0.46921175  0.61004922  1
+  C  C7  1  0.67953497  0.40358774  -0.01329941  1
+  C  C8  1  0.84050539  0.31401397  0.46026198  1
+  C  C9  1  0.19529853  0.71325222  0.58565156  1
+  C  C10  1  0.67978649  0.87601760  0.86295617  1
+  C  C11  1  0.34337834  0.66452407  0.19863665  1
+  C  C12  1  0.18888496  0.46471636  1.00041252  1
+  C  C13  1  0.68852736  0.07341658  0.33485054  1
+  C  C14  1  0.84168576  0.07573307  0.98937170  1
+  C  C15  1  0.69680833  0.55296768  0.24800242  1
+  C  C16  1  0.38227074  0.59208713  0.45338395  1
+  C  C17  1  0.30979944  0.46211591  0.79588218  1
+",-154.06725444444444
+3384,C-53824-8786-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45016000
+_cell_length_b   5.03799000
+_cell_length_c   5.86556000
+_cell_angle_alpha   101.45597000
+_cell_angle_beta   101.85871000
+_cell_angle_gamma   90.11244000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   69.37771696
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.89047968  1.05861878  0.23674744  1
+  C  C1  1  0.66676687  -0.02550567  0.78180250  1
+  C  C2  1  0.48667559  0.46947720  0.42352188  1
+  C  C3  1  0.69370348  0.26570361  0.83485834  1
+  C  C4  1  0.24519969  0.69031647  0.94170438  1
+  C  C5  1  0.12428582  0.81866002  0.69663924  1
+  C  C6  1  0.01989353  0.60345745  0.48690940  1
+  C  C7  1  0.21967199  0.39864156  0.88855169  1
+  C  C8  1  0.42365022  0.19108247  0.30073787  1
+  C  C9  1  0.78691103  0.84621831  0.02527676  1
+",-154.13103900000002
+2429,C-141022-7340-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43203000
+_cell_length_b   4.58315000
+_cell_length_c   4.02793000
+_cell_angle_alpha   83.78215000
+_cell_angle_beta   91.51534000
+_cell_angle_gamma   104.14986000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.27846563
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.22485894  0.97965280  0.30824375  1
+  C  C1  1  0.00398252  0.53540196  0.86269725  1
+  C  C2  1  -0.10793142  0.31441015  0.63929338  1
+  C  C3  1  0.55810598  0.64619734  0.97485693  1
+  C  C4  1  0.33794204  0.20361502  0.52713446  1
+  C  C5  1  0.67101654  0.86950893  0.19474053  1
+",-154.45886366666667
+9086,C-53814-5771-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48162000
+_cell_length_b   3.68735000
+_cell_length_c   4.22042000
+_cell_angle_alpha   105.02917000
+_cell_angle_beta   89.98100000
+_cell_angle_gamma   109.64377000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.96717031
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.04578144  0.58226869  0.80824275  1
+  C  C1  1  1.07902574  0.64877483  0.17297388  1
+  C  C2  1  0.62457906  0.73956593  0.67799732  1
+  C  C3  1  0.50082813  0.49208032  0.30351750  1
+  C  C4  1  0.82164426  0.13618058  0.60146929  1
+  C  C5  1  0.30075888  0.09491566  0.37956997  1
+",-154.31005933333333
+5563,C-80155-5756-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48976000
+_cell_length_b   4.85173000
+_cell_length_c   6.62793000
+_cell_angle_alpha   100.94169000
+_cell_angle_beta   79.16834000
+_cell_angle_gamma   120.88844000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.06842561
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.05986464  -0.16247608  0.51994796  1
+  C  C1  1  0.19257035  0.39802934  0.13616953  1
+  C  C2  1  0.49359931  0.53785334  0.81147237  1
+  C  C3  1  0.91618615  0.31057210  0.51181932  1
+  C  C4  1  0.57224805  0.49885368  0.57604093  1
+  C  C5  1  0.13737110  0.23342110  0.91430128  1
+  C  C6  1  0.56049326  1.00540436  0.61315345  1
+  C  C7  1  0.86490910  0.14788324  0.29020461  1
+  C  C8  1  0.91661877  0.62101815  0.13415131  1
+  C  C9  1  0.14064232  -0.07557666  0.29147587  1
+  C  C10  1  1.11614779  0.70627626  0.90435049  1
+  C  C11  1  0.48105423  0.04502085  0.84942287  1
+",-154.43395916666665
+9950,C-56491-7685-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42631000
+_cell_length_b   4.15396000
+_cell_length_c   6.42721000
+_cell_angle_alpha   68.44293000
+_cell_angle_beta   79.05940000
+_cell_angle_gamma   89.99950000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.97968037
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71969660  0.54179639  0.58449338  1
+  C  C1  1  0.06931221  0.08975167  0.88322591  1
+  C  C2  1  -0.04987719  0.84924172  0.12609887  1
+  C  C3  1  0.93165805  0.47566782  0.16769780  1
+  C  C4  1  0.61950340  0.23180596  0.78269962  1
+  C  C5  1  0.39171891  -0.07143378  0.24108232  1
+  C  C6  1  0.27015683  0.68506001  0.48426731  1
+  C  C7  1  0.41732559  0.30459331  0.19633520  1
+",-154.25175875
+8371,C-136225-3934-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.19883000
+_cell_length_b   4.18312000
+_cell_length_c   4.20650000
+_cell_angle_alpha   101.53603000
+_cell_angle_beta   113.49139000
+_cell_angle_gamma   112.00188000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.63768491
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.69701457  0.28148820  0.92751208  1
+  C  C1  1  1.03034609  0.61511771  0.59409852  1
+  C  C2  1  0.36305071  0.94862367  0.92695244  1
+  C  C3  1  0.69686240  0.28184094  0.59382638  1
+  C  C4  1  0.03069361  0.61554345  0.26060077  1
+  C  C5  1  0.36375081  0.94835392  0.26076712  1
+",-154.44630666666666
+2041,C-145327-8310-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48844000
+_cell_length_b   4.30441000
+_cell_length_c   4.30525000
+_cell_angle_alpha   80.41344000
+_cell_angle_beta   73.17710000
+_cell_angle_gamma   89.99524000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.46813154
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.77204881  -0.05937171  0.91354555  1
+  C  C1  1  -0.04107656  1.00322967  0.53862683  1
+  C  C2  1  0.45892344  0.50322967  0.53862683  1
+  C  C3  1  0.02199373  0.69054406  0.41354476  1
+  C  C4  1  0.20897852  0.75331389  1.03862762  1
+  C  C5  1  0.52199373  0.19054406  0.41354476  1
+  C  C6  1  0.27204881  0.44062829  -0.08645445  1
+  C  C7  1  0.70897852  0.25331389  0.03862762  1
+",-154.54651875
+9898,C-142748-3187-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.54941000
+_cell_length_b   3.65151000
+_cell_length_c   5.54848000
+_cell_angle_alpha   94.60236000
+_cell_angle_beta   76.73545000
+_cell_angle_gamma   110.49398000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.09198419
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.99333249  0.00708463  0.23741519  1
+  C  C1  1  0.24170985  1.00685839  0.74108409  1
+  C  C2  1  0.51192739  0.37515909  0.56911612  1
+  C  C3  1  0.09156301  0.37520391  0.40991208  1
+  C  C4  1  0.20862545  0.18831454  -0.01115129  1
+  C  C5  1  0.39636250  0.56595887  -0.01112851  1
+  C  C6  1  0.61143258  0.74597640  0.74089851  1
+  C  C7  1  0.36288183  0.74596057  0.23759530  1
+",-154.18405
+5742,C-130238-8833-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48446000
+_cell_length_b   7.69290000
+_cell_length_c   8.06618000
+_cell_angle_alpha   86.42288000
+_cell_angle_beta   87.67385000
+_cell_angle_gamma   79.46667000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C24
+_cell_volume   151.20638466
+_cell_formula_units_Z   24
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64120014  0.81102833  0.40006171  1
+  C  C1  1  0.61968826  0.83700372  0.58155394  1
+  C  C2  1  0.72769067  0.62428497  0.36567811  1
+  C  C3  1  0.40767691  0.31829214  0.15187614  1
+  C  C4  1  0.60410323  0.93820714  0.24392554  1
+  C  C5  1  1.30569202  0.51504034  0.11232811  1
+  C  C6  1  0.26541274  0.54253475  0.42897445  1
+  C  C7  1  0.72051033  0.50482020  0.80763062  1
+  C  C8  1  0.52589984  0.03121090  0.59802355  1
+  C  C9  1  0.89325131  0.28758097  0.51177930  1
+  C  C10  1  0.04455440  1.04775850  0.23068993  1
+  C  C11  1  0.35830089  0.60575340  0.94040507  1
+  C  C12  1  0.84296231  0.30958896  0.82632552  1
+  C  C13  1  0.75525361  0.60796559  0.17868932  1
+  C  C14  1  0.17540731  0.59715864  0.76593771  1
+  C  C15  1  0.08510098  0.91783215  0.83249294  1
+  C  C16  1  0.95417872  0.22673504  0.17532768  1
+  C  C17  1  -0.01200992  0.11168001  0.53922724  1
+  C  C18  1  0.51788440  0.03009895  -0.20209364  1
+  C  C19  1  0.39083608  0.21953176  0.83560835  1
+  C  C20  1  0.20683461  0.80062204  0.98949051  1
+  C  C21  1  0.34897701  0.37499069  0.48688664  1
+  C  C22  1  0.13261831  0.78052160  0.68430029  1
+  C  C23  1  0.68837434  0.80049601  0.09890958  1
+",-154.07231208333334
+9733,C-57113-4466-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46138000
+_cell_length_b   6.03555000
+_cell_length_c   6.86821000
+_cell_angle_alpha   89.37131000
+_cell_angle_beta   100.33507000
+_cell_angle_gamma   89.99108000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   100.37091674
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.10344370  0.16198718  0.10959912  1
+  C  C1  1  0.61548245  0.54122790  0.13078583  1
+  C  C2  1  0.88684977  0.80961651  0.67787787  1
+  C  C3  1  0.43993632  0.80172713  0.78184647  1
+  C  C4  1  0.76204516  0.10821557  0.42582528  1
+  C  C5  1  0.77581877  0.86012568  0.45212296  1
+  C  C6  1  0.25674216  0.40445483  0.41886867  1
+  C  C7  1  0.46026327  0.31791661  0.83050790  1
+  C  C8  1  0.91438136  0.34095501  0.73918299  1
+  C  C9  1  0.56779561  0.28987018  1.04151330  1
+  C  C10  1  0.81123748  0.34750616  0.53053284  1
+  C  C11  1  0.10055613  0.89889038  0.10154418  1
+  C  C12  1  0.55359031  0.78579416  1.01013296  1
+  C  C13  1  0.20978514  0.18261412  0.32300481  1
+  C  C14  1  0.18063812  0.56877308  0.26054409  1
+  C  C15  1  0.21416046  0.79757349  0.32979924  1
+",-154.139076875
+1391,C-157707-3900-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44976000
+_cell_length_b   5.53876000
+_cell_length_c   7.00815000
+_cell_angle_alpha   113.05955000
+_cell_angle_beta   100.08230000
+_cell_angle_gamma   90.01092000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   85.89343959
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.02539884  0.51518833  0.52100718  1
+  C  C1  1  0.35988185  0.73834678  0.19142492  1
+  C  C2  1  0.35997565  1.23027433  0.19109934  1
+  C  C3  1  0.69693240  0.96981198  0.86432410  1
+  C  C4  1  0.69654614  0.67159687  0.86397497  1
+  C  C5  1  0.47583997  0.35287457  0.42415998  1
+  C  C6  1  0.80687296  0.70282426  0.08700906  1
+  C  C7  1  0.02599029  0.78510234  0.52181637  1
+  C  C8  1  -0.19304805  0.16038801  0.08702142  1
+  C  C9  1  0.10336508  0.22572850  0.67349276  1
+  C  C10  1  0.47635327  0.85083691  0.42472200  1
+  C  C11  1  0.13923914  -0.00050594  0.74990948  1
+  C  C12  1  0.53160132  0.15494909  0.53067361  1
+  C  C13  1  0.13877603  0.52786207  0.74969502  1
+",-154.31925714285714
+4489,C-73665-9416-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.37801000
+_cell_length_b   4.71846000
+_cell_length_c   5.24466000
+_cell_angle_alpha   82.25066000
+_cell_angle_beta   70.69580000
+_cell_angle_gamma   60.37856000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   68.54239236
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.26163236  0.13417035  0.54473648  1
+  C  C1  1  0.76872591  0.91535554  0.95751582  1
+  C  C2  1  0.66487325  0.80320220  0.53761508  1
+  C  C3  1  0.52961478  0.58484231  0.42328925  1
+  C  C4  1  0.13622379  0.65507437  0.09107112  1
+  C  C5  1  0.83669142  0.66594206  0.77345547  1
+  C  C6  1  0.10677928  0.80914085  0.32650483  1
+  C  C7  1  0.91428927  0.41688669  0.17020563  1
+  C  C8  1  0.66007621  0.46729992  -0.04539568  1
+  C  C9  1  0.37007857  0.38417796  0.63144747  1
+  C  C10  1  0.77388013  0.19954781  0.77981414  1
+  C  C11  1  0.23944612  0.08827234  0.24115329  1
+",-154.1324875
+8815,C-96686-8751-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.63205000
+_cell_length_b   3.27460000
+_cell_length_c   4.23349000
+_cell_angle_alpha   84.65492000
+_cell_angle_beta   48.37609000
+_cell_angle_gamma   75.42314000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.23575820
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.11165365  0.79184690  0.82032153  1
+  C  C1  1  0.66195550  0.58066786  0.03287529  1
+  C  C2  1  0.54838919  0.52580052  0.76548915  1
+  C  C3  1  0.86463046  0.20904907  0.44900803  1
+  C  C4  1  0.75059405  0.15364529  0.18146912  1
+  C  C5  1  0.30116355  0.94141806  0.39391687  1
+",-154.200439
+5553,C-102889-8686-53,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44242000
+_cell_length_b   4.19366000
+_cell_length_c   6.36398000
+_cell_angle_alpha   107.24553000
+_cell_angle_beta   100.91396000
+_cell_angle_gamma   90.16608000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   61.00649025
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.13549714  0.58673442  0.79610514  1
+  C  C1  1  0.47868064  1.21492598  0.48617667  1
+  C  C2  1  0.35990771  0.05208505  0.24026861  1
+  C  C3  1  0.83637274  0.52969261  0.18731597  1
+  C  C4  1  0.68995447  0.69979009  0.90255886  1
+  C  C5  1  0.81370489  -0.14193998  0.14958507  1
+  C  C6  1  0.03213030  0.32994106  0.59127338  1
+  C  C7  1  0.34249231  0.37839878  0.19899120  1
+",-154.20482375
+8355,C-13671-2117-57,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.30125000
+_cell_length_b   3.30138000
+_cell_length_c   4.82854000
+_cell_angle_alpha   77.43913000
+_cell_angle_beta   77.42785000
+_cell_angle_gamma   79.69579000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.65339686
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71124919  1.03866520  0.20637993  1
+  C  C1  1  0.34746957  0.40238960  0.20644994  1
+  C  C2  1  0.92747399  0.94694119  0.92136821  1
+  C  C3  1  0.81141038  0.17585442  0.66541611  1
+  C  C4  1  0.48454713  0.50391579  0.66539071  1
+  C  C5  1  0.39474922  0.72230981  0.38015540  1
+  C  C6  1  0.25508621  0.61929641  0.92154519  1
+  C  C7  1  1.03108162  0.08590168  0.38018571  1
+",-154.21806375
+170,C-80199-6032-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.38602000
+_cell_length_b   5.73993000
+_cell_length_c   6.68538000
+_cell_angle_alpha   67.24557000
+_cell_angle_beta   80.70835000
+_cell_angle_gamma   84.99719000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   118.20531454
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.28238246  0.04116938  1.11370934  1
+  C  C1  1  0.43346161  0.80577743  0.27529986  1
+  C  C2  1  0.37148130  0.61227316  0.21099453  1
+  C  C3  1  0.92553504  0.05980678  0.77259609  1
+  C  C4  1  0.77363988  0.52809294  0.61500597  1
+  C  C5  1  0.86272815  0.86365920  0.70418151  1
+  C  C6  1  0.68397238  0.95702972  0.51813362  1
+  C  C7  1  0.62196753  0.76354861  0.45395214  1
+  C  C8  1  0.43955806  0.35471467  0.27328902  1
+  C  C9  1  0.13073961  0.50944814  0.95595316  1
+  C  C10  1  0.19326829  0.70563796  1.02463309  1
+  C  C11  1  0.93390148  0.60097728  0.77046251  1
+  C  C12  1  0.76439204  0.28784940  0.61716326  1
+  C  C13  1  0.12270976  -0.03164692  -0.04203766  1
+  C  C14  1  0.29111206  0.28136424  0.11171355  1
+  C  C15  1  0.61533544  0.21442921  0.45587711  1
+",-154.14529625
+4158,C-126149-3704-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.31848000
+_cell_length_b   3.51847000
+_cell_length_c   3.52066000
+_cell_angle_alpha   120.09226000
+_cell_angle_beta   90.00147000
+_cell_angle_gamma   90.01286000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.56667408
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.35830820  0.92333113  0.55783667  1
+  C  C1  1  0.85831613  0.46017607  0.63072189  1
+  C  C2  1  0.52621887  0.45988696  0.32613296  1
+  C  C3  1  0.69296898  0.22846035  0.86257495  1
+  C  C4  1  0.19295523  0.15469940  0.32554469  1
+  C  C5  1  0.02625048  0.92356769  0.86185803  1
+",-154.4124485
+1757,C-92105-6529-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.59198000
+_cell_length_b   3.59330000
+_cell_length_c   4.35344000
+_cell_angle_alpha   84.30072000
+_cell_angle_beta   95.68076000
+_cell_angle_gamma   40.55300000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.00507817
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.21618608  0.71939033  0.96618801  1
+  C  C1  1  0.40445171  0.53095375  0.34231348  1
+  C  C2  1  0.77484206  0.90170337  0.34221618  1
+  C  C3  1  0.29879288  0.00728128  0.76040632  1
+  C  C4  1  0.58633215  0.09039117  -0.03390723  1
+  C  C5  1  0.69262222  0.61332421  0.54808204  1
+",-154.194639
+2076,C-47627-477-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48116000
+_cell_length_b   4.14102000
+_cell_length_c   6.99962000
+_cell_angle_alpha   107.20377000
+_cell_angle_beta   100.21504000
+_cell_angle_gamma   89.98998000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.50656929
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.83455862  0.88056924  0.63030798  1
+  C  C1  1  0.69252677  0.21242772  0.33860990  1
+  C  C2  1  0.99893937  0.39028827  0.95771952  1
+  C  C3  1  0.49922916  -0.12740588  -0.04099743  1
+  C  C4  1  0.80078447  0.19099127  0.56223674  1
+  C  C5  1  -0.03634391  0.01196624  0.88892452  1
+  C  C6  1  0.34487999  0.38702105  0.64922649  1
+  C  C7  1  1.11373656  0.63347116  0.18159658  1
+  C  C8  1  0.45564219  0.49977371  0.87113940  1
+  C  C9  1  0.61399892  0.86183029  0.18221231  1
+  C  C10  1  0.19219139  0.43834272  0.33792630  1
+  C  C11  1  0.29989167  0.67179672  0.56089679  1
+",-154.39338833333332
+6254,C-90796-891-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48546000
+_cell_length_b   4.78066000
+_cell_length_c   4.68273000
+_cell_angle_alpha   103.71872000
+_cell_angle_beta   74.58984000
+_cell_angle_gamma   121.34921000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.47783170
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.85835315  0.54294177  0.27334762  1
+  C  C1  1  0.53678019  0.00727025  0.84500962  1
+  C  C2  1  0.55981437  0.18708452  1.15846280  1
+  C  C3  1  0.61973112  0.47503506  0.61397710  1
+  C  C4  1  -0.19139542  0.78068647  0.84709440  1
+  C  C5  1  0.89163674  0.24863202  0.61651793  1
+  C  C6  1  0.57041901  0.71260130  0.18747510  1
+  C  C7  1  0.86855393  1.06820840  0.30312412  1
+",-154.36806875
+4246,C-80155-5756-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44294000
+_cell_length_b   4.20164000
+_cell_length_c   6.28940000
+_cell_angle_alpha   73.56179000
+_cell_angle_beta   78.78515000
+_cell_angle_gamma   89.98481000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   60.63256113
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.29520800  1.02251214  0.81835429  1
+  C  C1  1  0.84857871  0.13845992  0.71356521  1
+  C  C2  1  0.50174218  0.51433240  0.40684550  1
+  C  C3  1  0.62237194  0.67204734  0.15726921  1
+  C  C4  1  0.16728640  0.86373585  0.06704887  1
+  C  C5  1  0.14139344  0.19068589  0.10850092  1
+  C  C6  1  -0.05064579  0.39862699  0.51201967  1
+  C  C7  1  0.63656332  0.34395867  1.11806292  1
+",-154.20153875
+9615,C-102901-5226-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48452000
+_cell_length_b   4.67942000
+_cell_length_c   5.84260000
+_cell_angle_alpha   127.35358000
+_cell_angle_beta   102.26836000
+_cell_angle_gamma   105.41186000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.44357549
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.29391140  0.27976093  0.19203943  1
+  C  C1  1  0.59222216  0.52019192  0.54771877  1
+  C  C2  1  0.34348197  0.61523668  0.95450091  1
+  C  C3  1  0.61629099  0.38687324  0.72855429  1
+  C  C4  1  0.53371271  0.68945581  0.26071370  1
+  C  C5  1  0.28312761  0.78301790  0.66654086  1
+  C  C6  1  0.58095284  0.02383100  0.02219224  1
+  C  C7  1  0.26074001  -0.08242658  0.48655971  1
+",-154.3653475
+4315,C-107732-5386-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.69868000
+_cell_length_b   3.67903000
+_cell_length_c   5.21587000
+_cell_angle_alpha   62.27359000
+_cell_angle_beta   62.50648000
+_cell_angle_gamma   71.35885000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   55.23128813
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87454799  -0.26245047  0.31406888  1
+  C  C1  1  0.18626023  0.51748239  0.47071297  1
+  C  C2  1  0.19211414  1.04995391  0.68621729  1
+  C  C3  1  0.84286781  0.44268753  -0.00092984  1
+  C  C4  1  0.65712421  -0.01083175  0.52857042  1
+  C  C5  1  -0.03117316  0.76946409  0.68528185  1
+  C  C6  1  1.00387137  1.06427118  0.00003286  1
+  C  C7  1  0.65131190  0.45713001  0.31293346  1
+",-154.09692125
+6942,C-22167-6764-72,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46565000
+_cell_length_b   6.81058000
+_cell_length_c   7.03972000
+_cell_angle_alpha   114.56380000
+_cell_angle_beta   102.69120000
+_cell_angle_gamma   88.31720000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   104.63312342
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.12331045  0.59354264  0.85933534  1
+  C  C1  1  0.49229031  0.62438540  0.54701461  1
+  C  C2  1  0.81192780  0.76266665  0.20096192  1
+  C  C3  1  0.46008212  0.42630798  0.35028891  1
+  C  C4  1  -0.16383966  0.13125731  0.16191207  1
+  C  C5  1  0.26838161  0.61522437  0.10001317  1
+  C  C6  1  0.75244215  0.90289153  1.07700587  1
+  C  C7  1  1.01891682  0.29738231  0.36993673  1
+  C  C8  1  0.33230966  0.27270737  0.56336047  1
+  C  C9  1  -0.00862944  0.75806957  0.56998007  1
+  C  C10  1  0.54099109  0.50640865  0.72092864  1
+  C  C11  1  1.10820904  0.93580913  0.78687859  1
+  C  C12  1  0.17559219  0.83469964  0.93808113  1
+  C  C13  1  0.90434785  -0.09878205  0.44782003  1
+  C  C14  1  0.43778581  0.05568897  0.55640748  1
+  C  C15  1  0.60661540  0.06826678  0.79346121  1
+  C  C16  1  -0.25608588  0.25513512  0.02005282  1
+  C  C17  1  0.29579816  0.40048812  0.11250122  1
+",-154.09165277777777
+8255,C-189738-7344-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46747000
+_cell_length_b   3.37496000
+_cell_length_c   6.12098000
+_cell_angle_alpha   112.17189000
+_cell_angle_beta   101.52284000
+_cell_angle_gamma   111.58239000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.35936315
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.74110030  0.17484557  0.58107970  1
+  C  C1  1  0.77797124  0.64479056  0.18374545  1
+  C  C2  1  1.05495068  0.52773625  0.85515760  1
+  C  C3  1  0.76714774  0.82589398  -0.01981665  1
+  C  C4  1  0.06580376  0.34660980  1.05873900  1
+  C  C5  1  0.09218948  -0.00204485  0.45778730  1
+",-154.14583916666666
+5635,C-157676-6832-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51469000
+_cell_length_b   5.87577000
+_cell_length_c   4.79718000
+_cell_angle_alpha   114.83799000
+_cell_angle_beta   74.54939000
+_cell_angle_gamma   102.61266000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   61.53969379
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.24911738  0.88503362  0.00628934  1
+  C  C1  1  0.68381021  -0.02903890  0.22084567  1
+  C  C2  1  0.36774898  0.36612766  0.25019645  1
+  C  C3  1  0.22858820  0.60702753  0.76987248  1
+  C  C4  1  0.66013023  0.43617418  0.73143702  1
+  C  C5  1  0.39567079  0.62813567  0.45794983  1
+  C  C6  1  0.42959998  1.02405578  0.78649519  1
+  C  C7  1  -0.24110143  0.26550429  0.36490421  1
+  C  C8  1  0.49209537  0.27984514  0.91360291  1
+  C  C9  1  0.50732609  0.86835302  0.47053819  1
+",-154.138573
+1387,C-170382-4594-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.32107000
+_cell_length_b   4.83832000
+_cell_length_c   4.83609000
+_cell_angle_alpha   42.61150000
+_cell_angle_beta   46.62060000
+_cell_angle_gamma   46.63626000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.55293002
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.81109076  0.62106767  0.19245239  1
+  C  C1  1  0.87671436  0.15716561  0.42413840  1
+  C  C2  1  1.20978163  0.85310997  0.72869319  1
+  C  C3  1  -0.15981626  0.62094610  0.49727001  1
+  C  C4  1  0.17383607  -0.07510410  0.19257412  1
+  C  C5  1  0.23913314  0.15724715  0.72857559  1
+",-154.41091933333334
+4590,C-53844-8150-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49028000
+_cell_length_b   4.35387000
+_cell_length_c   3.59340000
+_cell_angle_alpha   84.27671000
+_cell_angle_beta   110.34721000
+_cell_angle_gamma   106.63581000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.00086473
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.09513302  0.76049362  0.39808624  1
+  C  C1  1  0.65130114  0.13620716  1.13781714  1
+  C  C2  1  0.46431471  0.76020561  0.13824502  1
+  C  C3  1  0.17650739  0.55444646  0.76756245  1
+  C  C4  1  0.56908978  0.34206166  0.76709531  1
+  C  C5  1  0.28231376  0.13639479  0.39758554  1
+",-154.195112
+4445,C-9643-4757-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47244000
+_cell_length_b   3.75886000
+_cell_length_c   9.29707000
+_cell_angle_alpha   74.80913000
+_cell_angle_beta   105.50644000
+_cell_angle_gamma   90.04565000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   80.12549438
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.14631647  0.76333524  -0.03450208  1
+  C  C1  1  0.31959644  0.40867810  0.63373200  1
+  C  C2  1  0.03490882  0.20271828  0.35222453  1
+  C  C3  1  0.15008642  1.13318175  0.96940498  1
+  C  C4  1  0.89917473  0.58565146  0.22158253  1
+  C  C5  1  0.90583400  0.98110789  0.22768130  1
+  C  C6  1  0.30953262  0.14829365  0.13247908  1
+  C  C7  1  0.75225167  0.33172239  0.56674663  1
+  C  C8  1  0.62413160  0.20123009  0.44031916  1
+  C  C9  1  1.04181538  0.51993809  0.85508772  1
+  C  C10  1  0.44909047  0.53173495  0.76185426  1
+  C  C11  1  0.30587457  0.53780092  0.12907699  1
+",-154.09061083333333
+8905,C-72712-3931-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47372000
+_cell_length_b   4.23549000
+_cell_length_c   5.45958000
+_cell_angle_alpha   89.98160000
+_cell_angle_beta   90.00180000
+_cell_angle_gamma   89.99870000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.20228961
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20699760  0.41958956  0.20793026  1
+  C  C1  1  0.70699760  0.93141147  0.20951805  1
+  C  C2  1  0.70699760  0.26285515  0.83565527  1
+  C  C3  1  1.20699760  0.75968929  0.81713007  1
+  C  C4  1  0.20699760  0.28173548  0.46942360  1
+  C  C5  1  0.70699760  0.06117099  0.46954950  1
+  C  C6  1  0.20699760  0.75962302  0.12399418  1
+  C  C7  1  0.70699760  0.93122146  0.72996493  1
+  C  C8  1  0.20699760  0.41984249  0.73109305  1
+  C  C9  1  0.70699760  0.26289449  0.10301389  1
+",-154.361772
+2770,C-126165-3752-56,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51120000
+_cell_length_b   4.88145000
+_cell_length_c   6.76666000
+_cell_angle_alpha   89.96442000
+_cell_angle_beta   97.94892000
+_cell_angle_gamma   83.14899000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   81.55180708
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20310692  0.93408304  0.67942541  1
+  C  C1  1  0.67159792  0.69869253  0.42644933  1
+  C  C2  1  0.33108089  0.33553468  0.24838536  1
+  C  C3  1  0.39709217  0.85191752  0.00218287  1
+  C  C4  1  0.30401504  1.10188227  0.86495727  1
+  C  C5  1  0.64874764  0.95861573  0.55107462  1
+  C  C6  1  0.71187623  0.45359199  0.56523227  1
+  C  C7  1  0.79566365  0.51097471  0.78492453  1
+  C  C8  1  0.94984994  0.87600997  0.12684955  1
+  C  C9  1  0.28723605  0.67868808  0.81606618  1
+  C  C10  1  0.79977486  0.25866910  -0.08656698  1
+  C  C11  1  0.84210824  0.22485464  0.14528890  1
+  C  C12  1  0.53881356  0.24157111  0.46098815  1
+  C  C13  1  0.14219738  0.66654473  0.29684366  1
+",-154.10965785714285
+5932,C-106855-9459-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47210000
+_cell_length_b   5.03468000
+_cell_length_c   5.67506000
+_cell_angle_alpha   73.06152000
+_cell_angle_beta   98.04955000
+_cell_angle_gamma   85.37577000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   66.35124028
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53525662  0.85751646  0.24536955  1
+  C  C1  1  0.43487137  0.61068439  0.12840733  1
+  C  C2  1  0.24105942  0.01316207  0.67824783  1
+  C  C3  1  0.34283702  0.26031737  0.79463006  1
+  C  C4  1  0.89440148  0.28068892  0.94490800  1
+  C  C5  1  0.75376237  0.68530503  0.52357540  1
+  C  C6  1  -0.11857336  0.58991863  0.97864039  1
+  C  C7  1  0.78524088  0.82862720  0.72388512  1
+  C  C8  1  0.31731147  0.50424731  0.55873979  1
+  C  C9  1  0.99016705  0.04172838  1.19916165  1
+  C  C10  1  0.45882205  0.36642068  0.36378938  1
+  C  C11  1  1.02343664  0.18552035  0.39935341  1
+",-154.25789583333332
+9693,C-152556-5725-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.92297000
+_cell_length_b   4.55239000
+_cell_length_c   4.52620000
+_cell_angle_alpha   51.95305000
+_cell_angle_beta   79.62757000
+_cell_angle_gamma   98.04942000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   59.23820882
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.57226183  0.77846900  0.65038437  1
+  C  C1  1  0.38617336  0.03919166  0.00304173  1
+  C  C2  1  -0.05649993  0.39584017  1.00481789  1
+  C  C3  1  0.99351378  0.76116518  0.27356928  1
+  C  C4  1  -0.05430551  0.75431029  0.62621689  1
+  C  C5  1  0.31774701  0.37216657  0.98050022  1
+  C  C6  1  0.68913048  0.97736797  0.19779209  1
+  C  C7  1  0.89536135  0.38860594  0.35744128  1
+  C  C8  1  0.50299703  0.11099020  0.62785133  1
+  C  C9  1  0.19994859  0.17265391  0.43334603  1
+",-154.09215999999998
+899,C-56505-7826-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.29142000
+_cell_length_b   5.27411000
+_cell_length_c   5.30571000
+_cell_angle_alpha   99.72084000
+_cell_angle_beta   96.10939000
+_cell_angle_gamma   63.34987000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   81.08741563
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.03834955  0.68115459  0.04531628  1
+  C  C1  1  0.48717057  0.21026948  0.28150945  1
+  C  C2  1  1.01865926  0.94121076  -0.03574886  1
+  C  C3  1  0.71852523  0.58801410  0.83421382  1
+  C  C4  1  0.16718378  0.45919908  0.42549219  1
+  C  C5  1  0.93326772  0.70120135  0.31304530  1
+  C  C6  1  0.46052721  0.44717193  0.91865979  1
+  C  C7  1  0.33945780  0.05950390  0.62775285  1
+  C  C8  1  0.60273703  0.97176637  0.41139600  1
+  C  C9  1  0.33818332  0.87259751  0.78164069  1
+  C  C10  1  0.67776019  0.20246311  0.05905364  1
+  C  C11  1  0.13825783  0.38384112  0.67766956  1
+",-154.10235666666668
+3751,C-53801-6753-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.27817000
+_cell_length_b   3.13721000
+_cell_length_c   4.82155000
+_cell_angle_alpha   104.57848000
+_cell_angle_beta   100.66021000
+_cell_angle_gamma   110.54367000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.84556258
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.85825517  1.19369104  0.10131321  1
+  C  C1  1  0.01050982  0.35303907  0.40844150  1
+  C  C2  1  0.41722038  0.75508791  0.60250259  1
+  C  C3  1  1.07064335  0.40649828  0.90670399  1
+  C  C4  1  0.79814350  0.14072452  0.60316906  1
+  C  C5  1  0.45325777  -0.21049441  0.90697535  1
+",-154.1169335
+6047,C-141020-5549-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47993000
+_cell_length_b   5.97548000
+_cell_length_c   3.68946000
+_cell_angle_alpha   125.11232000
+_cell_angle_beta   70.34005000
+_cell_angle_gamma   128.50568000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.97867785
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.00855077  0.05548927  0.75359545  1
+  C  C1  1  0.96039263  0.55109367  0.33779526  1
+  C  C2  1  0.45608967  0.92476370  0.46618581  1
+  C  C3  1  0.83725683  0.62682975  0.81070807  1
+  C  C4  1  0.40792863  0.42023118  1.05012635  1
+  C  C5  1  0.57878296  0.84873803  0.99278936  1
+",-154.31406366666667
+6875,C-76050-9799-51,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.35293000
+_cell_length_b   3.40456000
+_cell_length_c   4.58104000
+_cell_angle_alpha   89.27785000
+_cell_angle_beta   111.43346000
+_cell_angle_gamma   92.11721000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.64397131
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76163609  -0.16688603  0.25040074  1
+  C  C1  1  0.79278569  0.34649071  0.64532595  1
+  C  C2  1  0.11924203  0.53376628  0.93103240  1
+  C  C3  1  0.41810921  0.82113557  0.93077614  1
+  C  C4  1  0.45919793  0.01332147  0.64591078  1
+  C  C5  1  0.09732766  0.52451565  0.25063457  1
+  C  C6  1  0.53149765  0.68009183  0.45545897  1
+  C  C7  1  1.02015802  0.17960353  0.43208236  1
+",-154.20089125
+4021,C-34643-7107-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48359000
+_cell_length_b   3.99863000
+_cell_length_c   7.50194000
+_cell_angle_alpha   102.50751000
+_cell_angle_beta   80.39882000
+_cell_angle_gamma   108.09021000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   68.73916950
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.12873763  0.54279826  0.15084004  1
+  C  C1  1  0.62452194  0.42292886  0.04219349  1
+  C  C2  1  0.30209889  0.92583690  0.18559980  1
+  C  C3  1  0.80711006  0.04608330  0.29410284  1
+  C  C4  1  0.96028304  -0.06799935  0.88376608  1
+  C  C5  1  0.76676093  0.50437048  0.84559919  1
+  C  C6  1  -0.02024807  0.43473101  0.33621681  1
+  C  C7  1  -0.33055150  0.96583149  0.49060521  1
+  C  C8  1  0.23911342  0.18144501  0.56727497  1
+  C  C9  1  0.45199411  0.03398190  0.00050467  1
+  C  C10  1  0.47191809  0.53677351  0.45292572  1
+  C  C11  1  0.19632926  0.28762522  0.76895858  1
+",-154.2567975
+5622,C-126161-9940-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.28949000
+_cell_length_b   4.66442000
+_cell_length_c   4.18337000
+_cell_angle_alpha   97.83461000
+_cell_angle_beta   72.47434000
+_cell_angle_gamma   105.17501000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.95869850
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.43109696  0.72613904  0.42410041  1
+  C  C1  1  0.02487140  0.28357119  0.11191985  1
+  C  C2  1  0.03361185  0.73520241  0.74381814  1
+  C  C3  1  0.22208058  0.00834951  0.95147530  1
+  C  C4  1  0.42696542  0.44707823  0.22887762  1
+  C  C5  1  0.57650415  0.22576448  0.37437632  1
+  C  C6  1  -0.16502207  0.89027138  0.54065728  1
+  C  C7  1  0.82603344  0.43879009  0.90938840  1
+  C  C8  1  0.63821354  0.16614884  0.70110199  1
+  C  C9  1  0.28317052  0.94776804  0.27795311  1
+",-154.105906
+1990,C-189722-5605-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.22014000
+_cell_length_b   4.26594000
+_cell_length_c   3.63113000
+_cell_angle_alpha   98.79100000
+_cell_angle_beta   111.23899000
+_cell_angle_gamma   101.15867000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.23732686
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.58630689  0.50170718  0.79940120  1
+  C  C1  1  0.09015508  1.00175071  0.74268102  1
+  C  C2  1  -0.10100221  0.81148129  0.95755327  1
+  C  C3  1  0.39537192  0.31149278  0.01447509  1
+  C  C4  1  0.39625004  0.31246117  0.39624947  1
+  C  C5  1  1.08897168  0.00059457  0.36063734  1
+",-154.13160416666668
+143,C-113045-1591-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.57750000
+_cell_length_b   6.51269000
+_cell_length_c   6.51161000
+_cell_angle_alpha   74.88502000
+_cell_angle_beta   100.78791000
+_cell_angle_gamma   79.95621000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   100.74821676
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.12455162  0.37963135  0.34369634  1
+  C  C1  1  -0.12551917  0.13920538  1.11915701  1
+  C  C2  1  0.50625746  0.01249883  0.25383336  1
+  C  C3  1  0.88903653  0.48797734  0.64089309  1
+  C  C4  1  -0.17125173  0.36386791  0.13740533  1
+  C  C5  1  0.07771553  0.24507794  0.73458879  1
+  C  C6  1  0.67654149  0.77513238  0.25749636  1
+  C  C7  1  0.72321967  0.75390161  0.05243650  1
+  C  C8  1  0.78673030  0.62741852  0.76023993  1
+  C  C9  1  0.70023182  0.14547326  0.87386436  1
+  C  C10  1  1.57759273  0.04242314  0.48814550  1
+  C  C11  1  0.71455994  0.85512926  0.68821929  1
+  C  C12  1  0.80914187  0.56679696  0.41422616  1
+  C  C13  1  0.77685221  0.56282410  0.98482443  1
+  C  C14  1  0.02792813  0.17474744  0.51858899  1
+  C  C15  1  0.73611314  0.92165437  0.87468096  1
+",-154.113755625
+9428,C-176667-771-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47341000
+_cell_length_b   4.23463000
+_cell_length_c   5.45954000
+_cell_angle_alpha   89.96235000
+_cell_angle_beta   89.99135000
+_cell_angle_gamma   90.00283000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.18307889
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.89765426  0.34736130  0.87497462  1
+  C  C1  1  0.39765549  0.18983330  0.97975664  1
+  C  C2  1  0.39768635  -0.01143526  0.61357103  1
+  C  C3  1  0.39797046  0.18995619  0.24700854  1
+  C  C4  1  0.89792999  0.34730493  0.35183324  1
+  C  C5  1  0.39755001  0.85826607  0.87373890  1
+  C  C6  1  0.89746718  0.68676649  0.96040167  1
+  C  C7  1  -0.10225605  0.21004916  0.61341207  1
+  C  C8  1  0.89785648  0.68684795  0.26754330  1
+  C  C9  1  0.39791312  0.85834997  0.35356940  1
+",-154.35853500000002
+10071,C-130507-2037-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46806000
+_cell_length_b   3.38381000
+_cell_length_c   5.24349000
+_cell_angle_alpha   90.36792000
+_cell_angle_beta   90.01207000
+_cell_angle_gamma   111.42413000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.76388145
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.21598723  0.49982277  0.25517816  1
+  C  C1  1  0.59492483  0.24937044  0.85507792  1
+  C  C2  1  0.73785179  0.54420180  0.38000811  1
+  C  C3  1  0.37133828  0.80256147  0.77932652  1
+  C  C4  1  0.18418735  0.42783649  0.97996260  1
+  C  C5  1  0.78117032  0.62283693  0.65472939  1
+",-154.16478483333333
+1609,C-184058-8674-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.56907000
+_cell_length_b   3.64407000
+_cell_length_c   5.50248000
+_cell_angle_alpha   109.80809000
+_cell_angle_beta   61.37235000
+_cell_angle_gamma   91.08609000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.89446851
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.65801497  1.05420206  0.68225047  1
+  C  C1  1  0.65832627  0.66952572  0.68212592  1
+  C  C2  1  0.15481743  0.61340120  0.18335361  1
+  C  C3  1  -0.03552349  0.40113338  0.37405194  1
+  C  C4  1  -0.03521219  0.01645704  0.37392739  1
+  C  C5  1  0.46798535  0.45725790  0.87282426  1
+",-154.069936
+2655,C-170329-7952-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48716000
+_cell_length_b   3.95467000
+_cell_length_c   6.72664000
+_cell_angle_alpha   111.45007000
+_cell_angle_beta   111.66692000
+_cell_angle_gamma   89.99078000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.52921368
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.27323633  0.65158510  0.37735908  1
+  C  C1  1  0.50437009  0.82765638  0.10943838  1
+  C  C2  1  0.60923058  0.34092517  0.71394015  1
+  C  C3  1  1.10353186  0.57491261  0.70813652  1
+  C  C4  1  0.30111022  0.96474946  0.90860377  1
+  C  C5  1  0.01095599  0.59392413  0.11574245  1
+  C  C6  1  0.84263717  0.51860624  0.44689076  1
+  C  C7  1  0.80706213  0.20440317  0.91462624  1
+  C  C8  1  0.36357575  0.05046560  0.46850129  1
+  C  C9  1  0.74983718  1.11934934  0.35480376  1
+",-154.32873999999998
+8309,C-170918-845-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.58600000
+_cell_length_b   3.25901000
+_cell_length_c   4.90461000
+_cell_angle_alpha   69.19811000
+_cell_angle_beta   70.67812000
+_cell_angle_gamma   76.31444000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   50.10190428
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.41984426  0.61175822  0.53991605  1
+  C  C1  1  0.84490140  0.01419929  0.82107300  1
+  C  C2  1  0.23910965  0.74839773  0.79367143  1
+  C  C3  1  0.33989803  0.89447836  0.24663426  1
+  C  C4  1  0.94438256  0.15778940  0.27504345  1
+  C  C5  1  0.49678575  0.68934959  0.98818350  1
+  C  C6  1  0.68711987  0.21825269  0.07991760  1
+  C  C7  1  0.76069698  0.29148131  0.52927630  1
+",-154.0664025
+7202,C-148254-5891-57,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48185000
+_cell_length_b   6.83415000
+_cell_length_c   6.35447000
+_cell_angle_alpha   111.95013000
+_cell_angle_beta   101.25002000
+_cell_angle_gamma   100.38164000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   94.17416921
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.26650208  0.98533082  0.68009860  1
+  C  C1  1  0.13314260  1.05806644  0.33991403  1
+  C  C2  1  0.89410509  0.13655915  0.78470236  1
+  C  C3  1  0.11629070  0.52832318  0.83612416  1
+  C  C4  1  0.42247736  0.48765280  0.48809941  1
+  C  C5  1  1.02841307  0.06436597  0.12450369  1
+  C  C6  1  0.23493932  0.82632731  0.78243813  1
+  C  C7  1  -0.07473965  0.29546307  0.68230751  1
+  C  C8  1  1.08242249  0.24146991  1.05546943  1
+  C  C9  1  0.33909207  0.27335880  0.53113785  1
+  C  C10  1  0.86331047  0.63173121  0.22537637  1
+  C  C11  1  0.29834039  0.49002593  0.23961375  1
+  C  C12  1  0.73821831  0.63418131  0.97688291  1
+  C  C13  1  0.07784581  0.88051141  0.40901988  1
+  C  C14  1  -0.17880275  0.84848315  0.93367581  1
+  C  C15  1  0.04479135  0.59384552  0.62867040  1
+",-154.157649375
+157,C-170335-8559-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51383000
+_cell_length_b   4.81744000
+_cell_length_c   4.18705000
+_cell_angle_alpha   54.87047000
+_cell_angle_beta   72.51040000
+_cell_angle_gamma   58.55041000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.37817435
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.54725800  0.77560588  0.78808776  1
+  C  C1  1  0.91580702  0.01848798  0.56464005  1
+  C  C2  1  0.54733181  0.38730674  0.56460628  1
+  C  C3  1  0.91555135  0.40680026  0.78806939  1
+  C  C4  1  0.39734408  0.73178580  0.17631699  1
+  C  C5  1  0.06596285  0.06238145  0.17630023  1
+",-154.23102066666667
+9928,C-96707-5370-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43050000
+_cell_length_b   5.68235000
+_cell_length_c   6.36105000
+_cell_angle_alpha   87.59972000
+_cell_angle_beta   96.33867000
+_cell_angle_gamma   91.38293000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   87.22163652
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46444311  0.27355330  0.48802917  1
+  C  C1  1  0.41217036  0.44643015  0.83161249  1
+  C  C2  1  0.95531163  0.30051976  0.14841388  1
+  C  C3  1  0.86516158  0.82967451  0.72091155  1
+  C  C4  1  0.45128411  0.43386031  0.06373370  1
+  C  C5  1  0.98462901  0.06970478  0.04185281  1
+  C  C6  1  0.44785570  0.22865886  0.71997313  1
+  C  C7  1  0.48923058  0.70446538  0.05830347  1
+  C  C8  1  0.72462402  0.81550371  0.48641658  1
+  C  C9  1  0.17286424  0.81325710  0.37911780  1
+  C  C10  1  0.39694328  0.70867273  0.81345304  1
+  C  C11  1  0.94154842  0.08338227  0.80180901  1
+  C  C12  1  0.03792317  0.82532736  0.14335437  1
+  C  C13  1  -0.04834631  0.28568917  0.38218689  1
+",-154.08556857142858
+4594,C-130505-1819-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46133000
+_cell_length_b   3.35725000
+_cell_length_c   4.48727000
+_cell_angle_alpha   111.95650000
+_cell_angle_beta   84.67073000
+_cell_angle_gamma   104.49368000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   33.29572745
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.11444344  0.28014631  0.60423164  1
+  C  C1  1  -0.09828115  0.03309145  0.83773243  1
+  C  C2  1  0.61445410  0.17518033  0.39369245  1
+  C  C3  1  0.32037994  0.75969581  0.83788108  1
+  C  C4  1  0.40187527  0.69443275  0.15983392  1
+  C  C5  1  0.82051500  0.42079984  0.15968899  1
+",-154.20251583333334
+107,C-41264-888-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42990000
+_cell_length_b   2.42997000
+_cell_length_c   8.47243000
+_cell_angle_alpha   81.88145000
+_cell_angle_beta   88.75421000
+_cell_angle_gamma   59.98423000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.81308816
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.37218463  1.05281043  0.98700668  1
+  C  C1  1  0.88308892  -0.02019420  0.65293664  1
+  C  C2  1  0.55016887  0.64600918  0.65348687  1
+  C  C3  1  0.72543908  0.22124675  0.31941034  1
+  C  C4  1  1.05874491  0.55455943  0.31942261  1
+  C  C5  1  0.70554958  0.38625953  0.98690557  1
+",-154.46060516666668
+5514,C-76014-6220-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48493000
+_cell_length_b   4.67890000
+_cell_length_c   4.08701000
+_cell_angle_alpha   96.69018000
+_cell_angle_beta   90.00331000
+_cell_angle_gamma   74.55347000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.46650329
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.29439960  0.26937582  0.57950657  1
+  C  C1  1  0.95218647  0.95765026  0.17316018  1
+  C  C2  1  0.06512356  0.72645682  0.86723275  1
+  C  C3  1  0.78059985  0.29937889  0.10565339  1
+  C  C4  1  0.45329095  0.95495613  0.39871096  1
+  C  C5  1  0.56419466  0.72803475  0.64054049  1
+  C  C6  1  0.23661567  0.38556921  0.93513956  1
+  C  C7  1  0.72168864  0.41353432  0.46147191  1
+",-154.36884875
+5341,C-102765-3112-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48561000
+_cell_length_b   6.10798000
+_cell_length_c   6.94277000
+_cell_angle_alpha   79.67896000
+_cell_angle_beta   89.96756000
+_cell_angle_gamma   78.25646000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   101.45884787
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.23291423  1.01224992  0.04230890  1
+  C  C1  1  1.01481096  0.51695950  0.24654948  1
+  C  C2  1  0.96005365  0.61609577  0.55528218  1
+  C  C3  1  0.28261905  0.97515177  0.68955541  1
+  C  C4  1  0.11135476  0.32498237  0.13145703  1
+  C  C5  1  0.71082248  0.11812535  0.70155452  1
+  C  C6  1  0.43988642  0.66688967  0.23302474  1
+  C  C7  1  0.40525898  0.72620877  0.45092328  1
+  C  C8  1  0.68559057  0.17624299  0.18605581  1
+  C  C9  1  1.06398083  0.40712818  0.46749247  1
+  C  C10  1  0.28893138  -0.04001703  0.47003717  1
+  C  C11  1  -0.34123497  0.22289926  0.87221754  1
+  C  C12  1  0.72589407  0.08535894  0.39397583  1
+  C  C13  1  0.96102940  0.61474266  0.79197519  1
+  C  C14  1  0.39203457  0.75267548  0.83815334  1
+  C  C15  1  1.34416358  0.85736975  0.04484053  1
+  C  C16  1  0.63180608  0.27144361  0.50908441  1
+  C  C17  1  0.08937592  0.36252453  0.90472668  1
+",-154.36725222222222
+9408,C-53838-1497-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48126000
+_cell_length_b   4.84331000
+_cell_length_c   4.89584000
+_cell_angle_alpha   44.49742000
+_cell_angle_beta   59.51472000
+_cell_angle_gamma   75.12733000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99303661
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.09392204  0.61367683  0.26275118  1
+  C  C1  1  0.80272898  0.77017669  0.97525663  1
+  C  C2  1  1.05354350  0.52674882  0.84567209  1
+  C  C3  1  0.76344939  0.68359486  0.55775610  1
+  C  C4  1  0.77954639  0.12905980  0.31898558  1
+  C  C5  1  0.07625269  1.16810469  0.50233632  1
+",-154.3092555
+259,C-80182-7828-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43018000
+_cell_length_b   4.20245000
+_cell_length_c   5.58606000
+_cell_angle_alpha   91.56940000
+_cell_angle_beta   89.93716000
+_cell_angle_gamma   89.76309000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.02688133
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.02608680  0.96138582  -0.07562995  1
+  C  C1  1  0.18695983  0.89713195  0.42585928  1
+  C  C2  1  0.52660375  0.12868580  -0.07542531  1
+  C  C3  1  0.18640485  0.22982017  0.42567655  1
+  C  C4  1  0.68641115  0.72982014  0.42568348  1
+  C  C5  1  1.02662464  0.62867673  0.92450077  1
+  C  C6  1  0.68695578  0.39713104  0.42586006  1
+  C  C7  1  0.52610771  0.46138455  -0.07570517  1
+",-154.43981625
+3342,C-56503-8782-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49180000
+_cell_length_b   2.48369000
+_cell_length_c   9.65280000
+_cell_angle_alpha   120.97799000
+_cell_angle_beta   112.51533000
+_cell_angle_gamma   90.00382000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.82525785
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53516467  0.43556166  0.69854849  1
+  C  C1  1  0.08555048  0.35199600  0.40672423  1
+  C  C2  1  0.92303804  0.63683861  0.29921218  1
+  C  C3  1  0.24027656  0.39040531  0.17619198  1
+  C  C4  1  1.06458192  0.65423278  0.05823473  1
+  C  C5  1  0.37353788  0.72054250  0.59103959  1
+  C  C6  1  0.21531114  0.68048545  0.82122570  1
+  C  C7  1  0.38834202  0.41591429  0.93900450  1
+",-154.34032375
+5882,C-102903-5111-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.19797000
+_cell_length_b   4.30268000
+_cell_length_c   3.75746000
+_cell_angle_alpha   115.85688000
+_cell_angle_beta   90.01150000
+_cell_angle_gamma   119.15454000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   51.34691351
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.56284081  0.91987807  0.80449540  1
+  C  C1  1  0.50735924  0.50765991  0.59784759  1
+  C  C2  1  0.85930864  0.49627678  0.59222641  1
+  C  C3  1  0.21070952  0.93120798  0.81013139  1
+  C  C4  1  0.89293302  1.26439684  0.17450697  1
+  C  C5  1  -0.10704622  0.26456652  0.77945745  1
+  C  C6  1  1.17706309  1.16327281  0.22896162  1
+  C  C7  1  0.17753090  0.16399080  0.62459058  1
+",-154.1460125
+7215,C-34617-8887-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48012000
+_cell_length_b   2.48056000
+_cell_length_c   8.66164000
+_cell_angle_alpha   73.36630000
+_cell_angle_beta   89.99159000
+_cell_angle_gamma   59.97476000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.54314842
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.89437566  0.96655426  0.12411436  1
+  C  C1  1  0.43586754  -0.11542587  0.43485527  1
+  C  C2  1  0.60304935  0.54963300  0.18638411  1
+  C  C3  1  0.06160997  0.63133665  0.87561654  1
+  C  C4  1  0.72693544  0.30208478  0.37210569  1
+  C  C5  1  0.77045410  0.21390980  0.93835146  1
+  C  C6  1  0.93668736  0.88229720  0.68674490  1
+  C  C7  1  0.56112178  0.63330708  0.62365576  1
+",-154.53071125
+2072,C-57148-8436-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45518000
+_cell_length_b   3.35266000
+_cell_length_c   7.41120000
+_cell_angle_alpha   91.32064000
+_cell_angle_beta   99.55173000
+_cell_angle_gamma   111.59246000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   55.70118717
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.18366643  0.88395499  0.13308723  1
+  C  C1  1  0.25438098  0.64931123  0.51174497  1
+  C  C2  1  0.83138933  0.52583807  0.79128757  1
+  C  C3  1  0.72815923  0.68808149  0.42132141  1
+  C  C4  1  0.90620211  0.47740545  0.98698786  1
+  C  C5  1  0.64900011  0.72611790  0.22412494  1
+  C  C6  1  0.37140348  0.31790672  0.07672616  1
+  C  C7  1  0.30829812  0.56948726  0.70187186  1
+",-154.20220125
+8188,C-13946-920-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42866000
+_cell_length_b   5.65669000
+_cell_length_c   4.01291000
+_cell_angle_alpha   52.57824000
+_cell_angle_beta   87.95219000
+_cell_angle_gamma   99.34022000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.56322058
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.49418775  0.68551355  0.05998434  1
+  C  C1  1  0.82784511  0.35284576  0.72680866  1
+  C  C2  1  0.27311468  0.24283692  0.94939482  1
+  C  C3  1  0.16099660  1.01913139  0.39343342  1
+  C  C4  1  0.60619219  0.90893712  0.61600700  1
+  C  C5  1  -0.06011982  0.57661046  0.28289136  1
+",-154.438803
+6801,C-170886-315-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43117000
+_cell_length_b   7.12772000
+_cell_length_c   6.12958000
+_cell_angle_alpha   57.32299000
+_cell_angle_beta   76.21194000
+_cell_angle_gamma   88.02594000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   86.25120455
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55247893  0.97867533  -0.01874645  1
+  C  C1  1  1.29466730  0.91010216  0.54964823  1
+  C  C2  1  0.44189077  0.75681758  0.20363973  1
+  C  C3  1  -0.03866176  0.24338998  0.21633908  1
+  C  C4  1  0.51750379  0.35460390  0.10492504  1
+  C  C5  1  0.18419247  0.68797442  0.77155230  1
+  C  C6  1  1.10856478  0.09012375  -0.12970928  1
+  C  C7  1  -0.11421662  0.64539400  0.31462740  1
+  C  C8  1  0.21914877  0.31204127  0.64797670  1
+  C  C9  1  0.85079557  1.02129857  0.43831111  1
+  C  C10  1  0.62804215  0.57673699  0.88293822  1
+  C  C11  1  -0.22476294  0.42351507  0.53701561  1
+",-154.45930916666666
+7470,C-53852-3564-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45465000
+_cell_length_b   4.59409000
+_cell_length_c   5.35845000
+_cell_angle_alpha   95.57648000
+_cell_angle_beta   89.94542000
+_cell_angle_gamma   74.47006000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.92202048
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.36708864  0.39288147  -0.04533039  1
+  C  C1  1  0.23588354  0.18964082  0.55180195  1
+  C  C2  1  0.94998733  0.76171582  0.75582569  1
+  C  C3  1  0.52422487  0.61926202  0.38311522  1
+  C  C4  1  0.74731012  0.16560550  0.13073314  1
+  C  C5  1  0.12515312  0.41031648  0.78928111  1
+  C  C6  1  0.48452232  0.68865706  1.12381878  1
+  C  C7  1  -0.09772546  0.85349923  0.03832834  1
+  C  C8  1  0.69264477  0.27985556  0.40114681  1
+  C  C9  1  0.40721715  0.84692545  0.60931455  1
+",-154.207494
+1678,C-170342-4227-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48764000
+_cell_length_b   3.51751000
+_cell_length_c   4.30463000
+_cell_angle_alpha   114.10916000
+_cell_angle_beta   106.78438000
+_cell_angle_gamma   90.01025000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.61423194
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.93759770  0.74376378  0.34786789  1
+  C  C1  1  0.77095343  0.32669329  0.01430111  1
+  C  C2  1  0.43762010  -0.00664005  0.34763444  1
+  C  C3  1  0.60426437  0.41043045  0.68120122  1
+  C  C4  1  1.10428676  0.66002662  0.68096778  1
+  C  C5  1  0.27093104  0.07709711  1.01453456  1
+",-154.54804
+7730,C-126153-9712-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46166000
+_cell_length_b   3.35781000
+_cell_length_c   4.48289000
+_cell_angle_alpha   68.03892000
+_cell_angle_beta   84.61523000
+_cell_angle_gamma   75.52017000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   33.27425004
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.33119365  0.96226643  0.28268813  1
+  C  C1  1  0.74996874  0.23571311  0.28269841  1
+  C  C2  1  0.83155002  0.62318019  0.96064741  1
+  C  C3  1  0.54067711  0.48220576  0.51639661  1
+  C  C4  1  1.04084165  0.37668754  0.72694920  1
+  C  C5  1  0.25032511  0.89662686  0.96065769  1
+",-154.20028883333333
+5982,C-90813-2847-59,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43197000
+_cell_length_b   4.20474000
+_cell_length_c   6.09246000
+_cell_angle_alpha   110.40100000
+_cell_angle_beta   79.77271000
+_cell_angle_gamma   90.21384000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.35041548
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.03518656  0.27123275  0.56231360  1
+  C  C1  1  0.96423252  0.93852317  0.56257518  1
+  C  C2  1  0.55853755  0.48305407  1.06420862  1
+  C  C3  1  0.46427810  0.43847631  0.56251938  1
+  C  C4  1  0.05850420  -0.01691016  1.06425863  1
+  C  C5  1  0.46478009  0.77126851  0.56236361  1
+  C  C6  1  1.05908512  0.31579941  0.06399705  1
+  C  C7  1  0.55903953  0.81584627  1.06405285  1
+",-154.453705
+9586,C-126155-7469-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42970000
+_cell_length_b   3.11460000
+_cell_length_c   6.24058000
+_cell_angle_alpha   100.86814000
+_cell_angle_beta   90.77164000
+_cell_angle_gamma   111.47493000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.98289427
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.12857980  0.62115428  0.82866534  1
+  C  C1  1  0.46216624  0.28834649  0.49526161  1
+  C  C2  1  0.35231711  0.06818618  0.27352441  1
+  C  C3  1  0.01914325  0.40188560  0.60683868  1
+  C  C4  1  0.68542153  0.73438030  0.94023772  1
+  C  C5  1  0.79520197  -0.04561966  0.16197493  1
+",-154.46577966666666
+6131,C-72752-8394-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43147000
+_cell_length_b   3.34549000
+_cell_length_c   5.96685000
+_cell_angle_alpha   98.12167000
+_cell_angle_beta   88.10945000
+_cell_angle_gamma   114.91258000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.56026305
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.52299126  0.20426587  0.41159525  1
+  C  C1  1  0.74564235  0.65040749  0.85583211  1
+  C  C2  1  0.41233805  0.98376332  0.18922209  1
+  C  C3  1  0.18967489  0.53758621  0.74487078  1
+  C  C4  1  0.85637267  0.87093123  0.07821532  1
+  C  C5  1  0.07894988  0.31707149  0.52254385  1
+",-154.464304
+8092,C-96669-7803-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.45833000
+_cell_length_b   3.35787000
+_cell_length_c   5.88274000
+_cell_angle_alpha   64.48236000
+_cell_angle_beta   82.10816000
+_cell_angle_gamma   89.25001000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   60.98518446
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.00810593  0.83911179  0.27513142  1
+  C  C1  1  0.94427193  0.92901396  0.69933524  1
+  C  C2  1  0.63300710  0.25484950  0.69273493  1
+  C  C3  1  0.37158233  0.52692524  1.00495803  1
+  C  C4  1  0.32714230  0.48985348  0.27838085  1
+  C  C5  1  0.75031402  0.47110845  0.85740264  1
+  C  C6  1  1.06798209  0.19421139  0.00203344  1
+  C  C7  1  0.25803494  0.98635188  0.83523898  1
+  C  C8  1  0.01430893  0.11231581  0.41535597  1
+  C  C9  1  0.68955584  0.46336400  0.39409892  1
+",-154.241139
+1901,C-40144-9743-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.36278000
+_cell_length_b   3.36528000
+_cell_length_c   5.87806000
+_cell_angle_alpha   100.34954000
+_cell_angle_beta   116.55779000
+_cell_angle_gamma   84.84337000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.52972992
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.01341033  1.25066752  0.18175309  1
+  C  C1  1  0.30683163  0.60561721  0.34779879  1
+  C  C2  1  0.19089338  0.90161523  0.52651852  1
+  C  C3  1  0.70873652  0.41924142  0.52649839  1
+  C  C4  1  0.63831866  0.13356858  0.68759003  1
+  C  C5  1  0.37749516  0.89164157  0.18675268  1
+  C  C6  1  1.00320687  0.77361801  0.69267521  1
+  C  C7  1  0.82502684  0.12457104  0.34792575  1
+  C  C8  1  0.35895365  0.66345777  -0.06036149  1
+  C  C9  1  0.65724986  0.36062215  0.93520992  1
+",-154.212782
+7901,C-96715-726-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42909000
+_cell_length_b   2.42940000
+_cell_length_c   8.43476000
+_cell_angle_alpha   86.03913000
+_cell_angle_beta   87.21701000
+_cell_angle_gamma   120.00366000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.80290067
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.30480333  1.12439524  0.81268083  1
+  C  C1  1  0.52792302  0.31147111  0.47998319  1
+  C  C2  1  0.86209284  0.97803173  0.47946833  1
+  C  C3  1  -0.02831655  0.45760280  0.81265585  1
+  C  C4  1  0.14077437  0.02552805  0.14490969  1
+  C  C5  1  0.47404188  0.69163365  0.14526021  1
+",-154.45327116666667
+9631,C-47642-4937-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48841000
+_cell_length_b   4.30450000
+_cell_length_c   4.97487000
+_cell_angle_alpha   106.79377000
+_cell_angle_beta   120.04843000
+_cell_angle_gamma   73.20881000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.48489279
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.89749696  0.56038437  0.75236985  1
+  C  C1  1  0.39789183  0.06038416  0.50242593  1
+  C  C2  1  0.39789183  1.06038416  1.00242593  1
+  C  C3  1  0.52301875  0.68537165  -0.06011080  1
+  C  C4  1  -0.10250304  0.56038437  0.25236985  1
+  C  C5  1  0.02341362  0.18537145  0.18994529  1
+  C  C6  1  0.52301875  0.68537165  0.43988920  1
+  C  C7  1  0.02341362  0.18537145  0.68994529  1
+",-154.54777375
+4435,C-148252-2749-56,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.47288000
+_cell_length_b   5.77976000
+_cell_length_c   4.41706000
+_cell_angle_alpha   55.62126000
+_cell_angle_beta   71.44640000
+_cell_angle_gamma   53.04106000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.44038492
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.60135377  0.91863213  0.41767257  1
+  C  C1  1  0.29613637  0.22963552  0.10243361  1
+  C  C2  1  0.39450715  0.68394098  0.10096156  1
+  C  C3  1  0.39400449  0.36695529  0.73364779  1
+  C  C4  1  0.08851300  0.67789702  0.41842877  1
+  C  C5  1  0.84608028  0.39132983  0.23101429  1
+  C  C6  1  0.29555107  -0.08737147  0.73509305  1
+  C  C7  1  0.84409557  0.20532750  0.60506446  1
+",-154.1890025
+7499,C-72746-903-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44096000
+_cell_length_b   4.04489000
+_cell_length_c   6.39210000
+_cell_angle_alpha   101.18741000
+_cell_angle_beta   72.21489000
+_cell_angle_gamma   78.14056000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.53586051
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.10452570  0.96813345  0.92046689  1
+  C  C1  1  0.53546610  0.07843951  0.34326780  1
+  C  C2  1  0.44011014  0.67896466  0.69248970  1
+  C  C3  1  -0.06905508  0.04889758  0.49029496  1
+  C  C4  1  0.35233632  0.43771576  0.32570659  1
+  C  C5  1  0.41783522  0.54586205  0.11512107  1
+  C  C6  1  -0.12959745  0.78982704  1.11492203  1
+  C  C7  1  1.04372437  0.70916387  0.54532565  1
+  C  C8  1  0.55550049  0.21233435  0.92060313  1
+  C  C9  1  0.62287190  0.31987502  0.70983687  1
+",-154.122242
+1689,C-47660-7998-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43059000
+_cell_length_b   4.86099000
+_cell_length_c   5.83914000
+_cell_angle_alpha   75.49740000
+_cell_angle_beta   76.46072000
+_cell_angle_gamma   59.80097000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.24266721
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.13651059  0.39998405  0.99283098  1
+  C  C1  1  0.56970903  0.18739340  0.49341672  1
+  C  C2  1  0.47072837  0.06705323  0.99174081  1
+  C  C3  1  0.56970939  0.68737272  0.49338199  1
+  C  C4  1  -0.09607973  0.85445633  0.49229100  1
+  C  C5  1  0.47075465  0.56702121  -0.00811775  1
+  C  C6  1  1.13644616  0.89995962  -0.00710885  1
+  C  C7  1  -0.09611336  0.35446494  0.49240609  1
+",-154.4474275
+1663,C-170350-1491-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45038000
+_cell_length_b   4.50411000
+_cell_length_c   4.67409000
+_cell_angle_alpha   78.75336000
+_cell_angle_beta   121.70716000
+_cell_angle_gamma   105.73776000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.15529514
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53272967  0.84239009  0.40676126  1
+  C  C1  1  0.24804066  0.89883521  0.59413939  1
+  C  C2  1  0.46029513  0.65754630  0.92593261  1
+  C  C3  1  0.17231999  0.34542148  0.79446296  1
+  C  C4  1  0.17579989  0.71602604  1.11231316  1
+  C  C5  1  0.53653116  0.21165968  0.72538423  1
+",-154.24457533333333
+2418,C-96678-2884-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48052000
+_cell_length_b   4.24340000
+_cell_length_c   5.62787000
+_cell_angle_alpha   97.84002000
+_cell_angle_beta   102.72666000
+_cell_angle_gamma   89.96696000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.21595932
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.95723535  0.13238837  0.44714349  1
+  C  C1  1  0.91382169  0.45755536  0.36148986  1
+  C  C2  1  0.28316199  0.76968407  0.09720326  1
+  C  C3  1  0.59915301  0.68348214  0.73039328  1
+  C  C4  1  0.65159904  0.37263405  0.83683954  1
+  C  C5  1  0.46518289  0.63466426  0.46468372  1
+  C  C6  1  0.78352268  0.54904292  0.09841648  1
+  C  C7  1  0.10934089  0.18606681  0.75041635  1
+  C  C8  1  0.14991297  0.86001758  0.83384594  1
+  C  C9  1  0.41295500  0.94547075  0.35904087  1
+",-154.36712
+1624,C-137385-5334-58,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47709000
+_cell_length_b   7.23079000
+_cell_length_c   7.70135000
+_cell_angle_alpha   68.43890000
+_cell_angle_beta   99.58467000
+_cell_angle_gamma   101.04779000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C22
+_cell_volume   125.21204364
+_cell_formula_units_Z   22
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.21172988  0.21826844  0.40528190  1
+  C  C1  1  0.78955099  0.42997889  0.27299483  1
+  C  C2  1  0.16951827  0.63084082  0.69800903  1
+  C  C3  1  1.11458596  0.49383796  0.58076701  1
+  C  C4  1  0.34647733  0.19091605  0.52731880  1
+  C  C5  1  -0.00715260  0.10443636  0.90220425  1
+  C  C6  1  0.30119949  -0.01753226  0.67545158  1
+  C  C7  1  -0.13839508  0.94781680  0.80398064  1
+  C  C8  1  -0.13058957  0.73494043  -0.06042443  1
+  C  C9  1  0.62974141  1.06316727  0.27711357  1
+  C  C10  1  1.14192559  0.84139530  0.56157474  1
+  C  C11  1  0.09720003  0.11027111  0.15084768  1
+  C  C12  1  0.15437879  0.33151574  0.04829876  1
+  C  C13  1  0.53075178  0.35415441  0.62268513  1
+  C  C14  1  0.53540265  0.23385133  0.83418131  1
+  C  C15  1  0.56403386  0.86046175  0.43702120  1
+  C  C16  1  1.26322373  0.45879752  0.15810984  1
+  C  C17  1  0.63115391  0.38018409  0.93325194  1
+  C  C18  1  0.71574156  0.59701368  0.81759323  1
+  C  C19  1  0.73075828  0.63930102  0.28554195  1
+  C  C20  1  0.29970410  0.67104812  0.38403694  1
+  C  C21  1  0.42339481  0.67964737  0.06243439  1
+",-154.13877181818182
+7407,C-113054-2060-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43056000
+_cell_length_b   4.20688000
+_cell_length_c   5.77203000
+_cell_angle_alpha   79.92478000
+_cell_angle_beta   78.33980000
+_cell_angle_gamma   90.14116000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.86632494
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79205053  0.19192034  0.39716548  1
+  C  C1  1  0.46440602  0.40285951  0.89270737  1
+  C  C2  1  0.96431572  0.90280790  -0.10710131  1
+  C  C3  1  0.29146656  0.02504208  0.39936819  1
+  C  C4  1  0.46394657  0.73604776  0.89464075  1
+  C  C5  1  0.29204267  0.69194732  0.39715894  1
+  C  C6  1  0.79144974  0.52506770  0.39936276  1
+  C  C7  1  -0.03611830  0.23601790  0.89477513  1
+",-154.43760375
+9288,C-28250-3871-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43085000
+_cell_length_b   3.85106000
+_cell_length_c   4.76852000
+_cell_angle_alpha   84.19997000
+_cell_angle_beta   105.73105000
+_cell_angle_gamma   89.19491000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.70776582
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.89595223  0.75392871  0.81078644  1
+  C  C1  1  0.78488046  0.53146446  0.58863546  1
+  C  C2  1  0.22952535  0.41977859  0.47795368  1
+  C  C3  1  0.45102890  -0.13358937  0.92106411  1
+  C  C4  1  0.56305879  0.08519796  0.14527831  1
+  C  C5  1  0.11809436  0.19770104  0.25562440  1
+",-154.44781566666668
+4202,C-73635-4417-62,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46580000
+_cell_length_b   3.30271000
+_cell_length_c   6.41365000
+_cell_angle_alpha   98.33716000
+_cell_angle_beta   97.79830000
+_cell_angle_gamma   103.65759000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.42783919
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.75259851  -0.04768578  0.15005084  1
+  C  C1  1  0.06178477  0.71307438  0.81480007  1
+  C  C2  1  0.62964193  0.78246565  0.94374533  1
+  C  C3  1  0.60629254  0.44123186  0.43909301  1
+  C  C4  1  0.78114347  0.29213838  0.65505687  1
+  C  C5  1  0.20558806  1.01986750  0.65334090  1
+  C  C6  1  0.18170391  0.71452189  0.44085089  1
+  C  C7  1  0.32025482  0.02088552  0.27909081  1
+",-154.1610275
+1403,C-170362-9529-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48679000
+_cell_length_b   2.48809000
+_cell_length_c   6.57443000
+_cell_angle_alpha   79.07265000
+_cell_angle_beta   112.19744000
+_cell_angle_gamma   120.05531000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.59941296
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.16614006  0.51563343  0.55069875  1
+  C  C1  1  0.91634803  0.84884038  0.63434372  1
+  C  C2  1  -0.08378653  0.18303000  0.96745899  1
+  C  C3  1  1.16613384  0.18357555  0.21732056  1
+  C  C4  1  0.91594051  0.51669542  0.30046340  1
+  C  C5  1  0.16656418  0.84945153  0.88451178  1
+",-154.5392035
+7296,C-73643-4390-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42730000
+_cell_length_b   3.54042000
+_cell_length_c   7.54605000
+_cell_angle_alpha   73.31711000
+_cell_angle_beta   81.74856000
+_cell_angle_gamma   101.03700000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   59.59565840
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.08553880  0.41810495  0.39918501  1
+  C  C1  1  0.83556625  0.91804958  0.14917481  1
+  C  C2  1  0.91879619  0.08507162  0.56561786  1
+  C  C3  1  0.66881081  0.58508329  0.31562090  1
+  C  C4  1  0.41887071  1.08502510  1.06560288  1
+  C  C5  1  0.33547759  -0.08193789  0.64917436  1
+  C  C6  1  0.16883211  0.58503076  0.81560186  1
+  C  C7  1  0.58559335  0.41802969  0.89916041  1
+",-154.42529125
+7225,C-189698-2813-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48768000
+_cell_length_b   2.48734000
+_cell_length_c   6.08796000
+_cell_angle_alpha   89.99863000
+_cell_angle_beta   90.00332000
+_cell_angle_gamma   120.03444000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.61228790
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.30764469  0.49223400  0.12167228  1
+  C  C1  1  0.30850894  0.49220223  0.37234053  1
+  C  C2  1  0.64192867  1.15898511  0.45502272  1
+  C  C3  1  -0.02507201  -0.17380064  0.78835423  1
+  C  C4  1  0.97425714  0.82557051  1.03900222  1
+  C  C5  1  0.64165297  0.15948060  0.70568850  1
+",-154.54079433333334
+7820,C-150707-6192-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   5.98238000
+_cell_length_b   4.84274000
+_cell_length_c   5.76386000
+_cell_angle_alpha   74.94299000
+_cell_angle_beta   78.43790000
+_cell_angle_gamma   66.19111000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C20
+_cell_volume   146.66387341
+_cell_formula_units_Z   20
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.61871425  0.87578569  0.45418468  1
+  C  C1  1  0.83778187  1.26540132  0.45553397  1
+  C  C2  1  0.22875345  0.92217869  0.45345524  1
+  C  C3  1  -0.12605596  0.74817790  0.45507623  1
+  C  C4  1  0.47054494  0.70938884  0.45507111  1
+  C  C5  1  0.65959228  0.61543888  -0.04592789  1
+  C  C6  1  0.06285751  0.65428825  0.95414723  1
+  C  C7  1  0.47133457  0.19066575  0.45501044  1
+  C  C8  1  0.30479889  0.44172619  -0.04433833  1
+  C  C9  1  0.22805426  1.22088181  0.45300804  1
+  C  C10  1  -0.01398892  0.95028432  0.45444442  1
+  C  C11  1  0.69570260  0.09895400  0.95287596  1
+  C  C12  1  0.58255885  0.39337218  0.45447224  1
+  C  C13  1  0.95073469  -0.02919186  0.95416722  1
+  C  C14  1  0.54775148  0.41326171  0.95454613  1
+  C  C15  1  0.91484968  0.48761716  0.95501587  1
+  C  C16  1  0.30549533  0.14349613  0.95571450  1
+  C  C17  1  -0.01438200  0.43230607  0.45473941  1
+  C  C18  1  1.06225685  0.17307381  0.95394743  1
+  C  C19  1  0.54783398  -0.06800415  0.95371001  1
+",-154.252431
+4413,C-170906-4496-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46279000
+_cell_length_b   4.24883000
+_cell_length_c   4.24801000
+_cell_angle_alpha   100.42055000
+_cell_angle_beta   90.00026000
+_cell_angle_gamma   89.99593000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.71792811
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.68076267  0.75792845  0.37835733  1
+  C  C1  1  0.79904549  0.63553020  0.02599671  1
+  C  C2  1  -0.06848319  0.27116837  0.02820657  1
+  C  C3  1  0.43151630  0.10726848  0.86429983  1
+  C  C4  1  0.18076232  0.62120951  0.51466326  1
+  C  C5  1  0.29912733  0.74304456  0.86630734  1
+  C  C6  1  0.55742330  1.10966794  0.50068029  1
+  C  C7  1  1.05739200  0.26934739  0.39258556  1
+",-154.2356225
+4352,C-40140-2962-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42615000
+_cell_length_b   4.22807000
+_cell_length_c   4.22805000
+_cell_angle_alpha   92.36983000
+_cell_angle_beta   90.00638000
+_cell_angle_gamma   89.99211000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.33395543
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70650908  0.66460827  0.32472403  1
+  C  C1  1  0.70663034  0.60309186  0.97572104  1
+  C  C2  1  0.70651983  0.01433597  0.38502812  1
+  C  C3  1  0.20656249  0.52014626  0.46950850  1
+  C  C4  1  0.20650662  0.17121789  0.40708732  1
+  C  C5  1  0.20661754  0.57905725  0.81866418  1
+",-154.315144
+8934,C-41296-52-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47532000
+_cell_length_b   6.70892000
+_cell_length_c   7.12679000
+_cell_angle_alpha   49.81790000
+_cell_angle_beta   66.31270000
+_cell_angle_gamma   72.87128000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   82.69780313
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.88093597  0.77811985  0.27343223  1
+  C  C1  1  -0.02268565  0.70803144  0.78937026  1
+  C  C2  1  0.73313595  0.85834461  0.89910608  1
+  C  C3  1  -0.04143997  0.44640757  0.02828957  1
+  C  C4  1  1.04964040  1.18525291  0.42856601  1
+  C  C5  1  0.75254475  0.60106066  0.54060768  1
+  C  C6  1  0.63965441  1.04513289  0.41578836  1
+  C  C7  1  0.31797425  0.22550758  1.00613832  1
+  C  C8  1  0.62023462  0.33019972  0.72650325  1
+  C  C9  1  0.79802219  0.05736503  0.17097318  1
+  C  C10  1  0.60732608  0.76063179  0.63586411  1
+  C  C11  1  0.26049402  0.44957235  1.16722737  1
+  C  C12  1  0.12386668  0.73441794  0.08035981  1
+  C  C13  1  -0.21997089  0.14275776  0.68102986  1
+",-154.08393928571428
+4562,C-72714-6010-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.25149000
+_cell_length_b   4.16311000
+_cell_length_c   3.63281000
+_cell_angle_alpha   102.68193000
+_cell_angle_beta   106.07687000
+_cell_angle_gamma   100.00386000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.63319013
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.27946271  0.39403957  0.55689283  1
+  C  C1  1  0.08657946  0.20416005  0.15132437  1
+  C  C2  1  0.58424175  0.70519709  0.21075577  1
+  C  C3  1  0.77771338  0.89464897  0.99726513  1
+  C  C4  1  0.27967467  0.39345805  0.93740981  1
+  C  C5  1  0.58522383  0.70461386  0.59173650  1
+",-154.12745616666666
+3146,C-57148-8436-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43258000
+_cell_length_b   9.35870000
+_cell_length_c   8.50311000
+_cell_angle_alpha   124.97914000
+_cell_angle_beta   115.42619000
+_cell_angle_gamma   97.44661000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   123.40874547
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.50690637  0.34200878  0.09051395  1
+  C  C1  1  0.22774428  0.33923194  0.90533728  1
+  C  C2  1  0.42298248  0.73491989  0.23416516  1
+  C  C3  1  0.20896464  0.27966858  0.57858059  1
+  C  C4  1  0.34241411  -0.16060676  0.14594041  1
+  C  C5  1  0.47723518  0.37659931  0.39213762  1
+  C  C6  1  1.16094308  0.35245707  0.18964061  1
+  C  C7  1  1.12693053  0.38349028  0.48948969  1
+  C  C8  1  -0.06116949  0.76876784  0.89969572  1
+  C  C9  1  1.08034305  -0.03706419  0.26366549  1
+  C  C10  1  0.04094557  0.77529118  0.63235170  1
+  C  C11  1  0.38670149  0.76480079  0.53313186  1
+  C  C12  1  0.61210587  0.34996532  0.82464037  1
+  C  C13  1  0.07162519  0.74136039  0.33115324  1
+  C  C14  1  0.47105138  0.15609585  0.46086434  1
+  C  C15  1  0.32137267  0.77874553  0.81822517  1
+",-154.162240625
+7172,C-189709-289-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47643000
+_cell_length_b   6.58823000
+_cell_length_c   6.47201000
+_cell_angle_alpha   122.29893000
+_cell_angle_beta   105.61930000
+_cell_angle_gamma   98.45168000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   80.28522691
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.92937186  0.09560316  0.62463812  1
+  C  C1  1  0.82665139  0.80735758  0.76969067  1
+  C  C2  1  0.66424039  0.84512698  0.38205524  1
+  C  C3  1  0.47544275  -0.19524069  0.11785711  1
+  C  C4  1  0.07059211  0.07715163  0.84631503  1
+  C  C5  1  1.08326915  0.69895294  0.37021227  1
+  C  C6  1  0.85617386  0.35649258  0.45154727  1
+  C  C7  1  -0.01412520  -0.09392180  0.07388405  1
+  C  C8  1  0.14894186  0.65860554  0.59138829  1
+  C  C9  1  0.25819143  0.51650996  -0.03998397  1
+  C  C10  1  0.77824186  0.21970660  1.02065786  1
+  C  C11  1  0.98783555  0.32531276  0.66794203  1
+  C  C12  1  0.83205848  0.47369003  0.07803227  1
+  C  C13  1  0.13333991  0.21731415  0.26066725  1
+",-154.12763142857145
+489,C-134199-8894-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45717000
+_cell_length_b   3.66389000
+_cell_length_c   6.48034000
+_cell_angle_alpha   108.04709000
+_cell_angle_beta   79.07823000
+_cell_angle_gamma   109.63227000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.00832943
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.24639524  0.62162669  0.71215104  1
+  C  C1  1  0.86922656  0.77999906  0.62577790  1
+  C  C2  1  1.14234597  0.65253713  0.94822159  1
+  C  C3  1  0.59120554  0.65303207  1.05268537  1
+  C  C4  1  0.49263126  0.69307946  0.28973528  1
+  C  C5  1  0.87095327  0.53573808  0.37660934  1
+  C  C6  1  0.64700029  0.13902653  0.42740829  1
+  C  C7  1  0.09344155  0.17626478  0.57377549  1
+",-154.2811275
+1042,C-172941-6659-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.69053000
+_cell_length_b   4.21539000
+_cell_length_c   3.69073000
+_cell_angle_alpha   104.78455000
+_cell_angle_beta   140.73712000
+_cell_angle_gamma   75.20076000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.97743564
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.34840520  0.34005928  -0.09185675  1
+  C  C1  1  0.09090501  0.91142077  0.16667187  1
+  C  C2  1  0.54756105  0.41508369  0.70893116  1
+  C  C3  1  0.12561101  0.54641596  0.13092118  1
+  C  C4  1  0.66943082  1.04232948  0.58817957  1
+  C  C5  1  0.86806890  0.11781683  0.38916238  1
+",-154.30809833333333
+3921,C-189726-6424-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.06461000
+_cell_length_b   2.42973000
+_cell_length_c   6.41465000
+_cell_angle_alpha   100.85287000
+_cell_angle_beta   112.03149000
+_cell_angle_gamma   92.81310000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.10723879
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.43943082  0.10520414  0.58123221  1
+  C  C1  1  0.43788547  0.54867029  0.46965483  1
+  C  C2  1  0.43986098  0.88252512  0.13673537  1
+  C  C3  1  0.44162734  -0.22753831  -0.08482560  1
+  C  C4  1  0.43779761  1.21538195  0.80285602  1
+  C  C5  1  0.44056127  0.43902461  0.24822487  1
+",-154.446268
+8232,C-189732-2937-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.27448000
+_cell_length_b   3.62285000
+_cell_length_c   3.26714000
+_cell_angle_alpha   104.28822000
+_cell_angle_beta   80.90930000
+_cell_angle_gamma   104.32183000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.19722306
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36551954  0.99417679  0.28666393  1
+  C  C1  1  0.31146424  0.37564334  0.55444949  1
+  C  C2  1  0.58022835  0.75730816  0.50052974  1
+  C  C3  1  0.72628526  -0.00546315  0.92565697  1
+  C  C4  1  -0.00606168  0.37588900  0.87075389  1
+  C  C5  1  -0.05932451  0.75766305  1.14015467  1
+",-154.1963515
+1664,C-126179-5885-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42635000
+_cell_length_b   4.87277000
+_cell_length_c   4.22335000
+_cell_angle_alpha   91.24402000
+_cell_angle_beta   89.96585000
+_cell_angle_gamma   119.88105000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.28165022
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.08436785  0.33073611  0.01857038  1
+  C  C1  1  1.25927477  0.17451471  0.99308865  1
+  C  C2  1  0.32256327  0.73843494  0.42885446  1
+  C  C3  1  0.90973901  0.82525702  0.93379156  1
+  C  C4  1  0.84905872  0.76477665  0.58514516  1
+  C  C5  1  0.26401099  0.67955416  0.07970349  1
+",-154.31213683333334
+9008,C-141033-8048-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45005000
+_cell_length_b   5.68478000
+_cell_length_c   4.38421000
+_cell_angle_alpha   82.44430000
+_cell_angle_beta   106.21348000
+_cell_angle_gamma   90.11592000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.08694048
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.43266973  0.19208666  0.01248261  1
+  C  C1  1  0.25213952  0.24070212  0.65099204  1
+  C  C2  1  0.73680460  0.85967077  0.63110576  1
+  C  C3  1  0.99142323  1.04629912  0.13510201  1
+  C  C4  1  0.68930460  0.37942090  0.52190769  1
+  C  C5  1  0.51025788  0.40786149  0.16528782  1
+  C  C6  1  0.48005168  0.67374142  0.12027830  1
+  C  C7  1  -0.08263632  0.81226471  -0.00843178  1
+  C  C8  1  0.65918865  0.64509284  0.47694203  1
+  C  C9  1  0.17813203  0.00627157  0.50872521  1
+",-154.14056399999998
+5448,C-13657-9600-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43949000
+_cell_length_b   5.80097000
+_cell_length_c   5.56777000
+_cell_angle_alpha   112.90844000
+_cell_angle_beta   89.96268000
+_cell_angle_gamma   102.17679000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   70.65354419
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17284728  0.30743148  0.93493314  1
+  C  C1  1  0.62792553  0.21829291  0.81495791  1
+  C  C2  1  0.16849937  0.29982675  0.34635739  1
+  C  C3  1  0.62645199  0.21651555  0.39821136  1
+  C  C4  1  0.26375732  0.48611810  0.21552769  1
+  C  C5  1  0.95997537  0.88234391  0.45887662  1
+  C  C6  1  0.53680157  1.03577868  0.53525165  1
+  C  C7  1  0.84055467  0.63960172  0.29457764  1
+",-154.11311125
+870,C-193954-5904-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42655000
+_cell_length_b   4.22509000
+_cell_length_c   6.37404000
+_cell_angle_alpha   130.15959000
+_cell_angle_beta   112.40906000
+_cell_angle_gamma   89.95807000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.30400938
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71553481  0.40347635  0.14092746  1
+  C  C1  1  1.05909902  0.27158388  0.98435757  1
+  C  C2  1  1.06484888  0.69197233  0.48984029  1
+  C  C3  1  0.71061616  -0.01645190  0.63553253  1
+  C  C4  1  0.12610126  0.40399744  0.55059974  1
+  C  C5  1  0.65029558  0.27199610  0.57514241  1
+",-154.31404866666665
+6676,C-126179-5885-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47485000
+_cell_length_b   3.72222000
+_cell_length_c   4.24929000
+_cell_angle_alpha   64.00573000
+_cell_angle_beta   90.00139000
+_cell_angle_gamma   89.99852000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.18427921
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63355430  0.36308270  0.35851577  1
+  C  C1  1  0.13366292  0.15956117  0.58149831  1
+  C  C2  1  0.13343587  0.75138511  0.58155101  1
+  C  C3  1  0.63353203  0.20563579  0.08082142  1
+  C  C4  1  0.13350288  0.31632751  0.85946330  1
+  C  C5  1  0.63341279  0.77110032  0.35870569  1
+",-154.292392
+1218,C-56483-6668-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48334000
+_cell_length_b   3.82329000
+_cell_length_c   5.22419000
+_cell_angle_alpha   81.21889000
+_cell_angle_beta   90.10845000
+_cell_angle_gamma   108.98310000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.29328256
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.21810631  -0.08324082  0.38575031  1
+  C  C1  1  -0.05909085  0.36371721  0.88493507  1
+  C  C2  1  0.60758700  0.69411954  0.49233263  1
+  C  C3  1  0.97788579  0.43783961  0.16458959  1
+  C  C4  1  0.43291282  0.34444432  0.32970153  1
+  C  C5  1  0.17998230  0.84146721  0.10607321  1
+  C  C6  1  0.72509970  0.93517341  0.94123991  1
+  C  C7  1  0.55100253  0.58572821  0.77892035  1
+",-154.22188375
+6033,C-79916-1840-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.18515000
+_cell_length_b   4.29716000
+_cell_length_c   8.10091000
+_cell_angle_alpha   72.34382000
+_cell_angle_beta   77.33170000
+_cell_angle_gamma   60.70799000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C20
+_cell_volume   120.63380373
+_cell_formula_units_Z   20
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.07769211  0.88245352  0.65252629  1
+  C  C1  1  0.39073142  -0.02972935  0.12124483  1
+  C  C2  1  0.09627131  0.24352515  0.55586150  1
+  C  C3  1  0.26710540  1.06486223  -0.07244726  1
+  C  C4  1  0.88730869  1.08021735  0.93418822  1
+  C  C5  1  0.44397868  0.53169218  0.64806305  1
+  C  C6  1  0.38599595  0.62671068  0.22100569  1
+  C  C7  1  0.58458223  0.80765679  0.82275591  1
+  C  C8  1  0.56105814  0.44620577  0.85075491  1
+  C  C9  1  0.61076771  0.38283657  0.36891898  1
+  C  C10  1  0.44792319  0.26488060  0.54762953  1
+  C  C11  1  0.72165386  0.89510845  0.62521073  1
+  C  C12  1  0.07766412  0.34401845  0.12903248  1
+  C  C13  1  0.03626530  0.61304089  0.22379647  1
+  C  C14  1  0.93658706  0.80203417  0.84654870  1
+  C  C15  1  0.19935532  0.44330630  0.93381601  1
+  C  C16  1  0.75492715  0.60307476  0.55910856  1
+  C  C17  1  0.87792668  0.48745541  0.39647145  1
+  C  C18  1  0.72883627  0.28670603  0.19182005  1
+  C  C19  1  0.75007862  -0.01398077  0.12442588  1
+",-154.1015495
+826,C-13915-4927-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49111000
+_cell_length_b   3.59442000
+_cell_length_c   4.35239000
+_cell_angle_alpha   84.28743000
+_cell_angle_beta   73.37362000
+_cell_angle_gamma   69.64640000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.01083733
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.16757827  0.36773305  0.33165430  1
+  C  C1  1  0.45638859  0.99756710  0.12598188  1
+  C  C2  1  0.27368930  0.73878452  0.74969347  1
+  C  C3  1  0.56056620  0.36804707  0.54423512  1
+  C  C4  1  0.08641384  0.73848442  0.12585300  1
+  C  C5  1  0.64275511  -0.00195536  0.75006184  1
+",-154.19470716666666
+8389,C-41318-6901-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.84044000
+_cell_length_b   3.62694000
+_cell_length_c   4.81781000
+_cell_angle_alpha   112.11774000
+_cell_angle_beta   91.88233000
+_cell_angle_gamma   92.87464000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   45.85146569
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.30034026  0.14800539  0.74962313  1
+  C  C1  1  0.30031460  0.58825386  0.24886150  1
+  C  C2  1  0.29998366  -0.00675199  0.43991822  1
+  C  C3  1  0.29989607  0.20660077  0.24882812  1
+  C  C4  1  0.30031289  0.93423059  0.94040673  1
+  C  C5  1  0.30007872  0.55294728  0.94054341  1
+",-154.16065833333332
+8772,C-9592-5537-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.27269000
+_cell_length_b   3.26992000
+_cell_length_c   6.86332000
+_cell_angle_alpha   90.00270000
+_cell_angle_beta   89.99786000
+_cell_angle_gamma   99.24174000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   72.49398781
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55438382  0.48096129  0.78732177  1
+  C  C1  1  0.91558167  0.84303642  0.78721451  1
+  C  C2  1  0.55446710  0.48069020  0.40540127  1
+  C  C3  1  0.06317877  1.01852253  0.59638345  1
+  C  C4  1  0.64829938  0.11143925  0.90550310  1
+  C  C5  1  0.28604393  0.75097162  0.90536306  1
+  C  C6  1  0.28615487  0.75074915  0.28740488  1
+  C  C7  1  0.64836430  0.11116639  0.28722426  1
+  C  C8  1  0.91566712  0.84279720  0.40553646  1
+  C  C9  1  0.82287163  0.26113693  0.09638108  1
+  C  C10  1  0.38158229  0.33502740  0.59636539  1
+  C  C11  1  0.14016781  0.57871863  0.09638126  1
+",-154.20307333333332
+8668,C-193915-3332-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48783000
+_cell_length_b   2.48723000
+_cell_length_c   6.08967000
+_cell_angle_alpha   89.99899000
+_cell_angle_beta   90.00322000
+_cell_angle_gamma   120.03285000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.62249574
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46953882  1.25173708  0.28249783  1
+  C  C1  1  0.80302329  0.91849760  0.19931973  1
+  C  C2  1  -0.19684282  -0.08131337  -0.05082610  1
+  C  C3  1  0.46978136  0.25168350  0.53265898  1
+  C  C4  1  0.13633710  0.58498111  0.61584145  1
+  C  C5  1  0.13663465  0.58539918  0.86600121  1
+",-154.54353166666667
+2478,C-9628-9669-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43161000
+_cell_length_b   4.81560000
+_cell_length_c   6.37598000
+_cell_angle_alpha   138.45779000
+_cell_angle_beta   90.05998000
+_cell_angle_gamma   104.60593000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.76947682
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.28572089  0.22281711  0.43854958  1
+  C  C1  1  1.14503287  0.94442013  -0.08694097  1
+  C  C2  1  0.98630837  0.62828282  0.38551750  1
+  C  C3  1  0.79087932  0.23565530  1.02073368  1
+  C  C4  1  0.08936660  0.82988671  0.07394913  1
+  C  C5  1  0.23014042  0.11431347  0.61159279  1
+  C  C6  1  0.93106624  0.51372951  0.54636067  1
+  C  C7  1  -0.15406901  0.34427335  0.84749581  1
+",-154.225005
+710,C-73657-5503-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.53137000
+_cell_length_b   4.52561000
+_cell_length_c   5.65873000
+_cell_angle_alpha   75.67012000
+_cell_angle_beta   116.62142000
+_cell_angle_gamma   123.71573000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.20610868
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36814133  0.20032271  0.08128605  1
+  C  C1  1  -0.05237124  -0.10097242  0.45944259  1
+  C  C2  1  0.50454185  0.52199516  0.89602503  1
+  C  C3  1  1.03851011  0.19967364  0.25130777  1
+  C  C4  1  0.54670875  0.50035383  0.45982376  1
+  C  C5  1  0.10170113  0.39449623  0.61963103  1
+  C  C6  1  0.71442787  0.00562001  0.61939441  1
+  C  C7  1  0.86333260  0.87920823  0.89571545  1
+",-154.10897625
+6957,C-184050-397-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.92943000
+_cell_length_b   3.62291000
+_cell_length_c   4.81171000
+_cell_angle_alpha   108.91433000
+_cell_angle_beta   107.67233000
+_cell_angle_gamma   94.71523000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   45.09626812
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.32860786  0.64228499  0.33150763  1
+  C  C1  1  0.82725271  0.70098518  0.83169183  1
+  C  C2  1  0.32888621  0.26108633  0.33143869  1
+  C  C3  1  1.13993858  0.85728636  0.14050352  1
+  C  C4  1  0.63578212  0.29724588  0.64105625  1
+  C  C5  1  0.63614221  0.91584466  0.64074718  1
+",-154.12864516666667
+7595,C-141071-4819-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46157000
+_cell_length_b   5.30522000
+_cell_length_c   3.39610000
+_cell_angle_alpha   84.85179000
+_cell_angle_beta   68.85693000
+_cell_angle_gamma   89.99382000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.17299016
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.02267251  0.40632535  0.52726309  1
+  C  C1  1  0.47168900  0.00389235  0.62153343  1
+  C  C2  1  0.05012753  0.68221052  0.46431067  1
+  C  C3  1  0.64599201  0.80814348  0.27078360  1
+  C  C4  1  0.50924503  0.27947709  0.55441798  1
+  C  C5  1  0.87574151  0.87681221  0.81425803  1
+",-154.15955583333331
+8788,C-80184-1378-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.57747000
+_cell_length_b   6.02212000
+_cell_length_c   4.67428000
+_cell_angle_alpha   112.29670000
+_cell_angle_beta   80.52542000
+_cell_angle_gamma   139.70836000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.92811397
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.48167118  -0.00908623  0.38771013  1
+  C  C1  1  0.43557935  0.46771549  0.36036991  1
+  C  C2  1  1.00431869  0.75194531  0.83312048  1
+  C  C3  1  1.01390780  0.75748837  0.52098346  1
+  C  C4  1  0.05971831  0.28141451  0.54863428  1
+  C  C5  1  0.38288715  0.44231245  0.83891180  1
+  C  C6  1  1.11262367  0.30618535  0.06969176  1
+  C  C7  1  0.49128966  -0.00438876  0.07476177  1
+",-154.19926875
+675,C-47629-544-53,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43441000
+_cell_length_b   6.50852000
+_cell_length_c   6.98296000
+_cell_angle_alpha   113.52134000
+_cell_angle_beta   117.59981000
+_cell_angle_gamma   97.37667000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   82.95286596
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.97380978  0.55204463  0.10337342  1
+  C  C1  1  0.33719888  0.26179771  0.20160777  1
+  C  C2  1  0.61452608  0.89514921  1.12897918  1
+  C  C3  1  0.42335135  0.39965586  0.60497847  1
+  C  C4  1  -0.21664222  0.97102420  0.60514223  1
+  C  C5  1  0.69149303  0.36707265  0.82348214  1
+  C  C6  1  1.16031024  0.99961800  0.12875763  1
+  C  C7  1  0.16991769  0.22218307  0.82357418  1
+  C  C8  1  0.09844854  -0.12826293  0.48492062  1
+  C  C9  1  0.72552111  0.31758141  0.10363460  1
+  C  C10  1  0.74767837  0.37909281  0.48501840  1
+  C  C11  1  0.65589796  0.70572529  0.20131306  1
+",-154.0792575
+266,C-176637-1600-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.29166000
+_cell_length_b   3.53729000
+_cell_length_c   5.17482000
+_cell_angle_alpha   94.66230000
+_cell_angle_beta   92.75980000
+_cell_angle_gamma   131.59424000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.00445372
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.66715173  0.39867442  0.21254059  1
+  C  C1  1  0.97254170  0.98377457  0.36174340  1
+  C  C2  1  0.32580230  0.96743251  0.34662057  1
+  C  C3  1  0.51311251  1.01955725  0.60758750  1
+  C  C4  1  0.83274892  -0.03042514  0.63627977  1
+  C  C5  1  1.02031132  0.38236170  0.19735481  1
+  C  C6  1  0.48004056  0.34657952  0.95158472  1
+  C  C7  1  0.16039221  0.39677152  0.92287001  1
+  C  C8  1  0.76988207  0.56216615  0.74353733  1
+  C  C9  1  0.22343419  -0.19575689  0.81572050  1
+",-154.067315
+1606,C-142755-3271-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47975000
+_cell_length_b   5.69487000
+_cell_length_c   5.46463000
+_cell_angle_alpha   111.67658000
+_cell_angle_beta   76.86514000
+_cell_angle_gamma   102.56601000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   69.07175694
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.58287804  0.95207752  0.67892166  1
+  C  C1  1  0.13780460  0.58333345  0.19434712  1
+  C  C2  1  0.72558478  0.72425146  0.16023504  1
+  C  C3  1  0.29741353  0.47759977  0.77383154  1
+  C  C4  1  0.00920882  0.79565202  0.67017104  1
+  C  C5  1  0.40877942  0.40287443  0.47495430  1
+  C  C6  1  0.12790457  0.33176967  -0.03507690  1
+  C  C7  1  0.84069877  0.65047313  0.86153530  1
+  C  C8  1  0.77386766  0.99715402  0.34388650  1
+  C  C9  1  0.99628802  0.54400044  0.44092674  1
+  C  C10  1  0.36688782  0.12970629  0.29153562  1
+  C  C11  1  0.55439947  0.17539359  -0.04466556  1
+",-154.21135666666666
+9621,C-136223-1797-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.84076000
+_cell_length_b   2.93739000
+_cell_length_c   7.73965000
+_cell_angle_alpha   75.00352000
+_cell_angle_beta   76.75372000
+_cell_angle_gamma   72.75217000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   100.12791070
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.02703150  0.36583847  0.18167058  1
+  C  C1  1  0.25762550  0.48965103  0.89611437  1
+  C  C2  1  0.39316965  -0.25559410  0.73362835  1
+  C  C3  1  1.18261245  1.09085973  0.63367572  1
+  C  C4  1  0.98575456  0.42816133  0.35887415  1
+  C  C5  1  0.30934263  0.34923064  0.07727393  1
+  C  C6  1  0.68220821  0.59532317  0.64182892  1
+  C  C7  1  0.55550547  0.23365304  1.16071754  1
+  C  C8  1  0.92317051  0.34227437  0.73066036  1
+  C  C9  1  0.96774585  0.41788335  0.89816484  1
+  C  C10  1  -0.17622244  0.35388682  1.07604452  1
+  C  C11  1  0.72401954  0.68768366  0.44960527  1
+  C  C12  1  0.22727893  0.17799065  0.44592652  1
+  C  C13  1  0.50817863  1.01677273  0.34944972  1
+",-154.1139914285714
+7861,C-96709-3568-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48063000
+_cell_length_b   4.21772000
+_cell_length_c   3.68891000
+_cell_angle_alpha   104.75406000
+_cell_angle_beta   109.62446000
+_cell_angle_gamma   89.93904000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.00359434
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.89586215  0.50941438  0.20667590  1
+  C  C1  1  0.57831557  0.21200188  0.56729497  1
+  C  C2  1  0.35707090  0.00584854  0.12230765  1
+  C  C3  1  1.09758912  0.43419977  0.60498593  1
+  C  C4  1  0.77860676  0.13691367  0.96541954  1
+  C  C5  1  0.31748761  0.64050656  0.04997111  1
+",-154.30933783333333
+6649,C-76008-2415-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48495000
+_cell_length_b   4.67702000
+_cell_length_c   4.78161000
+_cell_angle_alpha   87.76085000
+_cell_angle_beta   58.66546000
+_cell_angle_gamma   74.58109000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.42542295
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.96174806  0.12853899  0.53182302  1
+  C  C1  1  0.30027492  0.81419048  0.35066317  1
+  C  C2  1  1.09104300  0.35550247  0.28947630  1
+  C  C3  1  0.23664521  1.12585621  0.75788703  1
+  C  C4  1  0.34099102  0.78380405  0.82472016  1
+  C  C5  1  0.75392943  0.66994668  0.46944017  1
+  C  C6  1  0.71387844  0.69788356  0.99475208  1
+  C  C7  1  0.81553221  0.35717755  0.06392207  1
+",-154.36383875
+10055,C-41296-52-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.37421000
+_cell_length_b   4.81690000
+_cell_length_c   5.25604000
+_cell_angle_alpha   96.21039000
+_cell_angle_beta   83.98011000
+_cell_angle_gamma   73.56163000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   80.62838682
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.66558919  0.08362339  0.76683998  1
+  C  C1  1  -0.08446413  0.06959099  0.48042959  1
+  C  C2  1  0.71942525  1.02368142  0.22597338  1
+  C  C3  1  1.26275445  0.77008769  0.51182582  1
+  C  C4  1  0.25769346  0.26975078  -0.04189342  1
+  C  C5  1  0.97928031  0.59906925  0.63712021  1
+  C  C6  1  0.36824103  0.30006636  0.22988260  1
+  C  C7  1  0.07394284  0.56573455  0.90954728  1
+  C  C8  1  -0.02191364  0.36203905  0.42774135  1
+  C  C9  1  0.67077162  0.72055347  0.11164502  1
+  C  C10  1  0.57145125  0.53757523  0.30585075  1
+  C  C11  1  0.33259126  0.77003418  0.94107265  1
+  C  C12  1  0.55566067  0.80532683  0.70132856  1
+  C  C13  1  -0.00861206  0.05588800  0.97696824  1
+",-154.17103857142857
+6194,C-102901-5226-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46624000
+_cell_length_b   3.30932000
+_cell_length_c   8.22141000
+_cell_angle_alpha   51.12100000
+_cell_angle_beta   72.94836000
+_cell_angle_gamma   76.21164000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.80608937
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.30677061  0.11209422  0.76073129  1
+  C  C1  1  0.45344683  0.04643353  0.04879731  1
+  C  C2  1  0.01636324  0.24129898  0.91996026  1
+  C  C3  1  0.49029027  0.65272018  0.54769310  1
+  C  C4  1  0.78823898  0.52256755  0.38797951  1
+  C  C5  1  0.91552114  -0.07425324  0.54715950  1
+  C  C6  1  0.88210767  0.83865049  0.76116386  1
+  C  C7  1  0.35297006  0.71620618  0.25907568  1
+",-154.17732875
+1498,C-157693-2980-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43866000
+_cell_length_b   2.55086000
+_cell_length_c   7.31536000
+_cell_angle_alpha   60.50795000
+_cell_angle_beta   88.73863000
+_cell_angle_gamma   88.24888000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.59019536
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.49694507  -0.03054492  0.22834892  1
+  C  C1  1  0.49931602  0.63303363  0.45790363  1
+  C  C2  1  0.00561590  0.48226374  0.89903267  1
+  C  C3  1  0.50809400  0.65073749  0.79111907  1
+  C  C4  1  -0.00058114  0.13732960  0.12052388  1
+  C  C5  1  0.50602924  -0.01293333  0.56154383  1
+",-154.07072483333334
+9327,C-92158-6662-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48549000
+_cell_length_b   4.53499000
+_cell_length_c   5.92515000
+_cell_angle_alpha   109.64396000
+_cell_angle_beta   77.83392000
+_cell_angle_gamma   105.92379000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   59.96564492
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.08540978  0.60048109  0.17155460  1
+  C  C1  1  0.71624767  0.31096181  0.61168171  1
+  C  C2  1  0.55171428  0.20129544  0.83014838  1
+  C  C3  1  0.33705398  0.14111143  0.21051566  1
+  C  C4  1  0.04533575  0.78607895  0.43157410  1
+  C  C5  1  0.52133624  0.38898116  0.08990707  1
+  C  C6  1  0.87912090  0.67720272  0.65090681  1
+  C  C7  1  1.26979871  0.84931770  0.05211224  1
+  C  C8  1  0.38842136  0.84474511  0.79820682  1
+  C  C9  1  0.20872843  0.14362471  0.46392211  1
+",-154.09560100000002
+5290,C-170376-6835-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48143000
+_cell_length_b   3.74187000
+_cell_length_c   4.57731000
+_cell_angle_alpha   90.05337000
+_cell_angle_beta   57.14503000
+_cell_angle_gamma   90.00512000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.70295263
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.60083308  0.93997465  0.40610113  1
+  C  C1  1  0.30417152  0.20692607  0.70169649  1
+  C  C2  1  0.89500954  0.20644010  0.11124561  1
+  C  C3  1  0.39462789  0.44356531  0.11167538  1
+  C  C4  1  0.80381093  0.44427004  0.70212222  1
+  C  C5  1  0.10043865  0.71058172  0.40648027  1
+",-154.15367683333332
+5388,C-141041-1809-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.30338000
+_cell_length_b   3.72804000
+_cell_length_c   3.72824000
+_cell_angle_alpha   70.54282000
+_cell_angle_beta   54.70597000
+_cell_angle_gamma   54.70094000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.84351851
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.26034956  0.20768966  0.51510417  1
+  C  C1  1  0.51024082  0.20784121  1.01514083  1
+  C  C2  1  0.51029395  0.70763769  0.51508970  1
+  C  C3  1  0.26038953  0.45802693  0.76471334  1
+  C  C4  1  0.76014935  0.45818730  0.76476654  1
+  C  C5  1  0.76018918  0.70781301  0.01510293  1
+",-154.08075416666665
+1306,C-28258-8310-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48068000
+_cell_length_b   3.68890000
+_cell_length_c   4.84097000
+_cell_angle_alpha   111.47634000
+_cell_angle_beta   104.83327000
+_cell_angle_gamma   109.66921000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99474736
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.92723542  0.46196278  0.12407420  1
+  C  C1  1  -0.04992918  0.80552841  0.82651272  1
+  C  C2  1  0.22430968  0.27881118  0.90192733  1
+  C  C3  1  0.90941651  0.22248195  0.33021760  1
+  C  C4  1  0.24042665  0.51773722  0.69532128  1
+  C  C5  1  0.20082381  0.93476157  0.19951637  1
+",-154.31009233333333
+8137,C-57124-393-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43744000
+_cell_length_b   4.15987000
+_cell_length_c   9.53105000
+_cell_angle_alpha   114.24101000
+_cell_angle_beta   82.66359000
+_cell_angle_gamma   90.02781000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   87.25274901
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.58143967  1.06408176  0.08095946  1
+  C  C1  1  0.19819767  0.43050768  -0.13479803  1
+  C  C2  1  0.69106218  0.28963265  -0.12047261  1
+  C  C3  1  0.04369045  0.09355596  0.15564090  1
+  C  C4  1  0.96010000  0.15114677  0.32252646  1
+  C  C5  1  0.44561928  0.99198044  0.35231126  1
+  C  C6  1  0.90783171  0.56653528  0.42446355  1
+  C  C7  1  0.28761687  0.65995474  0.66622915  1
+  C  C8  1  -0.17597482  0.62618968  0.59130661  1
+  C  C9  1  0.67095814  -0.02984716  0.91040261  1
+  C  C10  1  0.20751000  0.75331396  0.83647348  1
+  C  C11  1  0.42413373  0.72315873  0.39331275  1
+",-154.27280249999998
+906,C-107766-482-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.87359000
+_cell_length_b   6.03405000
+_cell_length_c   5.27373000
+_cell_angle_alpha   95.56901000
+_cell_angle_beta   114.58747000
+_cell_angle_gamma   127.66251000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.45537117
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63467463  0.17139708  0.60575741  1
+  C  C1  1  1.13438141  0.67142433  0.60571737  1
+  C  C2  1  1.13523031  1.00497641  0.27217814  1
+  C  C3  1  0.63484745  0.67138935  1.10571795  1
+  C  C4  1  0.63533942  0.50495613  0.27219046  1
+  C  C5  1  -0.36452586  0.00497799  0.77217794  1
+  C  C6  1  0.13367233  0.17131810  0.10577384  1
+  C  C7  1  1.13452652  0.50489801  0.77216840  1
+",-154.36442875
+3560,C-172930-9950-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48988000
+_cell_length_b   3.59298000
+_cell_length_c   4.35470000
+_cell_angle_alpha   84.29014000
+_cell_angle_beta   106.59757000
+_cell_angle_gamma   110.33358000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.00788111
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17652395  0.90294230  0.06179416  1
+  C  C1  1  0.25787325  0.27235269  0.85564861  1
+  C  C2  1  0.73304851  0.64217746  0.43728356  1
+  C  C3  1  0.65066913  0.27187924  0.64336226  1
+  C  C4  1  0.36425330  0.90235674  0.43760557  1
+  C  C5  1  0.54567195  0.64279767  1.06145385  1
+",-154.19625716666667
+9095,C-96674-5773-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47265000
+_cell_length_b   4.46986000
+_cell_length_c   4.24974000
+_cell_angle_alpha   111.44356000
+_cell_angle_beta   89.95826000
+_cell_angle_gamma   123.63521000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.14377479
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64818437  0.33033642  0.17073659  1
+  C  C1  1  0.53742945  0.71848443  0.94766715  1
+  C  C2  1  0.08359663  0.76523564  0.44853941  1
+  C  C3  1  0.69422368  0.87557802  0.67005786  1
+  C  C4  1  0.24049736  0.92218102  0.17087455  1
+  C  C5  1  0.12868781  0.31034417  0.94779374  1
+",-154.2948266666667
+5280,C-53797-7447-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48232000
+_cell_length_b   6.07322000
+_cell_length_c   5.57127000
+_cell_angle_alpha   42.72068000
+_cell_angle_beta   89.96847000
+_cell_angle_gamma   89.95070000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.98133101
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.42183800  0.32594566  0.56997055  1
+  C  C1  1  0.42139687  0.78949787  0.51354056  1
+  C  C2  1  0.92159790  0.52220368  0.03293654  1
+  C  C3  1  0.92181136  0.47173654  0.34275940  1
+  C  C4  1  -0.07834470  0.30132381  0.98741280  1
+  C  C5  1  0.42170720  0.42171328  0.75715855  1
+  C  C6  1  0.42151963  -0.04011914  0.86888014  1
+  C  C7  1  0.92148506  0.83945169  0.09911130  1
+  C  C8  1  0.92136755  0.93524748  0.28627523  1
+  C  C9  1  0.42146443  0.73901912  -0.17662399  1
+",-154.40229
+5061,C-9646-232-61,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44662000
+_cell_length_b   5.69614000
+_cell_length_c   7.47185000
+_cell_angle_alpha   74.33883000
+_cell_angle_beta   80.57922000
+_cell_angle_gamma   89.95807000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   98.80820993
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.85353811  0.78174745  0.55059448  1
+  C  C1  1  0.59087968  0.38351616  0.07799999  1
+  C  C2  1  0.55287708  0.81679095  0.14490084  1
+  C  C3  1  0.04207525  -0.02936749  0.16947639  1
+  C  C4  1  0.89942458  0.58400910  0.45218456  1
+  C  C5  1  0.20972595  0.24006799  0.84362602  1
+  C  C6  1  0.94375237  0.98694545  0.37347502  1
+  C  C7  1  0.85575644  0.31985039  0.55215824  1
+  C  C8  1  0.75544394  0.24466924  0.75279895  1
+  C  C9  1  0.11060672  0.24447520  1.03985355  1
+  C  C10  1  0.48799461  0.36429481  0.28183883  1
+  C  C11  1  0.29411383  0.77183862  0.66764740  1
+  C  C12  1  0.93910731  0.23191416  0.38390313  1
+  C  C13  1  0.19860407  0.73211083  0.85564295  1
+  C  C14  1  0.46328941  0.60718202  0.32525815  1
+  C  C15  1  0.63874964  0.68130391  0.97344520  1
+",-154.110164375
+1706,C-113076-4059-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43152000
+_cell_length_b   4.64617000
+_cell_length_c   5.81747000
+_cell_angle_alpha   66.81804000
+_cell_angle_beta   78.82142000
+_cell_angle_gamma   73.37287000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.64225727
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.34528383  0.10278543  0.82303737  1
+  C  C1  1  0.09529696  0.85200735  0.57370542  1
+  C  C2  1  0.59535086  0.35199727  0.07371761  1
+  C  C3  1  0.51252429  0.93504968  0.65762671  1
+  C  C4  1  0.76282264  0.18408380  0.90845727  1
+  C  C5  1  0.84511983  0.60298841  0.32287444  1
+  C  C6  1  0.26265474  0.68426676  0.40831336  1
+  C  C7  1  1.01258036  0.43515500  0.15754103  1
+",-154.45770375
+5905,C-73639-7493-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.39868000
+_cell_length_b   3.31424000
+_cell_length_c   9.65823000
+_cell_angle_alpha   114.70504000
+_cell_angle_beta   105.58845000
+_cell_angle_gamma   90.92919000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   94.16532149
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.81863508  0.76422072  0.81282765  1
+  C  C1  1  0.48336214  0.40910914  0.81004972  1
+  C  C2  1  0.44763186  0.26127401  0.53484247  1
+  C  C3  1  0.26377056  0.79570940  0.90028417  1
+  C  C4  1  0.19499505  0.56209142  0.33074998  1
+  C  C5  1  0.93219227  0.75291490  0.54457051  1
+  C  C6  1  0.27479446  -0.17434121  0.06839603  1
+  C  C7  1  0.60894257  0.86777111  0.42370384  1
+  C  C8  1  0.85889220  0.90832238  0.32493590  1
+  C  C9  1  0.09316423  0.35947103  0.43301782  1
+  C  C10  1  -0.08275702  0.46772946  0.06275759  1
+  C  C11  1  0.05534697  0.21211276  0.15809977  1
+  C  C12  1  0.34599696  1.05894831  0.63717366  1
+  C  C13  1  0.62273574  0.15442075  0.90573996  1
+  C  C14  1  0.68249313  0.71282196  0.64327956  1
+  C  C15  1  0.72030520  0.85763778  0.15551986  1
+",-154.1924
+7075,C-72750-6436-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46124000
+_cell_length_b   3.35616000
+_cell_length_c   4.48581000
+_cell_angle_alpha   111.95913000
+_cell_angle_beta   84.62900000
+_cell_angle_gamma   104.48176000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   33.27405365
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.82577549  0.36326899  0.83910285  1
+  C  C1  1  0.61826761  0.88328896  0.60528416  1
+  C  C2  1  0.03691603  0.60985871  0.60529835  1
+  C  C3  1  0.11836804  0.22246241  0.28273343  1
+  C  C4  1  0.32600402  0.46907766  0.04976552  1
+  C  C5  1  0.53695801  0.94919407  0.28267250  1
+",-154.20188266666665
+9425,C-107740-6840-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.40424000
+_cell_length_b   3.35182000
+_cell_length_c   4.58242000
+_cell_angle_alpha   68.51842000
+_cell_angle_beta   90.80207000
+_cell_angle_gamma   92.09024000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.62274292
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.31859345  0.45781614  0.45118718  1
+  C  C1  1  0.66459792  0.53456322  0.63296926  1
+  C  C2  1  0.49821956  0.76000055  0.84689143  1
+  C  C3  1  0.02199340  0.13540104  1.13175851  1
+  C  C4  1  0.83139723  0.09461721  0.84682368  1
+  C  C5  1  1.01066137  0.79405677  0.45117889  1
+  C  C6  1  0.30875457  0.43433951  0.13214779  1
+  C  C7  1  0.16462180  0.02318047  0.65627576  1
+",-154.19697
+9151,C-177268-8621-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43366000
+_cell_length_b   4.22529000
+_cell_length_c   6.43660000
+_cell_angle_alpha   131.57593000
+_cell_angle_beta   112.19783000
+_cell_angle_gamma   73.32350000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.78050367
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.03218479  0.09515869  0.26533840  1
+  C  C1  1  0.17516037  0.30457775  1.01252751  1
+  C  C2  1  0.73301997  0.60809172  0.72469023  1
+  C  C3  1  0.93261498  0.27174671  0.75323949  1
+  C  C4  1  0.78895084  1.06226806  1.00599019  1
+  C  C5  1  0.22769891  0.75884722  0.29362063  1
+  C  C6  1  0.08862786  0.53166600  0.54095947  1
+  C  C7  1  0.87327369  0.83533344  0.47753277  1
+",-154.2284925
+5073,C-152569-5742-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.44676000
+_cell_length_b   3.39638000
+_cell_length_c   6.40687000
+_cell_angle_alpha   66.99661000
+_cell_angle_beta   66.26428000
+_cell_angle_gamma   92.18151000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   61.47613532
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.58447649  0.07533747  0.60110099  1
+  C  C1  1  0.74988017  0.74684695  -0.06005752  1
+  C  C2  1  0.41512645  0.38136112  -0.05142398  1
+  C  C3  1  0.69430128  0.19580050  0.77754977  1
+  C  C4  1  0.25867642  0.01176732  0.20354472  1
+  C  C5  1  0.52983635  0.72589660  0.19636868  1
+  C  C6  1  0.37292692  0.35562064  0.45139254  1
+  C  C7  1  1.03806993  0.98996531  0.45995843  1
+  C  C8  1  0.20332523  0.66139668  0.79884182  1
+  C  C9  1  0.09359806  0.54074421  0.62234885  1
+",-154.118294
+5958,C-141018-4458-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.49051000
+_cell_length_b   3.38153000
+_cell_length_c   6.87962000
+_cell_angle_alpha   119.44249000
+_cell_angle_beta   120.48690000
+_cell_angle_gamma   90.00070000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.47456792
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.29861913  0.12044161  0.23339318  1
+  C  C1  1  -0.04648456  0.61413711  0.05099818  1
+  C  C2  1  0.74577376  1.04232829  0.40535633  1
+  C  C3  1  0.19495344  0.54216725  0.40530505  1
+  C  C4  1  0.98730190  0.82286138  0.75962143  1
+  C  C5  1  0.16952444  0.49156074  0.60465623  1
+  C  C6  1  0.27900750  0.26171109  0.05086028  1
+  C  C7  1  0.64206811  -0.03562669  0.57738545  1
+  C  C8  1  0.66163910  0.47040085  0.75975524  1
+  C  C9  1  0.77128760  0.59309769  0.20608703  1
+",-154.319786
+9452,C-92111-7590-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43743000
+_cell_length_b   4.23221000
+_cell_length_c   6.53361000
+_cell_angle_alpha   84.37114000
+_cell_angle_beta   100.78314000
+_cell_angle_gamma   89.98332000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   65.87752580
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.00577263  0.53267797  -0.00198363  1
+  C  C1  1  0.45843706  0.39277513  0.90340761  1
+  C  C2  1  0.46380276  0.03950984  0.92088069  1
+  C  C3  1  0.34649088  0.48377909  0.67306248  1
+  C  C4  1  1.15978418  0.12799552  0.30762702  1
+  C  C5  1  0.67784114  0.61469889  0.33931494  1
+  C  C6  1  -0.03072090  0.88041091  0.93346556  1
+  C  C7  1  0.66708246  0.96860328  0.32300965  1
+  C  C8  1  1.12908272  0.47576281  0.24365442  1
+  C  C9  1  0.79517486  0.52076717  0.57018665  1
+",-154.277097
+2240,C-141068-2442-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48111000
+_cell_length_b   3.68913000
+_cell_length_c   4.84025000
+_cell_angle_alpha   122.62730000
+_cell_angle_beta   75.18486000
+_cell_angle_gamma   109.67302000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98017050
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.86105982  0.97022135  0.74407841  1
+  C  C1  1  0.43940795  0.25782841  0.87509757  1
+  C  C2  1  0.97919047  0.84091842  0.37104982  1
+  C  C3  1  0.66011499  0.49675956  0.66897834  1
+  C  C4  1  1.18014693  0.31411439  0.44667075  1
+  C  C5  1  0.40076395  0.55314266  0.24011731  1
+",-154.307958
+6803,C-176665-1085-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.84516000
+_cell_length_b   3.49584000
+_cell_length_c   3.98659000
+_cell_angle_alpha   122.38937000
+_cell_angle_beta   104.03890000
+_cell_angle_gamma   82.04563000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.89724373
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.77269259  0.72867391  0.78856650  1
+  C  C1  1  0.96540861  0.32399182  0.57441592  1
+  C  C2  1  0.46395994  0.38087035  0.13552855  1
+  C  C3  1  0.46478214  0.76221944  0.51758535  1
+  C  C4  1  0.77291689  0.10921802  0.17093564  1
+  C  C5  1  0.27201332  1.16671895  0.73165484  1
+",-154.1099955
+7544,C-90831-4076-60,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.44204000
+_cell_length_b   4.92081000
+_cell_length_c   4.87803000
+_cell_angle_alpha   120.73210000
+_cell_angle_beta   70.08375000
+_cell_angle_gamma   68.88260000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   50.09239925
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.41274619  0.86093540  0.84959650  1
+  C  C1  1  0.42943699  1.02319176  0.17099566  1
+  C  C2  1  0.41138839  0.53115362  0.68007480  1
+  C  C3  1  1.26354896  0.09084915  0.74291566  1
+  C  C4  1  0.57975821  0.43264765  0.08472606  1
+  C  C5  1  0.43090434  0.35291298  0.34049260  1
+  C  C6  1  0.57839842  0.79320809  0.27774712  1
+  C  C7  1  0.26224329  0.45135556  0.93591271  1
+",-154.1154625
+4598,C-72710-1910-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48684000
+_cell_length_b   3.95547000
+_cell_length_c   6.25372000
+_cell_angle_alpha   113.17599000
+_cell_angle_beta   89.96722000
+_cell_angle_gamma   90.00825000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.55118638
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.49925503  0.48030335  0.69048885  1
+  C  C1  1  0.49962677  0.34356816  0.89141992  1
+  C  C2  1  0.99888729  0.85781425  0.49620021  1
+  C  C3  1  0.49931557  0.63447473  0.13738567  1
+  C  C4  1  0.49913206  0.03310707  0.22818359  1
+  C  C5  1  -0.00090663  0.56625273  0.25116657  1
+  C  C6  1  -0.00038017  0.11069107  -0.10233264  1
+  C  C7  1  0.99931605  0.16716949  0.15921731  1
+  C  C8  1  0.49890310  0.09056430  0.48980086  1
+  C  C9  1  -0.00068877  0.72054426  0.69678506  1
+",-154.326981
+6520,C-90796-891-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47792000
+_cell_length_b   3.86346000
+_cell_length_c   8.66259000
+_cell_angle_alpha   102.83482000
+_cell_angle_beta   106.64251000
+_cell_angle_gamma   89.99295000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   77.29163212
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.33779439  1.01810603  1.06928685  1
+  C  C1  1  0.33788035  0.61603999  0.06948737  1
+  C  C2  1  0.23120198  0.51757464  0.46616780  1
+  C  C3  1  0.73958135  0.07675226  0.97188896  1
+  C  C4  1  0.56141276  0.48809974  0.79571229  1
+  C  C5  1  0.56135629  0.87127473  0.79590773  1
+  C  C6  1  0.47077481  0.38238387  0.20455289  1
+  C  C7  1  0.73976040  0.45991734  0.97209859  1
+  C  C8  1  -0.17058124  0.56612644  0.56394349  1
+  C  C9  1  0.96466111  0.93023608  0.69906648  1
+  C  C10  1  -0.03531276  0.33214449  0.69885771  1
+  C  C11  1  0.06790175  0.43101421  0.30205643  1
+",-154.2462525
+7071,C-142753-3906-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45620000
+_cell_length_b   3.66048000
+_cell_length_c   6.42553000
+_cell_angle_alpha   76.20832000
+_cell_angle_beta   79.03674000
+_cell_angle_gamma   70.55660000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.51702532
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.49917004  0.80035929  0.72594396  1
+  C  C1  1  0.48089546  0.59415219  0.96879762  1
+  C  C2  1  0.85490263  0.76183824  0.05590760  1
+  C  C3  1  0.27404987  1.20521997  0.77337513  1
+  C  C4  1  0.21724244  0.68806942  0.40032124  1
+  C  C5  1  1.12561340  0.63380009  0.63797891  1
+  C  C6  1  0.75943329  0.71198092  0.29335494  1
+  C  C7  1  0.70887557  0.18976569  0.91998580  1
+",-154.27611625
+26,C-172941-6659-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43061000
+_cell_length_b   3.92984000
+_cell_length_c   7.56479000
+_cell_angle_alpha   93.42646000
+_cell_angle_beta   81.42388000
+_cell_angle_gamma   89.55449000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   71.31231111
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.67557466  0.18115087  0.29803325  1
+  C  C1  1  0.47548938  0.98086265  0.69809997  1
+  C  C2  1  0.74449006  0.91709911  0.16361295  1
+  C  C3  1  0.27893400  0.78111206  0.09788418  1
+  C  C4  1  1.07347935  0.58100410  0.49817749  1
+  C  C5  1  0.94348973  0.11698530  0.76354832  1
+  C  C6  1  0.87865803  0.38091884  0.89794529  1
+  C  C7  1  0.54056054  0.71697627  0.56372549  1
+  C  C8  1  0.14092916  0.31704255  0.36379086  1
+  C  C9  1  0.34597621  0.51709944  0.96347110  1
+",-154.454464
+8782,C-145335-4867-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42632000
+_cell_length_b   4.15210000
+_cell_length_c   6.26280000
+_cell_angle_alpha   110.25575000
+_cell_angle_beta   78.91693000
+_cell_angle_gamma   89.92199000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.92934508
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71756897  0.22150509  0.40543928  1
+  C  C1  1  0.74146637  0.84771245  0.36088998  1
+  C  C2  1  0.20340118  0.39203632  0.43668038  1
+  C  C3  1  0.41622922  0.46476814  0.01607545  1
+  C  C4  1  0.86753637  0.60942862  0.11490205  1
+  C  C5  1  0.51271473  0.15111540  0.82279992  1
+  C  C6  1  0.18392359  0.76535199  0.47889790  1
+  C  C7  1  0.06041268  0.00649279  0.72425654  1
+",-154.22957125
+401,C-172937-7452-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44182000
+_cell_length_b   4.53890000
+_cell_length_c   5.41696000
+_cell_angle_alpha   76.91153000
+_cell_angle_beta   89.99743000
+_cell_angle_gamma   89.96848000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.47744537
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.10030479  0.56510028  0.51132260  1
+  C  C1  1  0.09999220  0.93446947  0.76402558  1
+  C  C2  1  0.10030022  0.44289166  0.79185407  1
+  C  C3  1  0.60032357  0.47109311  0.37519019  1
+  C  C4  1  0.59983097  0.10596204  0.36088931  1
+  C  C5  1  0.59913333  0.03458240  1.10083794  1
+  C  C6  1  0.10019113  0.65350619  0.94921298  1
+  C  C7  1  0.10014843  -0.06242013  0.49653714  1
+  C  C8  1  1.09912334  0.13964433  0.92908535  1
+  C  C9  1  0.59980971  0.67890224  0.11364664  1
+",-154.078666
+1327,C-107727-1562-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.38268000
+_cell_length_b   4.62726000
+_cell_length_c   6.07837000
+_cell_angle_alpha   120.23998000
+_cell_angle_beta   116.54506000
+_cell_angle_gamma   94.03853000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   88.02940302
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.41120898  0.92384277  0.65820821  1
+  C  C1  1  0.15189514  0.39680600  0.76701283  1
+  C  C2  1  0.29623388  0.56277383  0.42133233  1
+  C  C3  1  0.86121329  0.51953060  0.68380210  1
+  C  C4  1  0.50847901  0.34889030  0.42144030  1
+  C  C5  1  0.93432411  0.44762964  0.18306322  1
+  C  C6  1  -0.02378657  0.88058438  0.92079520  1
+  C  C7  1  0.76385264  0.09430395  0.92077399  1
+  C  C8  1  0.45969335  0.70485789  0.07560255  1
+  C  C9  1  0.12013781  1.04616283  0.57499784  1
+  C  C10  1  0.33820469  -0.00430419  0.15876728  1
+  C  C11  1  0.81240366  0.73789681  0.26647754  1
+",-154.28033833333333
+4779,C-176646-2657-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42640000
+_cell_length_b   4.22614000
+_cell_length_c   4.22508000
+_cell_angle_alpha   88.27541000
+_cell_angle_beta   90.00677000
+_cell_angle_gamma   89.99465000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.30563831
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64928893  0.30509153  0.23137977  1
+  C  C1  1  0.15045540  0.87063923  0.79766594  1
+  C  C2  1  1.14990995  0.21974934  0.73677267  1
+  C  C3  1  0.65043189  0.71420468  0.82149639  1
+  C  C4  1  0.64996480  0.36507922  0.88253088  1
+  C  C5  1  0.14935004  0.27959610  0.38807884  1
+",-154.3125705
+8962,C-172939-8068-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45229000
+_cell_length_b   4.53381000
+_cell_length_c   6.08845000
+_cell_angle_alpha   129.97113000
+_cell_angle_beta   101.64352000
+_cell_angle_gamma   105.55720000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.08533656
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.15441152  0.32835947  0.64329394  1
+  C  C1  1  1.06478818  0.65631690  0.13707692  1
+  C  C2  1  0.72462916  0.78748337  0.32565287  1
+  C  C3  1  0.69599957  0.59696917  0.45423898  1
+  C  C4  1  0.81324099  0.45856817  0.83161684  1
+  C  C5  1  0.18978139  0.52127933  0.51674986  1
+",-154.24976166666667
+346,C-106837-6296-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43739000
+_cell_length_b   3.48480000
+_cell_length_c   9.79696000
+_cell_angle_alpha   95.07365000
+_cell_angle_beta   82.78123000
+_cell_angle_gamma   69.53668000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   76.55619377
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53392285  0.12167261  0.24055354  1
+  C  C1  1  0.15704783  0.48981656  0.61962438  1
+  C  C2  1  0.25893100  -0.02095557  0.94276487  1
+  C  C3  1  0.78853738  0.71344151  0.14476709  1
+  C  C4  1  0.50541563  0.58161520  0.84151870  1
+  C  C5  1  0.35492642  0.67317535  1.05514565  1
+  C  C6  1  0.60730045  0.51935560  0.69066828  1
+  C  C7  1  0.89711845  0.39037945  0.24330326  1
+  C  C8  1  0.50802918  0.02718066  0.38523256  1
+  C  C9  1  0.70914726  0.60684474  0.40092591  1
+  C  C10  1  0.26362879  0.43353455  0.46710431  1
+  C  C11  1  -0.38694825  0.26981294  0.94286475  1
+",-154.10597083333332
+2094,C-57144-6540-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.39085000
+_cell_length_b   3.39516000
+_cell_length_c   6.65775000
+_cell_angle_alpha   104.82099000
+_cell_angle_beta   75.24649000
+_cell_angle_gamma   90.00821000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   71.48076836
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.60846851  0.99228206  0.43096623  1
+  C  C1  1  0.69908270  0.72906551  0.56588677  1
+  C  C2  1  0.19854851  0.22930817  0.56622800  1
+  C  C3  1  0.35032212  0.75202475  0.93077144  1
+  C  C4  1  0.30072200  0.63843807  0.70012662  1
+  C  C5  1  0.68636643  1.06774048  0.93114467  1
+  C  C6  1  0.95079132  -0.02344106  0.06591596  1
+  C  C7  1  -0.07659275  0.32899695  0.43128010  1
+  C  C8  1  0.96439792  -0.04599922  0.70035342  1
+  C  C9  1  0.72533084  0.71181831  0.19986288  1
+  C  C10  1  0.03998068  0.37566665  0.20022002  1
+  C  C11  1  0.45057722  0.47648571  0.06534237  1
+",-154.33328583333335
+7731,C-172951-5413-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42642000
+_cell_length_b   6.05123000
+_cell_length_c   8.10779000
+_cell_angle_alpha   111.99176000
+_cell_angle_beta   72.87162000
+_cell_angle_gamma   113.00669000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   100.06077678
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.82316860  0.45625243  -0.03150060  1
+  C  C1  1  0.61759068  0.80659423  0.53062855  1
+  C  C2  1  0.60754792  0.30327722  0.53391160  1
+  C  C3  1  0.69307214  0.69435987  0.34038500  1
+  C  C4  1  1.10087021  0.87912312  0.61954612  1
+  C  C5  1  0.31695458  0.04213155  0.06058262  1
+  C  C6  1  0.79016576  0.24989582  0.79647299  1
+  C  C7  1  0.12788942  0.08267382  0.79347140  1
+  C  C8  1  0.30991661  0.53200642  0.05712090  1
+  C  C9  1  0.22586952  0.14140426  0.25153348  1
+  C  C10  1  0.70342903  0.20939102  0.34260011  1
+  C  C11  1  0.03192343  0.31868976  0.62565023  1
+  C  C12  1  -0.11267767  1.01967647  -0.03257038  1
+  C  C13  1  0.23956685  0.64749273  0.24651026  1
+",-154.24643714285713
+2627,C-193954-5904-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45151000
+_cell_length_b   3.41816000
+_cell_length_c   5.69896000
+_cell_angle_alpha   103.79361000
+_cell_angle_beta   102.09155000
+_cell_angle_gamma   111.46286000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.76982907
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.17133990  0.32132988  1.06024716  1
+  C  C1  1  0.69326894  0.23760246  0.19230304  1
+  C  C2  1  -0.05588649  0.46308974  0.46847586  1
+  C  C3  1  0.34440874  0.73150273  0.00174613  1
+  C  C4  1  0.56797716  0.58827251  0.59347947  1
+  C  C5  1  0.82186044  0.81489717  0.86990754  1
+",-154.09535733333334
+7122,C-90863-258-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44610000
+_cell_length_b   5.99082000
+_cell_length_c   6.29415000
+_cell_angle_alpha   66.25869000
+_cell_angle_beta   101.18510000
+_cell_angle_gamma   78.21381000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   78.62504449
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.05355372  -0.04193704  0.55742380  1
+  C  C1  1  0.63346423  0.58053902  0.55765950  1
+  C  C2  1  0.92546018  0.49325187  0.04861983  1
+  C  C3  1  0.33347333  0.55225953  0.92376576  1
+  C  C4  1  0.21284659  0.05685390  0.18718551  1
+  C  C5  1  0.67481642  1.03583721  0.08946393  1
+  C  C6  1  0.11803851  0.38790090  0.32877450  1
+  C  C7  1  0.13893392  0.65585355  0.64358739  1
+  C  C8  1  0.57937454  1.01201029  0.87692987  1
+  C  C9  1  0.04283183  -0.01134845  0.78054793  1
+  C  C10  1  0.62355405  0.46295438  0.41531020  1
+  C  C11  1  0.30970353  0.08546145  0.41155016  1
+",-154.2201225
+1536,C-141020-5549-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44820000
+_cell_length_b   4.85251000
+_cell_length_c   5.44974000
+_cell_angle_alpha   71.28557000
+_cell_angle_beta   90.07443000
+_cell_angle_gamma   104.59878000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   59.11570977
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.29643554  0.02181694  0.72887792  1
+  C  C1  1  -0.02993307  0.37399220  0.01558311  1
+  C  C2  1  0.71049198  0.84978056  0.39894906  1
+  C  C3  1  0.02766273  0.48016769  0.72960117  1
+  C  C4  1  1.06861837  0.57175816  0.17438150  1
+  C  C5  1  0.55701061  0.54667956  0.34548428  1
+  C  C6  1  0.80438755  0.04351740  0.11871905  1
+  C  C7  1  0.19881361  -0.17646278  0.57032146  1
+  C  C8  1  0.46291205  0.35251577  0.62588653  1
+  C  C9  1  0.24061593  -0.08421859  1.01479293  1
+",-154.179128
+1095,C-106837-6296-51,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.36438000
+_cell_length_b   5.88547000
+_cell_length_c   5.69989000
+_cell_angle_alpha   107.62244000
+_cell_angle_beta   103.54944000
+_cell_angle_gamma   112.19641000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   91.49216061
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76473339  0.62906229  0.30486968  1
+  C  C1  1  0.60357002  1.01678208  0.47963476  1
+  C  C2  1  0.90046760  0.22950045  0.20574580  1
+  C  C3  1  0.75795369  0.50103453  0.02381381  1
+  C  C4  1  0.98262690  0.83636415  0.89064457  1
+  C  C5  1  0.24355658  0.81401886  0.54508846  1
+  C  C6  1  0.31903335  0.48294398  0.82450813  1
+  C  C7  1  -0.01466194  0.18678259  0.74674046  1
+  C  C8  1  0.99360465  0.99837997  0.15623672  1
+  C  C9  1  0.64959701  0.83422309  0.25220537  1
+  C  C10  1  0.18741677  0.67300305  -0.00372933  1
+  C  C11  1  0.51746314  0.18755369  0.34028301  1
+  C  C12  1  0.43901463  0.44181121  0.39728510  1
+  C  C13  1  0.23146020  0.01607411  0.78401731  1
+  C  C14  1  0.48426946  0.63227744  0.65880641  1
+  C  C15  1  0.72876164  0.23055042  0.94542323  1
+",-154.1393425
+278,C-102873-2379-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.26561000
+_cell_length_b   3.42702000
+_cell_length_c   4.54357000
+_cell_angle_alpha   71.36975000
+_cell_angle_beta   89.96700000
+_cell_angle_gamma   89.94916000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.18401493
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.51581915  0.37710696  0.14430036  1
+  C  C1  1  0.38707086  0.87759100  0.64423332  1
+  C  C2  1  0.88718735  0.32222101  0.34122922  1
+  C  C3  1  1.01508707  0.82227736  0.84104202  1
+  C  C4  1  0.23423203  1.01734977  0.30998719  1
+  C  C5  1  0.66602550  0.51717050  0.80993442  1
+  C  C6  1  0.73347585  0.18365991  0.67507324  1
+  C  C7  1  1.16551198  0.68389669  0.17529823  1
+",-154.189915
+9510,C-106863-9358-55,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47578000
+_cell_length_b   4.18323000
+_cell_length_c   5.39340000
+_cell_angle_alpha   112.80345000
+_cell_angle_beta   62.68274000
+_cell_angle_gamma   89.99156000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   44.65616623
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.13417091  0.35740764  0.65005539  1
+  C  C1  1  0.12319286  0.11387584  0.16162383  1
+  C  C2  1  1.12377921  0.48271512  0.16108782  1
+  C  C3  1  0.77885579  0.53516715  0.00629377  1
+  C  C4  1  -0.21073932  0.14966692  0.49491685  1
+  C  C5  1  0.77849125  -0.09359056  1.00663678  1
+  C  C6  1  1.13454617  0.72743332  0.64966276  1
+  C  C7  1  -0.21029376  0.77957887  0.49436410  1
+",-154.40617125
+8394,C-73647-3984-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.14067000
+_cell_length_b   4.14145000
+_cell_length_c   5.31303000
+_cell_angle_alpha   129.94032000
+_cell_angle_beta   129.93583000
+_cell_angle_gamma   71.51267000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.85819284
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76447782  0.59515845  0.69194762  1
+  C  C1  1  0.03339467  0.36468113  0.31360748  1
+  C  C2  1  0.43974023  0.27141267  0.36724600  1
+  C  C3  1  -0.06001308  0.77119451  0.36767679  1
+  C  C4  1  0.17094130  0.50176492  0.74584145  1
+  C  C5  1  0.53358998  0.86476426  1.10847492  1
+  C  C6  1  0.67073843  0.00158018  0.95115904  1
+  C  C7  1  0.26431995  0.09532108  0.69207359  1
+",-154.1819625
+3243,C-113062-5806-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47420000
+_cell_length_b   4.28020000
+_cell_length_c   4.80329000
+_cell_angle_alpha   89.99668000
+_cell_angle_beta   58.97567000
+_cell_angle_gamma   90.00124000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.59055555
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20460256  0.84050155  0.41127542  1
+  C  C1  1  0.07844253  0.34054918  1.03709814  1
+  C  C2  1  0.57822798  0.00705449  0.53716762  1
+  C  C3  1  1.07815625  0.50705105  0.53711247  1
+  C  C4  1  0.70456579  0.34049821  0.41120826  1
+  C  C5  1  0.57821473  0.84055431  0.03717936  1
+  C  C6  1  0.20454025  1.00719046  0.91126965  1
+  C  C7  1  0.70472122  0.50719125  -0.08879203  1
+",-154.518605
+4328,C-136229-8372-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42923000
+_cell_length_b   4.23284000
+_cell_length_c   4.23522000
+_cell_angle_alpha   82.24444000
+_cell_angle_beta   89.96697000
+_cell_angle_gamma   90.05832000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.15044407
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.94085472  0.50533034  0.94855110  1
+  C  C1  1  0.44091621  0.43002936  0.45929961  1
+  C  C2  1  0.44089999  0.36915485  0.81244691  1
+  C  C3  1  0.44109030  0.01605096  0.87455144  1
+  C  C4  1  -0.05910312  0.44327252  0.30209268  1
+  C  C5  1  0.94107470  0.85842867  -0.11107934  1
+",-154.25061683333334
+2529,C-73665-9416-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45152000
+_cell_length_b   4.61387000
+_cell_length_c   6.54022000
+_cell_angle_alpha   91.29315000
+_cell_angle_beta   111.56154000
+_cell_angle_gamma   98.67337000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.76785673
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.80948402  0.21004913  0.92519117  1
+  C  C1  1  0.39565310  1.04283235  1.01258694  1
+  C  C2  1  0.81213530  0.54390865  -0.00657114  1
+  C  C3  1  -0.30539740  0.04961736  0.26405617  1
+  C  C4  1  0.42155566  0.86977943  0.58341684  1
+  C  C5  1  0.98958980  0.58387282  0.23161234  1
+  C  C6  1  -0.06264255  0.70400329  0.65594363  1
+  C  C7  1  1.22955675  0.71128969  0.90735124  1
+  C  C8  1  0.20928537  0.88322028  0.33556601  1
+  C  C9  1  0.63675797  0.16891343  0.68804628  1
+  C  C10  1  0.65385200  0.39632185  0.53978096  1
+  C  C11  1  -0.02594343  0.35670672  0.38106798  1
+",-154.15125416666666
+6747,C-170890-7665-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.48328000
+_cell_length_b   4.61587000
+_cell_length_c   3.44310000
+_cell_angle_alpha   90.01582000
+_cell_angle_beta   85.28117000
+_cell_angle_gamma   111.66840000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   51.24605969
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.57891266  0.93824120  0.75574808  1
+  C  C1  1  0.17784108  0.29287493  0.35604842  1
+  C  C2  1  0.83374123  0.28160603  0.69809836  1
+  C  C3  1  0.97779401  0.45954256  0.07149486  1
+  C  C4  1  0.23398418  0.80360031  1.01143183  1
+  C  C5  1  0.07482752  0.96621477  0.26774458  1
+  C  C6  1  0.63479019  0.44889835  0.41349099  1
+  C  C7  1  0.73837123  0.77627125  0.49832299  1
+",-154.11933625
+5173,C-189692-2339-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.59424000
+_cell_length_b   2.49098000
+_cell_length_c   4.34967000
+_cell_angle_alpha   73.35009000
+_cell_angle_beta   84.29304000
+_cell_angle_gamma   69.69730000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99260089
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.27960964  0.15781540  0.25246665  1
+  C  C1  1  0.53821910  0.71797448  0.87580757  1
+  C  C2  1  -0.09077080  0.63439036  0.67026209  1
+  C  C3  1  0.27921899  0.34840440  -0.12421366  1
+  C  C4  1  0.53824912  0.52949587  0.25211914  1
+  C  C5  1  0.90936634  0.24048989  0.45776241  1
+",-154.19350266666666
+13,C-28246-1719-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42578000
+_cell_length_b   4.21403000
+_cell_length_c   4.86727000
+_cell_angle_alpha   90.00276000
+_cell_angle_beta   119.93978000
+_cell_angle_gamma   89.99537000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.11499302
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70500072  0.44821263  0.51920346  1
+  C  C1  1  0.76254439  0.79638367  0.57806959  1
+  C  C2  1  0.35927919  0.38668762  0.17177037  1
+  C  C3  1  0.70269163  0.36168006  0.01574755  1
+  C  C4  1  0.35403340  0.30026014  0.66789321  1
+  C  C5  1  0.29125177  0.95229508  0.60679222  1
+",-154.30582466666667
+9489,C-136251-4147-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43812000
+_cell_length_b   6.41054000
+_cell_length_c   5.27262000
+_cell_angle_alpha   127.50332000
+_cell_angle_beta   84.29334000
+_cell_angle_gamma   99.45321000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   64.48894796
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.24700000  0.70212624  0.78402470  1
+  C  C1  1  0.78892564  0.37547386  0.27758518  1
+  C  C2  1  0.95734528  0.57192734  0.21002975  1
+  C  C3  1  0.72205051  1.08681403  0.63210435  1
+  C  C4  1  0.51957697  0.67811202  0.20937299  1
+  C  C5  1  0.22175123  0.95896875  0.12166104  1
+  C  C6  1  0.68223794  -0.05725947  0.27806134  1
+  C  C7  1  0.74164966  0.58393431  0.63200446  1
+  C  C8  1  0.24720904  0.20262955  0.12125860  1
+  C  C9  1  0.21766932  0.12071449  0.78392519  1
+",-154.13472
+975,C-56516-5203-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.48749000
+_cell_length_b   4.67962000
+_cell_length_c   3.48648000
+_cell_angle_alpha   103.12094000
+_cell_angle_beta   105.33767000
+_cell_angle_gamma   108.74570000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.83557250
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64144649  0.51000859  0.05623027  1
+  C  C1  1  0.09211421  0.72442547  1.13871090  1
+  C  C2  1  0.62579833  0.17475639  0.06043903  1
+  C  C3  1  -0.19661375  0.00997030  0.71772663  1
+  C  C4  1  0.17499316  0.95978428  0.97716483  1
+  C  C5  1  0.33165253  0.45983039  0.63472175  1
+  C  C6  1  0.93465451  0.22437362  0.48134392  1
+  C  C7  1  0.46401911  0.67480665  0.39904417  1
+",-154.10830125
+8245,C-34613-7933-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52424000
+_cell_length_b   4.44877000
+_cell_length_c   4.36660000
+_cell_angle_alpha   106.09713000
+_cell_angle_beta   85.89129000
+_cell_angle_gamma   99.13701000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.49581384
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.41566603  0.93083221  0.75343104  1
+  C  C1  1  0.18894353  0.58703779  0.73048093  1
+  C  C2  1  0.46935415  0.56670584  0.20559267  1
+  C  C3  1  0.03189408  0.07153863  0.29243211  1
+  C  C4  1  0.24302290  0.40233275  0.44299834  1
+  C  C5  1  0.95309659  0.09200902  0.93322188  1
+  C  C6  1  0.49442119  0.91625114  0.38566834  1
+  C  C7  1  0.98895323  0.45746452  0.99881799  1
+",-154.078365
+7674,C-172947-9910-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.84973000
+_cell_length_b   6.63441000
+_cell_length_c   6.86702000
+_cell_angle_alpha   114.78016000
+_cell_angle_beta   106.24945000
+_cell_angle_gamma   109.98137000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   129.96517341
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.26130610  0.22162503  0.48219165  1
+  C  C1  1  0.03555674  0.70214238  0.18422533  1
+  C  C2  1  0.26090640  0.55489608  0.81529393  1
+  C  C3  1  0.70179117  0.25777306  0.07299233  1
+  C  C4  1  -0.07315727  0.77685788  0.37053249  1
+  C  C5  1  1.59384698  0.99923900  0.92624667  1
+  C  C6  1  0.36939516  0.48015472  0.62901576  1
+  C  C7  1  0.36823828  0.14666399  0.29514712  1
+  C  C8  1  0.59357836  0.33245028  0.25938282  1
+  C  C9  1  0.70174727  0.92439416  0.73961407  1
+  C  C10  1  0.92665676  0.11031232  0.70372096  1
+  C  C11  1  1.03483867  0.03547330  0.51728381  1
+  C  C12  1  0.59414592  0.66602678  0.59308493  1
+  C  C13  1  0.03468534  0.36880461  0.85051629  1
+  C  C14  1  0.36871609  0.81341658  0.96194792  1
+  C  C15  1  -0.07239101  0.44368446  0.03750821  1
+  C  C16  1  0.70149370  0.59095234  0.40618338  1
+  C  C17  1  0.26042914  0.88823971  0.14844405  1
+",-154.45607666666666
+3572,C-80160-4880-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43259000
+_cell_length_b   4.20222000
+_cell_length_c   6.10857000
+_cell_angle_alpha   110.15652000
+_cell_angle_beta   78.36024000
+_cell_angle_gamma   90.06496000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.25462337
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.15922108  0.73881318  0.90864416  1
+  C  C1  1  0.38145819  0.77891210  0.40841892  1
+  C  C2  1  0.65946667  0.57162526  -0.09138612  1
+  C  C3  1  0.65927906  0.23881657  0.90863060  1
+  C  C4  1  0.88146108  0.27892511  0.40845520  1
+  C  C5  1  0.15943073  1.07159249  0.90859557  1
+  C  C6  1  0.88167677  0.61167998  0.40841450  1
+  C  C7  1  0.38164742  0.11173781  0.40845187  1
+",-154.45272375
+10146,C-136231-9145-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.31952000
+_cell_length_b   3.51872000
+_cell_length_c   3.51788000
+_cell_angle_alpha   120.02925000
+_cell_angle_beta   90.00075000
+_cell_angle_gamma   90.01072000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.57488955
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.74054708  0.80075515  0.58107326  1
+  C  C1  1  0.57511980  0.26441752  0.81259985  1
+  C  C2  1  0.07518090  0.80074560  0.27677561  1
+  C  C3  1  0.40763534  0.49601999  0.27653639  1
+  C  C4  1  -0.09235243  0.56917739  0.81303115  1
+  C  C5  1  0.24050541  0.26443077  0.50872424  1
+",-154.41286633333334
+1015,C-130236-8568-66,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.41494000
+_cell_length_b   5.48544000
+_cell_length_c   9.80253000
+_cell_angle_alpha   90.20337000
+_cell_angle_beta   75.67418000
+_cell_angle_gamma   89.91786000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   125.81514323
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.02522315  0.08448291  0.69557573  1
+  C  C1  1  0.13862446  0.13616442  0.07504317  1
+  C  C2  1  1.10915695  0.40545460  0.10880427  1
+  C  C3  1  0.81638504  0.56332226  0.89926993  1
+  C  C4  1  0.05657996  0.90538669  0.15590018  1
+  C  C5  1  0.38223843  0.42925341  0.33515150  1
+  C  C6  1  0.30496750  0.19643503  0.40968637  1
+  C  C7  1  0.52779135  0.50511351  0.18969645  1
+  C  C8  1  -0.39986695  0.08680011  0.62075621  1
+  C  C9  1  1.26286777  0.58167659  0.46149652  1
+  C  C10  1  0.53830183  0.78227313  0.17555526  1
+  C  C11  1  0.69064054  0.61345433  0.53325562  1
+  C  C12  1  0.87225306  0.08075521  0.84497451  1
+  C  C13  1  0.53841337  0.61822257  0.68100610  1
+  C  C14  1  0.96384796  0.60884554  0.75428884  1
+  C  C15  1  0.24960889  0.51865289  0.96629168  1
+  C  C16  1  0.29636525  0.09298299  0.91979285  1
+  C  C17  1  0.74078256  0.12999311  0.47441638  1
+",-154.10083055555555
+5945,C-47660-7998-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42676000
+_cell_length_b   4.81449000
+_cell_length_c   6.51015000
+_cell_angle_alpha   65.09145000
+_cell_angle_beta   79.20954000
+_cell_angle_gamma   59.65099000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   59.50133787
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.01909780  0.83943766  0.24148936  1
+  C  C1  1  0.28764151  0.77122928  0.82917247  1
+  C  C2  1  0.07848666  0.07958097  0.62871993  1
+  C  C3  1  0.36977044  0.46369985  0.28516798  1
+  C  C4  1  0.36084067  1.01129453  0.21297419  1
+  C  C5  1  0.00444190  0.38585937  0.17202416  1
+  C  C6  1  0.48744127  0.22128055  0.52736901  1
+  C  C7  1  0.87901145  0.62987989  0.93001550  1
+",-154.25934625
+7103,C-34609-1384-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50677000
+_cell_length_b   3.94897000
+_cell_length_c   4.77730000
+_cell_angle_alpha   86.87308000
+_cell_angle_beta   81.80767000
+_cell_angle_gamma   79.80305000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.04844794
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63491699  0.89775993  0.38009653  1
+  C  C1  1  0.26843030  0.45297005  0.63460670  1
+  C  C2  1  0.20094967  0.41106261  0.13802031  1
+  C  C3  1  0.18155076  0.65736161  0.37541375  1
+  C  C4  1  0.74494317  0.16961397  0.13344841  1
+  C  C5  1  0.11746673  0.61419728  0.87874788  1
+  C  C6  1  0.92929883  0.98287140  0.84943381  1
+  C  C7  1  0.45426854  1.08288225  0.66343871  1
+",-154.13011875
+9555,C-106889-5288-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.39596000
+_cell_length_b   5.73940000
+_cell_length_c   5.66837000
+_cell_angle_alpha   34.16733000
+_cell_angle_beta   53.96745000
+_cell_angle_gamma   52.98406000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.53208912
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.47119640  0.18819964  0.08474881  1
+  C  C1  1  0.52212224  0.41726865  0.65033269  1
+  C  C2  1  0.84951932  0.07445742  0.67423394  1
+  C  C3  1  -0.00499725  0.67602827  0.57299112  1
+  C  C4  1  0.14186674  0.77764568  0.97128693  1
+  C  C5  1  -0.05217652  0.11562678  0.34715818  1
+  C  C6  1  0.61475630  0.45054712  1.01248410  1
+  C  C7  1  0.83077065  0.75378483  0.31393643  1
+",-154.19996625
+324,C-142789-7601-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.03477000
+_cell_length_b   4.72426000
+_cell_length_c   6.85596000
+_cell_angle_alpha   78.82201000
+_cell_angle_beta   98.70080000
+_cell_angle_gamma   70.08888000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   88.11339787
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.33183220  0.55157873  0.92336580  1
+  C  C1  1  -0.29868100  0.26897492  0.28908977  1
+  C  C2  1  1.01198875  0.45690758  0.59743710  1
+  C  C3  1  -0.09331394  0.25286963  0.49440127  1
+  C  C4  1  0.54057219  0.84908232  0.12825861  1
+  C  C5  1  -0.09466600  0.76592046  0.49405390  1
+  C  C6  1  0.33483144  0.03805737  -0.07621773  1
+  C  C7  1  1.02304206  -0.04806631  0.60710056  1
+  C  C8  1  0.53624419  0.53496312  0.12887094  1
+  C  C9  1  0.22161334  0.85109707  -0.18948771  1
+  C  C10  1  0.69884043  0.95484059  0.28966867  1
+  C  C11  1  1.22942094  0.34691052  0.82020883  1
+",-154.24984
+5853,C-157676-6832-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.12198000
+_cell_length_b   3.96777000
+_cell_length_c   4.84593000
+_cell_angle_alpha   78.89431000
+_cell_angle_beta   66.26432000
+_cell_angle_gamma   84.68575000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   71.18278828
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.88072438  0.55461930  0.04181995  1
+  C  C1  1  0.88189525  0.55535260  0.55943265  1
+  C  C2  1  0.37053740  1.03317037  0.79975738  1
+  C  C3  1  0.12819121  0.79282665  0.52913529  1
+  C  C4  1  0.47936064  0.15053936  1.00263035  1
+  C  C5  1  0.52183537  0.18038530  0.48316970  1
+  C  C6  1  0.12665300  0.79367507  0.82873881  1
+  C  C7  1  0.37247066  0.03381164  0.31674877  1
+  C  C8  1  0.73038519  0.40903750  0.87576879  1
+  C  C9  1  0.77339289  0.43793233  0.35627361  1
+",-154.206675
+6806,C-152607-7999-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43159000
+_cell_length_b   3.99026000
+_cell_length_c   4.63575000
+_cell_angle_alpha   84.01454000
+_cell_angle_beta   74.87145000
+_cell_angle_gamma   89.65943000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.17301475
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.84786346  0.35719362  0.44615088  1
+  C  C1  1  0.95895049  0.13371726  0.22532162  1
+  C  C2  1  0.18047451  0.68768784  0.78130121  1
+  C  C3  1  0.29277976  0.46921430  0.55731275  1
+  C  C4  1  0.51412369  1.02203547  0.11401542  1
+  C  C5  1  0.62562498  0.80034052  0.89210081  1
+",-154.46109533333333
+1700,C-142753-3906-51,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.26833000
+_cell_length_b   4.73604000
+_cell_length_c   4.54281000
+_cell_angle_alpha   103.34448000
+_cell_angle_beta   90.02376000
+_cell_angle_gamma   46.33223000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.21287078
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79090190  0.18546809  0.34593054  1
+  C  C1  1  0.45716171  1.01852349  0.71066785  1
+  C  C2  1  0.72220237  0.68510779  0.84582806  1
+  C  C3  1  0.80303133  0.32440050  0.68010233  1
+  C  C4  1  0.37646635  0.37958779  0.87650812  1
+  C  C5  1  0.74811570  0.87993026  0.37656355  1
+  C  C6  1  0.38859357  0.51867957  0.21072809  1
+  C  C7  1  0.43121917  -0.17554240  0.18007285  1
+",-154.19017375
+8819,C-106839-3195-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.00815000
+_cell_length_b   4.00821000
+_cell_length_c   4.00775000
+_cell_angle_alpha   105.42977000
+_cell_angle_beta   105.38109000
+_cell_angle_gamma   117.99316000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.70930082
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.03732095  0.21189423  0.44157510  1
+  C  C1  1  0.33719824  0.91203804  0.44154704  1
+  C  C2  1  1.16687500  1.04132736  0.14170617  1
+  C  C3  1  0.46665846  0.34137341  0.74149658  1
+  C  C4  1  0.53732243  0.41207610  0.14170797  1
+  C  C5  1  0.66689404  0.84139805  0.44178385  1
+  C  C6  1  0.83727017  0.71201453  0.74150566  1
+  C  C7  1  0.96657712  0.54135578  0.44140604  1
+",-154.20555625
+3048,C-142803-3273-65,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.30069000
+_cell_length_b   4.82280000
+_cell_length_c   3.30319000
+_cell_angle_alpha   77.55573000
+_cell_angle_beta   79.78196000
+_cell_angle_gamma   77.55405000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.66497215
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.18833292  0.61889683  0.06091340  1
+  C  C1  1  0.72090457  0.16027231  0.28565141  1
+  C  C2  1  0.04751115  0.16023041  0.95938106  1
+  C  C3  1  0.50463928  0.44545946  0.37737105  1
+  C  C4  1  0.14188230  0.44530678  0.73976326  1
+  C  C5  1  0.82579558  0.61939255  0.42354410  1
+  C  C6  1  0.60563522  0.90449704  0.51751120  1
+  C  C7  1  0.27929659  0.90439391  0.84407231  1
+",-154.2195125
+7600,C-145350-4405-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.78608000
+_cell_length_b   4.89821000
+_cell_length_c   4.38018000
+_cell_angle_alpha   90.01214000
+_cell_angle_beta   90.01581000
+_cell_angle_gamma   59.63638000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   70.08850242
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.11997139  0.01615721  0.44946507  1
+  C  C1  1  0.50336104  0.40427263  0.26522799  1
+  C  C2  1  0.36845979  0.11111459  0.91137781  1
+  C  C3  1  0.14402136  0.96837192  0.09055605  1
+  C  C4  1  0.83962709  0.37343407  0.46943282  1
+  C  C5  1  1.14433794  0.46842328  0.81154729  1
+  C  C6  1  0.50381361  0.90414019  0.63749535  1
+  C  C7  1  0.69231750  1.07268201  0.13490916  1
+  C  C8  1  0.69281237  0.57258825  0.76804002  1
+  C  C9  1  0.36868673  0.61087606  0.99032672  1
+  C  C10  1  0.83986104  0.87348235  0.43340903  1
+  C  C11  1  0.11917965  0.51640984  0.45169049  1
+",-154.1296575
+4586,C-96692-7228-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48174000
+_cell_length_b   3.84307000
+_cell_length_c   4.48884000
+_cell_angle_alpha   90.09464000
+_cell_angle_beta   123.55895000
+_cell_angle_gamma   90.00230000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.67617877
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.44200882  0.35696928  0.13330561  1
+  C  C1  1  0.44249070  -0.05366272  0.13411176  1
+  C  C2  1  0.70514245  0.35653592  0.89660336  1
+  C  C3  1  0.43829247  0.65111122  0.62973888  1
+  C  C4  1  0.70562156  0.94585436  0.89739888  1
+  C  C5  1  0.70925550  0.65176214  0.40095761  1
+",-154.152554
+9414,C-126153-9712-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48011000
+_cell_length_b   3.68792000
+_cell_length_c   4.89703000
+_cell_angle_alpha   92.97467000
+_cell_angle_beta   59.53059000
+_cell_angle_gamma   70.37509000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.97383357
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.42516013  0.95138631  0.61787506  1
+  C  C1  1  0.87244855  0.79464206  0.74889521  1
+  C  C2  1  0.30128185  0.34890599  0.54247435  1
+  C  C3  1  0.47431426  0.86257414  0.11348815  1
+  C  C4  1  0.04501901  0.30817837  0.32008943  1
+  C  C5  1  0.92220180  0.70518523  0.24398040  1
+",-154.31532516666667
+2915,C-73647-3984-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45437000
+_cell_length_b   5.53132000
+_cell_length_c   9.11113000
+_cell_angle_alpha   56.32135000
+_cell_angle_beta   93.33245000
+_cell_angle_gamma   87.95891000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   102.41415089
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.20974806  0.03001557  0.91247385  1
+  C  C1  1  0.60563025  0.78241607  0.70119918  1
+  C  C2  1  0.51219611  0.21940964  0.30843436  1
+  C  C3  1  0.03136250  0.03793357  0.37314861  1
+  C  C4  1  0.01973606  -0.23514278  0.41401684  1
+  C  C5  1  0.58592897  0.34833904  0.64189871  1
+  C  C6  1  0.76257106  0.87992245  0.01102510  1
+  C  C7  1  0.59821834  0.47458242  0.76033449  1
+  C  C8  1  0.55555097  0.30806558  0.11682406  1
+  C  C9  1  0.88098129  0.67258228  0.18394859  1
+  C  C10  1  0.11664618  0.15694163  0.70824346  1
+  C  C11  1  0.10141938  0.90989058  0.69215529  1
+  C  C12  1  0.52745698  0.59120667  0.44414010  1
+  C  C13  1  0.43777853  0.52534159  0.28998920  1
+  C  C14  1  0.12015676  0.33696231  0.87481047  1
+  C  C15  1  0.06398826  0.32972637  0.03685858  1
+",-154.105741875
+9986,C-76020-2605-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.28136000
+_cell_length_b   3.28679000
+_cell_length_c   5.40837000
+_cell_angle_alpha   95.12701000
+_cell_angle_beta   52.70827000
+_cell_angle_gamma   98.43061000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.90363966
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.25843924  0.28087390  0.85406037  1
+  C  C1  1  0.62614006  0.68893257  0.35377706  1
+  C  C2  1  0.98806732  0.05021067  0.35404779  1
+  C  C3  1  0.71582724  0.41837508  0.53341450  1
+  C  C4  1  0.89620746  0.91828305  0.85409867  1
+  C  C5  1  0.44772517  1.18868007  0.03356515  1
+  C  C6  1  0.80886104  0.54992508  0.03334080  1
+  C  C7  1  0.07791286  0.78094857  0.53347976  1
+",-154.3231775
+7196,C-170374-5689-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46026000
+_cell_length_b   3.40780000
+_cell_length_c   5.32045000
+_cell_angle_alpha   83.61037000
+_cell_angle_beta   89.96427000
+_cell_angle_gamma   68.66551000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.25381788
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.59177415  0.85472355  0.78905000  1
+  C  C1  1  0.19164880  0.65696279  -0.08468671  1
+  C  C2  1  0.41976216  0.19843519  0.98262024  1
+  C  C3  1  1.04568150  -0.05919930  0.38600053  1
+  C  C4  1  0.01842800  1.00220341  0.10992900  1
+  C  C5  1  0.55617419  0.91900465  0.51270653  1
+",-154.15868983333334
+3595,C-130520-8193-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48772000
+_cell_length_b   3.51799000
+_cell_length_c   4.30500000
+_cell_angle_alpha   65.89134000
+_cell_angle_beta   73.19092000
+_cell_angle_gamma   90.00396000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.61805062
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.34073768  0.73430905  0.58659939  1
+  C  C1  1  0.50768486  0.65046615  0.25349524  1
+  C  C2  1  0.84067241  0.98378991  0.58681881  1
+  C  C3  1  0.67415067  1.06764219  0.91992523  1
+  C  C4  1  0.00774732  0.40096440  0.25327830  1
+  C  C5  1  1.17409147  0.31714331  0.92013963  1
+",-154.54613416666666
+3546,C-157683-5975-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48050000
+_cell_length_b   4.24354000
+_cell_length_c   5.62772000
+_cell_angle_alpha   82.22516000
+_cell_angle_beta   102.73068000
+_cell_angle_gamma   90.00704000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.22349703
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.21489589  0.56624907  0.23155863  1
+  C  C1  1  0.67099047  0.75302700  0.14306719  1
+  C  C2  1  0.36731388  0.51362125  0.53441629  1
+  C  C3  1  0.17172388  0.24065748  0.14641113  1
+  C  C4  1  0.85796592  1.01612366  0.51470630  1
+  C  C5  1  0.04052461  0.15032814  0.88277898  1
+  C  C6  1  0.53991673  0.92984471  0.88120101  1
+  C  C7  1  0.40882012  0.83953828  0.61786105  1
+  C  C8  1  0.91026568  0.32671086  0.62113282  1
+  C  C9  1  0.72227352  1.06394725  0.24891220  1
+",-154.365403
+6026,C-130559-5355-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.89824000
+_cell_length_b   4.00363000
+_cell_length_c   5.90578000
+_cell_angle_alpha   54.23356000
+_cell_angle_beta   54.28097000
+_cell_angle_gamma   60.96902000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.05153355
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.24354077  0.82930001  0.54137766  1
+  C  C1  1  0.18155324  0.38630290  1.04177066  1
+  C  C2  1  0.96501580  0.79186860  0.85087047  1
+  C  C3  1  0.58391751  0.17289732  0.85108836  1
+  C  C4  1  0.62443399  0.44833092  0.54095811  1
+  C  C5  1  0.02687929  0.23462465  0.35043264  1
+",-154.11284366666666
+8025,C-136347-2764-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.84845000
+_cell_length_b   4.76886000
+_cell_length_c   8.96025000
+_cell_angle_alpha   78.74265000
+_cell_angle_beta   101.02124000
+_cell_angle_gamma   101.97377000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C24
+_cell_volume   155.81430005
+_cell_formula_units_Z   24
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76651363  -0.13061520  0.83718728  1
+  C  C1  1  0.24622941  0.97652648  0.12728147  1
+  C  C2  1  0.71077434  0.07029460  0.94665260  1
+  C  C3  1  0.92970163  0.28255983  0.19105831  1
+  C  C4  1  -0.01433767  0.14572895  0.07339128  1
+  C  C5  1  0.63378924  0.32820783  0.84075532  1
+  C  C6  1  0.37315471  -0.12681823  0.01111246  1
+  C  C7  1  0.55849702  0.57816750  0.89273245  1
+  C  C8  1  0.59561784  0.72466238  0.54619129  1
+  C  C9  1  0.54219538  0.77397060  0.38585921  1
+  C  C10  1  1.15981534  0.17478245  0.32420215  1
+  C  C11  1  0.71724351  0.49921403  0.18377201  1
+  C  C12  1  0.50067822  0.87335270  0.66244422  1
+  C  C13  1  0.96918910  0.41043368  0.74162815  1
+  C  C14  1  0.37495572  0.16974823  0.60740800  1
+  C  C15  1  1.14546641  -0.09731857  0.84484009  1
+  C  C16  1  -0.26841851  0.44147934  0.59045998  1
+  C  C17  1  1.11752805  0.22321004  0.46605821  1
+  C  C18  1  0.24274101  0.67690875  0.77481287  1
+  C  C19  1  0.50566076  0.59343680  0.04804239  1
+  C  C20  1  0.35632303  0.97810027  0.28441447  1
+  C  C21  1  0.69960342  0.56361709  0.33073629  1
+  C  C22  1  0.25640891  0.20494968  0.75349485  1
+  C  C23  1  0.87551600  0.40594355  0.45973293  1
+",-154.09682875
+6235,C-170348-4384-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48651000
+_cell_length_b   2.48678000
+_cell_length_c   5.55859000
+_cell_angle_alpha   77.06549000
+_cell_angle_beta   102.92689000
+_cell_angle_gamma   90.00634000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.60471387
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87120524  0.74207040  0.94938204  1
+  C  C1  1  0.12142892  0.99229829  0.44973592  1
+  C  C2  1  0.20451749  0.40902021  0.61603989  1
+  C  C3  1  0.78811666  0.32534848  0.78307808  1
+  C  C4  1  0.53784856  0.07560035  0.28270650  1
+  C  C5  1  0.45478560  0.65876833  0.11641146  1
+",-154.54457166666666
+6142,C-170329-7952-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47893000
+_cell_length_b   4.11700000
+_cell_length_c   6.44180000
+_cell_angle_alpha   108.59756000
+_cell_angle_beta   112.58250000
+_cell_angle_gamma   90.01377000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.96453208
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.61699787  0.51821818  0.05529790  1
+  C  C1  1  0.87207640  0.14532554  0.31004152  1
+  C  C2  1  -0.01624983  0.57962781  -0.07792434  1
+  C  C3  1  0.74247650  0.97789438  0.68241448  1
+  C  C4  1  -0.38338867  0.14409455  0.05491412  1
+  C  C5  1  0.50463912  0.71079550  0.44344516  1
+  C  C6  1  0.87222268  0.77234814  0.31023757  1
+  C  C7  1  0.50460407  0.34026863  0.44302906  1
+  C  C8  1  0.74342628  0.31263816  0.68268970  1
+  C  C9  1  0.98348017  -0.05050479  -0.07787148  1
+",-154.340108
+1657,C-113064-8679-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.21833000
+_cell_length_b   2.43295000
+_cell_length_c   8.21756000
+_cell_angle_alpha   82.50456000
+_cell_angle_beta   88.34580000
+_cell_angle_gamma   114.51173000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.79851173
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.41228736  0.77924895  0.39315884  1
+  C  C1  1  0.49804242  0.36458470  0.31005393  1
+  C  C2  1  0.74791405  0.11451655  0.06004352  1
+  C  C3  1  0.91216573  0.27920496  0.89313518  1
+  C  C4  1  0.99765494  0.86439601  0.81000748  1
+  C  C5  1  0.16203735  1.02913680  0.64312477  1
+  C  C6  1  0.24779242  0.61447256  0.56001986  1
+  C  C7  1  0.66242484  0.52932549  0.14317122  1
+",-154.4638625
+8870,C-136249-3748-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48131000
+_cell_length_b   4.21517000
+_cell_length_c   3.68907000
+_cell_angle_alpha   104.77479000
+_cell_angle_beta   109.62260000
+_cell_angle_gamma   89.94055000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99009229
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.12379256  0.16900558  0.45440925  1
+  C  C1  1  0.92579366  0.24383823  1.05607880  1
+  C  C2  1  0.44472860  0.46651852  0.09449465  1
+  C  C3  1  0.66524056  0.67264526  0.53930972  1
+  C  C4  1  0.70200810  0.03778600  0.61072761  1
+  C  C5  1  0.24369072  0.54180170  0.69651237  1
+",-154.30874083333333
+8799,C-107744-9535-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48391000
+_cell_length_b   5.01293000
+_cell_length_c   4.05127000
+_cell_angle_alpha   66.10755000
+_cell_angle_beta   78.99013000
+_cell_angle_gamma   85.52871000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.27336914
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55721314  0.12261954  0.53607342  1
+  C  C1  1  0.37786322  1.12244051  0.92601730  1
+  C  C2  1  1.05685256  0.31387369  0.44072687  1
+  C  C3  1  0.69411657  0.83930683  0.48798203  1
+  C  C4  1  0.87764219  0.31363421  0.83038436  1
+  C  C5  1  0.19316842  0.59781111  0.10923431  1
+  C  C6  1  0.24619292  -0.16096048  0.25802881  1
+  C  C7  1  -0.25481710  0.59785320  0.87785510  1
+",-154.07165
+2961,C-157715-9420-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.55252000
+_cell_length_b   2.45974000
+_cell_length_c   6.29847000
+_cell_angle_alpha   78.67786000
+_cell_angle_beta   76.97366000
+_cell_angle_gamma   89.47154000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   37.75234061
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.77128668  0.48752379  0.92001604  1
+  C  C1  1  0.50194556  0.70098632  0.49703732  1
+  C  C2  1  0.60699908  -0.18529131  0.26723319  1
+  C  C3  1  -0.16036408  1.05303796  0.78911842  1
+  C  C4  1  0.66219362  0.37417369  0.14927693  1
+  C  C5  1  0.43447273  1.13427455  0.62874411  1
+",-154.1885
+6934,C-9618-6957-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.38974000
+_cell_length_b   4.74708000
+_cell_length_c   5.24085000
+_cell_angle_alpha   68.57215000
+_cell_angle_beta   69.99192000
+_cell_angle_gamma   81.05560000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   73.72033903
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.69061142  0.35408926  0.76901827  1
+  C  C1  1  0.81886796  0.82948659  0.00559062  1
+  C  C2  1  0.32967720  0.56366392  0.73747684  1
+  C  C3  1  0.09293653  0.53305749  0.53256134  1
+  C  C4  1  0.01132984  0.52042162  1.04119467  1
+  C  C5  1  0.72476569  1.03779271  0.74393621  1
+  C  C6  1  0.48913121  0.88815417  0.61380331  1
+  C  C7  1  0.85860855  -0.01045086  0.15134631  1
+  C  C8  1  0.24662801  0.36969008  0.28478337  1
+  C  C9  1  0.93879206  0.85287906  0.41536000  1
+  C  C10  1  0.70043188  0.30908324  0.07482083  1
+  C  C11  1  0.13653036  0.05519741  0.49376765  1
+",-154.07240333333334
+6286,C-34602-3867-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52633000
+_cell_length_b   4.29809000
+_cell_length_c   4.86462000
+_cell_angle_alpha   71.84868000
+_cell_angle_beta   71.39610000
+_cell_angle_gamma   95.01191000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.53662503
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.32181544  0.84884454  0.27569052  1
+  C  C1  1  0.49862234  -0.09506937  0.91720142  1
+  C  C2  1  0.89664136  0.35952600  0.26610213  1
+  C  C3  1  0.27615213  0.55215448  0.94394228  1
+  C  C4  1  0.13472537  0.08724242  0.74364120  1
+  C  C5  1  0.31084235  0.14381444  0.38572650  1
+  C  C6  1  0.35697159  0.43986098  0.71774700  1
+  C  C7  1  0.73608881  0.63296031  0.39565795  1
+",-154.068355
+9250,C-102893-3152-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48754000
+_cell_length_b   4.30399000
+_cell_length_c   4.30552000
+_cell_angle_alpha   99.58808000
+_cell_angle_beta   73.20822000
+_cell_angle_gamma   89.99922000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.45780628
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.38887794  0.53198687  0.39685714  1
+  C  C1  1  0.82645750  0.71983935  0.52199752  1
+  C  C2  1  0.32636428  0.21983225  0.52199390  1
+  C  C3  1  0.88869137  0.03194678  0.39689068  1
+  C  C4  1  0.57668142  0.46988662  0.02196099  1
+  C  C5  1  0.63891529  0.78199405  0.89685415  1
+  C  C6  1  0.07649485  0.96984653  0.02199453  1
+  C  C7  1  0.13900851  0.28200115  0.89685777  1
+",-154.54460625
+536,C-134199-8894-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.28254000
+_cell_length_b   4.52874000
+_cell_length_c   7.02378000
+_cell_angle_alpha   80.09992000
+_cell_angle_beta   81.96119000
+_cell_angle_gamma   132.08053000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   71.54624897
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.27222020  0.45608335  0.19693595  1
+  C  C1  1  0.27230929  0.11521449  0.19981065  1
+  C  C2  1  0.70373406  0.42104746  0.80927829  1
+  C  C3  1  0.64716496  0.69175718  0.32405429  1
+  C  C4  1  0.47980401  0.09037803  0.00556548  1
+  C  C5  1  0.33444302  0.74613174  0.46051358  1
+  C  C6  1  0.29278116  0.24996070  0.68256697  1
+  C  C7  1  0.63364784  0.18195878  0.33869304  1
+  C  C8  1  0.68926129  0.43243730  0.46227233  1
+  C  C9  1  0.71682373  0.78830807  0.79582003  1
+  C  C10  1  0.26744900  0.58452964  0.68073937  1
+  C  C11  1  0.47193006  0.78373296  -0.00028150  1
+",-154.21214583333332
+4744,C-126177-4900-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.36032000
+_cell_length_b   5.38946000
+_cell_length_c   4.21152000
+_cell_angle_alpha   77.55248000
+_cell_angle_beta   105.92450000
+_cell_angle_gamma   91.22749000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   71.56307248
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36143102  0.03067686  0.19241230  1
+  C  C1  1  0.76128542  0.63082873  0.39255765  1
+  C  C2  1  -0.03763716  0.43098452  -0.00749709  1
+  C  C3  1  -0.03590354  0.43142375  0.32617215  1
+  C  C4  1  0.76332877  0.63163465  0.72621660  1
+  C  C5  1  0.36309302  1.03123046  0.52610160  1
+  C  C6  1  1.16457994  0.23211607  0.92624769  1
+  C  C7  1  0.56530246  0.83202092  0.12649430  1
+  C  C8  1  0.56298749  -0.16851559  0.79268807  1
+  C  C9  1  0.16204597  0.23136384  0.59249044  1
+",-154.45036199999998
+9654,C-148232-7880-60,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46590000
+_cell_length_b   3.77169000
+_cell_length_c   6.40663000
+_cell_angle_alpha   60.23638000
+_cell_angle_beta   84.73081000
+_cell_angle_gamma   61.14109000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   44.43752908
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.44566727  0.79755652  0.32878713  1
+  C  C1  1  0.13943703  0.52933971  0.32862183  1
+  C  C2  1  0.89928064  1.00881353  0.84914433  1
+  C  C3  1  1.04777150  0.26737436  1.08887732  1
+  C  C4  1  0.38204733  -0.01651728  0.50864038  1
+  C  C5  1  0.29682723  0.53938326  0.08863082  1
+  C  C6  1  0.20533576  0.27702189  0.84929718  1
+  C  C7  1  -0.03770417  0.82269883  0.66949010  1
+",-154.1367425
+8802,C-72738-5062-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.71816000
+_cell_length_b   2.47367000
+_cell_length_c   4.24512000
+_cell_angle_alpha   89.88236000
+_cell_angle_beta   64.10516000
+_cell_angle_gamma   89.77417000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.12403958
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.44582284  -0.03260935  0.47455292  1
+  C  C1  1  0.33486930  0.46736630  0.69563961  1
+  C  C2  1  0.90034610  0.46751691  0.97347655  1
+  C  C3  1  0.28913202  0.96753405  0.19629014  1
+  C  C4  1  0.88026387  0.96711532  1.19665580  1
+  C  C5  1  0.49144107  0.46724567  -0.02597682  1
+",-154.2820045
+2726,C-142789-7601-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.34853000
+_cell_length_b   4.05301000
+_cell_length_c   6.08459000
+_cell_angle_alpha   97.32181000
+_cell_angle_beta   79.08201000
+_cell_angle_gamma   76.50062000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   77.55823244
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.22853242  0.14775198  0.70783830  1
+  C  C1  1  0.52474209  0.82297806  0.33636011  1
+  C  C2  1  0.04575843  0.33028263  0.11178914  1
+  C  C3  1  0.44833928  0.40464055  -0.00590583  1
+  C  C4  1  0.67446048  0.64270595  0.10024051  1
+  C  C5  1  0.28839838  0.52392791  0.79818786  1
+  C  C6  1  0.84658302  0.77559030  0.88689749  1
+  C  C7  1  0.73155652  0.63679585  0.47337252  1
+  C  C8  1  -0.00808825  0.32997596  0.35751565  1
+  C  C9  1  0.21923668  1.10203450  0.46117009  1
+  C  C10  1  0.55725416  0.77004500  0.71414082  1
+  C  C11  1  0.88254888  0.13219170  0.92089975  1
+",-154.06587
+1844,C-189732-2937-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.48449000
+_cell_length_b   5.69173000
+_cell_length_c   4.60596000
+_cell_angle_alpha   102.59796000
+_cell_angle_beta   90.55060000
+_cell_angle_gamma   126.16812000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   70.85157924
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87683660  0.72761359  0.17640574  1
+  C  C1  1  0.10925825  0.16496912  0.62028651  1
+  C  C2  1  0.03726948  0.01440572  0.83035422  1
+  C  C3  1  1.08813521  0.61134963  0.32644318  1
+  C  C4  1  0.05195473  1.04263700  0.32193294  1
+  C  C5  1  1.07610784  0.59580273  0.61608214  1
+  C  C6  1  0.86449966  0.71022126  0.82659308  1
+  C  C7  1  0.28773574  0.48025404  0.76749438  1
+  C  C8  1  0.12759823  0.19315076  0.11151336  1
+  C  C9  1  0.29968938  0.49725165  0.11579227  1
+",-154.082676
+3787,C-170882-2973-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46529000
+_cell_length_b   3.21462000
+_cell_length_c   7.37383000
+_cell_angle_alpha   98.55792000
+_cell_angle_beta   80.42122000
+_cell_angle_gamma   112.63133000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.95445215
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40954989  0.12376723  0.34369045  1
+  C  C1  1  0.52903542  0.04424385  0.02574479  1
+  C  C2  1  0.64849555  0.44655581  0.18549221  1
+  C  C3  1  0.19111287  1.07323093  0.73440986  1
+  C  C4  1  0.28753817  0.72176854  0.18328862  1
+  C  C5  1  0.75091893  0.09369794  0.63495226  1
+  C  C6  1  1.07924800  1.03580072  0.91764264  1
+  C  C7  1  0.86045848  0.13220058  0.45197118  1
+",-154.25846
+3988,C-184035-5891-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44402000
+_cell_length_b   4.18515000
+_cell_length_c   7.75624000
+_cell_angle_alpha   115.01773000
+_cell_angle_beta   108.36316000
+_cell_angle_gamma   90.01374000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   67.40443500
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.74001263  0.62507703  0.05186474  1
+  C  C1  1  -0.21543583  0.35022207  0.09627439  1
+  C  C2  1  0.53430583  0.25563990  0.34584137  1
+  C  C3  1  0.13101548  0.29519312  0.44305634  1
+  C  C4  1  0.89331948  0.92973230  0.70799356  1
+  C  C5  1  0.31493256  0.18447567  0.12720740  1
+  C  C6  1  1.37883834  0.07333321  0.69315886  1
+  C  C7  1  0.94977974  0.62868963  0.76112910  1
+  C  C8  1  0.18942969  0.76381639  1.00046091  1
+  C  C9  1  0.35511807  0.40312658  0.66628573  1
+",-154.23873
+1136,C-170362-9529-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45058000
+_cell_length_b   4.01752000
+_cell_length_c   6.13977000
+_cell_angle_alpha   132.87950000
+_cell_angle_beta   101.48157000
+_cell_angle_gamma   89.91617000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.64654564
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.21239960  0.40690908  0.83545006  1
+  C  C1  1  0.15465090  0.59179424  0.71991263  1
+  C  C2  1  0.89852325  0.46502691  0.20990260  1
+  C  C3  1  0.74136353  0.27771301  0.89346915  1
+  C  C4  1  0.46636173  0.53440021  0.34572902  1
+  C  C5  1  0.62587689  0.72084375  0.66225594  1
+",-154.24975016666667
+7638,C-141022-7340-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47763000
+_cell_length_b   2.47771000
+_cell_length_c   6.31085000
+_cell_angle_alpha   78.67322000
+_cell_angle_beta   101.31720000
+_cell_angle_gamma   120.00924000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.67457163
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53859417  0.29216123  0.76144722  1
+  C  C1  1  0.84431530  0.98635104  0.67778182  1
+  C  C2  1  0.31501758  0.51638269  0.09185614  1
+  C  C3  1  0.62104305  0.21058042  0.00884099  1
+  C  C4  1  0.39856994  0.43222688  0.34286353  1
+  C  C5  1  0.76022215  0.07032344  0.42674160  1
+",-154.52645466666667
+3635,C-73663-9884-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43158000
+_cell_length_b   3.25621000
+_cell_length_c   9.02873000
+_cell_angle_alpha   75.41384000
+_cell_angle_beta   104.69837000
+_cell_angle_gamma   66.72550000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.32091742
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.09055672  0.78352878  0.66244000  1
+  C  C1  1  1.09038993  0.78282818  0.16255811  1
+  C  C2  1  0.42244296  0.95255728  1.07925416  1
+  C  C3  1  0.42330371  0.95178052  0.57912095  1
+  C  C4  1  0.42200180  0.45377472  0.82952688  1
+  C  C5  1  0.08961287  0.28468539  0.91281412  1
+  C  C6  1  1.09117357  0.28165302  0.41220311  1
+  C  C7  1  0.42349844  0.45051881  0.32884358  1
+",-154.4688575
+5818,C-157676-6832-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46735000
+_cell_length_b   3.36605000
+_cell_length_c   6.14609000
+_cell_angle_alpha   121.86333000
+_cell_angle_beta   78.36147000
+_cell_angle_gamma   111.59311000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.30845600
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.95808280  0.74350060  0.73585742  1
+  C  C1  1  0.14845145  -0.07742878  0.53185741  1
+  C  C2  1  0.73521563  0.22107007  0.65672259  1
+  C  C3  1  0.58951070  0.39921663  0.13394328  1
+  C  C4  1  0.54583197  0.04272786  0.86017970  1
+  C  C5  1  0.11493335  0.57438003  0.25730140  1
+",-154.13996749999998
+7369,C-157674-4910-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46026000
+_cell_length_b   3.40296000
+_cell_length_c   5.31357000
+_cell_angle_alpha   84.28131000
+_cell_angle_beta   89.99582000
+_cell_angle_gamma   68.69106000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.20716705
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.09741144  0.17094049  0.53329413  1
+  C  C1  1  0.49947635  0.36546714  0.40641375  1
+  C  C2  1  0.63790570  0.08326967  0.93619904  1
+  C  C3  1  0.67321965  0.01837220  0.21162856  1
+  C  C4  1  1.12610681  0.10768980  0.80880546  1
+  C  C5  1  0.27183444  0.82283970  0.33877537  1
+",-154.15837433333334
+5264,C-107752-5318-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46692000
+_cell_length_b   5.79631000
+_cell_length_c   5.93431000
+_cell_angle_alpha   68.46070000
+_cell_angle_beta   78.04137000
+_cell_angle_gamma   64.83099000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   71.30384442
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.47322004  0.50237627  0.70504518  1
+  C  C1  1  0.59928472  0.76877668  0.92539972  1
+  C  C2  1  0.06459693  -0.27033325  1.07216281  1
+  C  C3  1  0.19121073  -0.00424567  0.29265582  1
+  C  C4  1  0.69027486  0.40667611  0.46831087  1
+  C  C5  1  0.81009557  0.65933233  0.71753796  1
+  C  C6  1  0.85421925  0.83881628  0.28028363  1
+  C  C7  1  0.09451675  0.20965611  0.05440282  1
+  C  C8  1  0.12345694  0.53973811  0.33574761  1
+  C  C9  1  0.56974616  0.28865221  -0.05648517  1
+  C  C10  1  0.54089216  0.95854106  0.66165179  1
+  C  C11  1  0.97406840  0.09160996  0.52904067  1
+",-154.1338125
+5438,C-193938-7314-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47621000
+_cell_length_b   4.91862000
+_cell_length_c   3.72269000
+_cell_angle_alpha   112.21938000
+_cell_angle_beta   89.98297000
+_cell_angle_gamma   120.25068000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.21757070
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.28024944  0.55117056  0.29735883  1
+  C  C1  1  0.28094339  0.05184913  0.75142332  1
+  C  C2  1  0.28022861  0.55097197  0.70523019  1
+  C  C3  1  0.00255530  0.77367574  0.31646793  1
+  C  C4  1  1.00213754  0.27308168  0.86236704  1
+  C  C5  1  1.00304622  0.77405482  0.90860839  1
+",-154.2923785
+4518,C-92128-7037-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48827000
+_cell_length_b   3.60179000
+_cell_length_c   7.31346000
+_cell_angle_alpha   82.56396000
+_cell_angle_beta   99.81692000
+_cell_angle_gamma   110.23157000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   60.42418999
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.12947581  0.16023165  0.82769291  1
+  C  C1  1  0.41957731  0.37856160  0.18861002  1
+  C  C2  1  0.76129290  0.34906160  0.90191347  1
+  C  C3  1  0.55642886  0.77606310  0.07073246  1
+  C  C4  1  0.52751191  0.38704540  0.39424397  1
+  C  C5  1  1.39414317  -0.01665169  0.53269212  1
+  C  C6  1  1.02102873  0.14434309  0.62341897  1
+  C  C7  1  1.15157068  0.54477119  0.48577407  1
+  C  C8  1  0.78883034  1.19204711  0.11412473  1
+  C  C9  1  -0.01145081  0.76388435  0.94599519  1
+",-154.201542
+8565,C-76026-3583-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.34717000
+_cell_length_b   3.46521000
+_cell_length_c   6.56787000
+_cell_angle_alpha   84.52719000
+_cell_angle_beta   82.21062000
+_cell_angle_gamma   90.61452000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   75.10984929
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.93787258  0.96726344  0.03702447  1
+  C  C1  1  0.36766364  0.61454159  0.24475617  1
+  C  C2  1  0.91952387  0.29083846  0.71194398  1
+  C  C3  1  0.59552389  0.65060277  0.01860358  1
+  C  C4  1  0.66048840  0.73813149  0.39157921  1
+  C  C5  1  0.16975236  0.24672411  0.35800635  1
+  C  C6  1  0.46369595  0.06821336  0.49762076  1
+  C  C7  1  0.34624504  0.96303584  0.90990613  1
+  C  C8  1  0.79755556  0.36955821  0.50251073  1
+  C  C9  1  0.02910318  0.91613120  0.25273876  1
+  C  C10  1  0.22949499  0.04477956  0.70338022  1
+  C  C11  1  0.68993183  1.27670536  -0.07338716  1
+",-154.19003166666667
+6038,C-40100-7984-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48137000
+_cell_length_b   3.68831000
+_cell_length_c   4.83652000
+_cell_angle_alpha   111.42733000
+_cell_angle_beta   104.88118000
+_cell_angle_gamma   109.65641000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.97475939
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.44209962  0.18349466  0.37253725  1
+  C  C1  1  0.42645150  -0.05621406  0.57893381  1
+  C  C2  1  0.40161310  0.59857785  0.87697065  1
+  C  C3  1  1.11136503  0.88630096  1.00779532  1
+  C  C4  1  0.15036753  0.47059925  0.50325635  1
+  C  C5  1  0.12813403  0.12564975  0.80099113  1
+",-154.30904266666667
+1332,C-184052-2353-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46956000
+_cell_length_b   6.12305000
+_cell_length_c   4.08908000
+_cell_angle_alpha   92.29502000
+_cell_angle_beta   89.97466000
+_cell_angle_gamma   101.56039000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   60.52722946
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.29327430  0.38737558  0.57449258  1
+  C  C1  1  0.52107286  0.83397511  0.40234066  1
+  C  C2  1  0.27646347  0.34770628  0.22236153  1
+  C  C3  1  1.07721848  0.95234725  0.87531504  1
+  C  C4  1  0.02045126  0.83261107  0.19582259  1
+  C  C5  1  -0.23201953  0.33048520  0.06798694  1
+  C  C6  1  0.95589520  0.70744555  0.86014012  1
+  C  C7  1  0.73992853  0.28096485  0.71256367  1
+  C  C8  1  0.42242409  0.64026378  0.67420076  1
+  C  C9  1  0.61367964  0.02436931  0.70298952  1
+",-154.153169
+3853,C-96682-5217-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.26168000
+_cell_length_b   3.37080000
+_cell_length_c   4.58497000
+_cell_angle_alpha   72.64440000
+_cell_angle_beta   73.77265000
+_cell_angle_gamma   66.83340000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.47331987
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.62107355  0.48036105  0.95829368  1
+  C  C1  1  1.21747084  0.69373373  0.15033250  1
+  C  C2  1  0.06286572  0.53876581  0.46108020  1
+  C  C3  1  0.00615764  0.09768008  -0.04068029  1
+  C  C4  1  0.65857238  0.75162734  0.65275838  1
+  C  C5  1  0.27498686  0.13494058  0.65185493  1
+",-154.11247733333332
+4814,C-142777-6074-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48809000
+_cell_length_b   4.30395000
+_cell_length_c   4.30526000
+_cell_angle_alpha   80.42719000
+_cell_angle_beta   73.21165000
+_cell_angle_gamma   90.01352000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.46681086
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.37465216  0.72023469  0.01964862  1
+  C  C1  1  0.62458623  0.47036909  0.51965702  1
+  C  C2  1  0.68768141  0.15747646  0.39457961  1
+  C  C3  1  0.18757838  0.65747715  0.39453703  1
+  C  C4  1  0.87475518  0.22023401  0.01969121  1
+  C  C5  1  0.12466495  -0.02963499  0.51965869  1
+  C  C6  1  0.93766861  0.90734615  0.89456955  1
+  C  C7  1  0.43774734  0.40734207  -0.10542879  1
+",-154.5475925
+9582,C-41304-5896-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47962000
+_cell_length_b   2.53600000
+_cell_length_c   6.22311000
+_cell_angle_alpha   112.58229000
+_cell_angle_beta   78.40438000
+_cell_angle_gamma   90.05003000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.26887261
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.86586132  0.72222959  0.32827666  1
+  C  C1  1  0.94704619  0.07284370  0.16729909  1
+  C  C2  1  0.28761806  0.86894494  0.48323650  1
+  C  C3  1  0.51797684  0.92876711  1.02443692  1
+  C  C4  1  0.20547301  0.51863353  0.64447708  1
+  C  C5  1  0.63439638  0.66220423  0.78679845  1
+",-154.28260566666668
+8388,C-40130-2113-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.92604000
+_cell_length_b   3.84257000
+_cell_length_c   7.17098000
+_cell_angle_alpha   74.42688000
+_cell_angle_beta   82.34483000
+_cell_angle_gamma   70.23360000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   73.01081885
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.27169663  0.52633035  -0.04647502  1
+  C  C1  1  0.25838533  0.94366684  0.14300007  1
+  C  C2  1  0.27914248  0.34659281  0.58416090  1
+  C  C3  1  0.25829923  0.57222630  0.14332796  1
+  C  C4  1  0.27810480  0.71853482  0.58403296  1
+  C  C5  1  0.25724054  0.19751649  0.26490202  1
+  C  C6  1  1.28045242  0.11442744  0.77319533  1
+  C  C7  1  0.27748398  0.76189203  0.77347171  1
+  C  C8  1  1.26849180  0.17398235  -0.04635529  1
+  C  C9  1  0.27114979  0.09452957  0.46205596  1
+",-154.086848
+4739,C-152587-3980-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47506000
+_cell_length_b   3.72273000
+_cell_length_c   4.23987000
+_cell_angle_alpha   64.00728000
+_cell_angle_beta   89.96903000
+_cell_angle_gamma   89.96442000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.11452554
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.82259383  0.87299994  0.63295227  1
+  C  C1  1  0.82275115  0.46512432  0.63287648  1
+  C  C2  1  0.32261954  0.91912789  0.13201946  1
+  C  C3  1  0.82263437  0.03020706  0.91075844  1
+  C  C4  1  0.32288913  0.48432454  0.40987829  1
+  C  C5  1  0.32263189  0.07649686  0.40978646  1
+",-154.28007433333332
+1968,C-72722-2079-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46509000
+_cell_length_b   3.39070000
+_cell_length_c   5.27575000
+_cell_angle_alpha   87.37981000
+_cell_angle_beta   89.98539000
+_cell_angle_gamma   68.76206000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.05259275
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.03984633  0.09672616  0.76408227  1
+  C  C1  1  0.36704361  0.28356446  0.63941797  1
+  C  C2  1  0.54735221  -0.07994082  0.44087895  1
+  C  C3  1  0.51605947  0.98704985  0.16560535  1
+  C  C4  1  1.13887558  0.73541129  0.56722631  1
+  C  C5  1  -0.00295354  1.02497597  1.03953035  1
+",-154.16671866666667
+9530,C-176648-5645-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42748000
+_cell_length_b   3.98561000
+_cell_length_c   6.46781000
+_cell_angle_alpha   120.52760000
+_cell_angle_beta   82.59321000
+_cell_angle_gamma   124.16317000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.51472543
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.82116117  0.43922724  0.65975956  1
+  C  C1  1  0.15575359  0.21829770  0.54811159  1
+  C  C2  1  0.15610405  0.55220172  0.21429350  1
+  C  C3  1  0.15569915  0.88499518  0.88152459  1
+  C  C4  1  0.82151163  0.77313125  0.32594147  1
+  C  C5  1  0.82156607  0.10643377  -0.00747153  1
+",-154.44794783333333
+529,C-142751-9264-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47414000
+_cell_length_b   4.27927000
+_cell_length_c   4.80384000
+_cell_angle_alpha   90.00171000
+_cell_angle_beta   121.00642000
+_cell_angle_gamma   90.00169000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.59320954
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.50910566  0.95621722  0.89654551  1
+  C  C1  1  0.50912534  0.78963371  0.39654464  1
+  C  C2  1  0.00912534  0.28963371  0.39654464  1
+  C  C3  1  0.63486244  0.28966757  0.02239922  1
+  C  C4  1  0.00910566  0.45621722  -0.10345449  1
+  C  C5  1  0.13486244  0.78966757  0.02239922  1
+  C  C6  1  0.63484275  0.45625108  0.52240009  1
+  C  C7  1  0.13484275  0.95625108  0.52240009  1
+",-154.5194425
+3711,C-34613-7933-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45764000
+_cell_length_b   3.66391000
+_cell_length_c   6.48280000
+_cell_angle_alpha   79.76228000
+_cell_angle_beta   100.93120000
+_cell_angle_gamma   70.37424000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.11402480
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.14157876  0.68293995  0.81960517  1
+  C  C1  1  0.53908017  0.56518768  0.49541747  1
+  C  C2  1  0.67751959  0.52495164  0.73241862  1
+  C  C3  1  -0.01472506  0.56769833  0.39044388  1
+  C  C4  1  -0.03231688  0.08018751  0.87013481  1
+  C  C5  1  0.38782444  0.44087351  0.06843761  1
+  C  C6  1  0.55860152  1.04450990  0.01608546  1
+  C  C7  1  0.85241426  0.59967848  0.15472328  1
+",-154.28675
+8322,C-96665-6528-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46328000
+_cell_length_b   3.38481000
+_cell_length_c   5.83421000
+_cell_angle_alpha   83.87072000
+_cell_angle_beta   115.04465000
+_cell_angle_gamma   111.19011000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.02909519
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.27685824  -0.07459681  0.40945894  1
+  C  C1  1  0.60359191  0.63442597  0.88219876  1
+  C  C2  1  0.32162746  0.82019407  1.00804882  1
+  C  C3  1  0.63263689  0.88996679  0.28311443  1
+  C  C4  1  0.30508936  0.18199949  0.81039253  1
+  C  C5  1  0.58654174  0.99512319  0.68457262  1
+",-154.16252183333333
+7258,C-148248-8795-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48461000
+_cell_length_b   6.45186000
+_cell_length_c   5.90944000
+_cell_angle_alpha   89.58638000
+_cell_angle_beta   102.12771000
+_cell_angle_gamma   78.90167000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   90.77191322
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.95154653  0.80283112  0.57545769  1
+  C  C1  1  0.55292905  0.41083712  0.38822013  1
+  C  C2  1  0.88953017  0.02365190  0.67458502  1
+  C  C3  1  0.83839526  0.75917874  0.30666087  1
+  C  C4  1  0.38542451  0.62272628  0.26534477  1
+  C  C5  1  -0.01172869  1.23042537  0.07965814  1
+  C  C6  1  0.65252263  0.45796813  0.63533028  1
+  C  C7  1  0.68659245  0.68581342  -0.07281982  1
+  C  C8  1  0.38401103  0.34101544  -0.01819572  1
+  C  C9  1  0.64675796  0.88868994  0.05489960  1
+  C  C10  1  0.28688339  0.57538354  1.01848835  1
+  C  C11  1  0.10271098  0.27392143  0.34817042  1
+  C  C12  1  0.55474144  0.69231954  0.67269614  1
+  C  C13  1  0.29169382  0.14458290  0.59877098  1
+  C  C14  1  0.04881673  0.00982810  0.98022109  1
+  C  C15  1  0.25411663  0.34752164  0.72652250  1
+",-154.3092625
+8821,C-170344-2342-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43060000
+_cell_length_b   3.44427000
+_cell_length_c   6.32938000
+_cell_angle_alpha   57.94539000
+_cell_angle_beta   98.34272000
+_cell_angle_gamma   87.38888000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.95662334
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.43322833  0.44617093  0.43090869  1
+  C  C1  1  0.54454190  0.00107357  0.65312738  1
+  C  C2  1  0.09989500  0.77950426  0.76424202  1
+  C  C3  1  0.87787524  0.66774024  0.31979404  1
+  C  C4  1  0.76656166  0.11283759  0.09757536  1
+  C  C5  1  0.21120857  0.33440691  -0.01353929  1
+",-154.46014933333333
+4773,C-92118-6527-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.36000000
+_cell_length_b   4.37876000
+_cell_length_c   4.38068000
+_cell_angle_alpha   94.60373000
+_cell_angle_beta   93.90629000
+_cell_angle_gamma   86.30278000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   63.98118446
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.34588410  0.41861239  0.44345206  1
+  C  C1  1  0.62849372  0.35348033  0.18084545  1
+  C  C2  1  0.68154986  0.32446712  0.68579555  1
+  C  C3  1  0.25145081  0.74521299  0.52606913  1
+  C  C4  1  0.68122522  0.58655350  0.94748442  1
+  C  C5  1  0.05382889  0.93225500  0.34118300  1
+  C  C6  1  0.96346450  0.25957469  0.42306350  1
+  C  C7  1  0.62837823  0.09174853  0.91865909  1
+  C  C8  1  0.96389856  0.85034686  0.01350898  1
+  C  C9  1  0.34542873  0.82746228  0.85358410  1
+",-154.091448
+2905,C-184074-4085-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.39040000
+_cell_length_b   2.46312000
+_cell_length_c   7.32753000
+_cell_angle_alpha   59.74306000
+_cell_angle_beta   51.21842000
+_cell_angle_gamma   68.78820000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.10620591
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.54296650  0.64414524  0.34025916  1
+  C  C1  1  0.20061137  0.41764537  0.93897142  1
+  C  C2  1  0.88721344  -0.11538461  1.06494968  1
+  C  C3  1  0.03830304  0.79491793  0.74188064  1
+  C  C4  1  0.38229236  0.03532674  0.46652504  1
+  C  C5  1  0.72492179  1.26266853  0.86772776  1
+",-154.166649
+4442,C-9616-927-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.58690000
+_cell_length_b   4.61955000
+_cell_length_c   4.24708000
+_cell_angle_alpha   81.74331000
+_cell_angle_beta   104.40671000
+_cell_angle_gamma   100.68585000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.05146521
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.43314327  0.93710295  0.89765519  1
+  C  C1  1  0.22165125  0.68047988  0.40098061  1
+  C  C2  1  0.31218169  0.64997626  0.75944763  1
+  C  C3  1  0.61843757  0.18987757  0.72331357  1
+  C  C4  1  0.52624584  0.22029549  0.36475357  1
+  C  C5  1  1.01309518  0.40371680  0.24586530  1
+  C  C6  1  0.40635131  0.93335002  0.22655569  1
+  C  C7  1  0.82600199  0.46640922  0.87844153  1
+",-154.1608775
+8312,C-73649-6461-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.58380000
+_cell_length_b   3.35144000
+_cell_length_c   5.74199000
+_cell_angle_alpha   108.25751000
+_cell_angle_beta   125.23621000
+_cell_angle_gamma   111.44590000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.56598070
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.04595576  0.93572345  0.33496126  1
+  C  C1  1  0.62333216  0.49201444  0.47993538  1
+  C  C2  1  0.26407961  -0.09651568  0.32573264  1
+  C  C3  1  0.57290065  -0.12401185  0.63460391  1
+  C  C4  1  0.09988208  0.48031578  -0.01993332  1
+  C  C5  1  0.48006444  0.42091508  0.14642097  1
+  C  C6  1  1.14700499  0.75313632  0.81335008  1
+  C  C7  1  1.24415414  0.52378067  0.62493087  1
+",-154.19853
+8769,C-134160-6134-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48757000
+_cell_length_b   4.06344000
+_cell_length_c   5.84724000
+_cell_angle_alpha   61.76848000
+_cell_angle_beta   64.83250000
+_cell_angle_gamma   89.99222000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.60782874
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.73245364  0.44004522  0.03898910  1
+  C  C1  1  0.50860924  1.01418751  0.26356919  1
+  C  C2  1  0.23741128  0.67028779  0.03395559  1
+  C  C3  1  0.65586371  0.42849898  0.61646917  1
+  C  C4  1  1.04182210  0.51574676  0.73073116  1
+  C  C5  1  0.20096482  0.93900055  0.57170722  1
+  C  C6  1  1.00339116  0.78367321  0.26879308  1
+  C  C7  1  0.58640684  0.02593628  0.68622868  1
+",-154.36552375
+4043,C-73619-216-56,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45641000
+_cell_length_b   3.66635000
+_cell_length_c   6.47365000
+_cell_angle_alpha   106.50770000
+_cell_angle_beta   89.99667000
+_cell_angle_gamma   109.60618000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.36412967
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.20790767  0.15354241  0.78355073  1
+  C  C1  1  -0.01789460  0.70346676  0.73315711  1
+  C  C2  1  0.99107671  0.72216665  0.98024922  1
+  C  C3  1  0.35934506  0.45593362  0.64591758  1
+  C  C4  1  0.71447554  0.16670769  0.30297480  1
+  C  C5  1  0.26251200  0.26122402  0.40958376  1
+  C  C6  1  0.76755070  0.27159486  0.92880157  1
+  C  C7  1  0.61623302  0.97121309  0.06694453  1
+",-154.29036125
+7676,C-193915-3332-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.84483000
+_cell_length_b   3.62527000
+_cell_length_c   4.81989000
+_cell_angle_alpha   112.07775000
+_cell_angle_beta   93.62366000
+_cell_angle_gamma   85.11525000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   45.87043003
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63827673  0.42062869  0.32508428  1
+  C  C1  1  -0.36195459  0.76688892  0.01730718  1
+  C  C2  1  0.63743276  0.14833079  0.01727114  1
+  C  C3  1  0.63795413  0.36209777  0.82594188  1
+  C  C4  1  0.63772439  0.80231263  0.32519680  1
+  C  C5  1  0.63820888  0.20711451  0.51663942  1
+",-154.162814
+5370,C-53806-1811-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.38430000
+_cell_length_b   2.46486000
+_cell_length_c   5.82313000
+_cell_angle_alpha   115.10134000
+_cell_angle_beta   82.98159000
+_cell_angle_gamma   111.22261000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.97645057
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.38116254  0.37907317  0.09737421  1
+  C  C1  1  1.12833890  0.35269865  0.69656924  1
+  C  C2  1  0.42082804  1.02467280  0.22311813  1
+  C  C3  1  0.67765626  1.05311084  0.62345638  1
+  C  C4  1  0.49309693  0.33640061  0.49817337  1
+  C  C5  1  0.31123133  0.06881973  0.82211606  1
+",-154.1641605
+8083,C-134183-9440-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43195000
+_cell_length_b   4.22648000
+_cell_length_c   4.81711000
+_cell_angle_alpha   82.23848000
+_cell_angle_beta   75.33879000
+_cell_angle_gamma   73.26583000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.76894154
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.42041161  0.56910303  0.21402070  1
+  C  C1  1  0.65338253  0.63523431  0.67909364  1
+  C  C2  1  0.43761744  0.79573276  0.95418174  1
+  C  C3  1  0.26896726  0.16031812  0.92618004  1
+  C  C4  1  0.80588473  0.26814158  0.74203171  1
+  C  C5  1  0.02559334  0.10689584  0.46702106  1
+  C  C6  1  0.19303421  0.74215826  0.49491916  1
+  C  C7  1  0.04177709  0.33337641  0.20735954  1
+",-154.22328625
+4557,C-56475-1508-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48710000
+_cell_length_b   4.69558000
+_cell_length_c   4.06111000
+_cell_angle_alpha   106.02186000
+_cell_angle_beta   89.99781000
+_cell_angle_gamma   90.00209000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.58493443
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53096474  0.28646267  0.79730490  1
+  C  C1  1  0.03095969  0.74809611  0.99125808  1
+  C  C2  1  0.03120421  0.98314050  0.33955694  1
+  C  C3  1  1.03111034  0.33068177  0.33102380  1
+  C  C4  1  0.53106943  0.44535257  0.53228339  1
+  C  C5  1  0.03104988  0.40073590  0.99862051  1
+  C  C6  1  0.53102492  0.75380541  0.76699012  1
+  C  C7  1  0.53121469  0.97888968  0.56574337  1
+",-154.365545
+6839,C-40122-8937-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43714000
+_cell_length_b   4.23154000
+_cell_length_c   6.53922000
+_cell_angle_alpha   84.16615000
+_cell_angle_beta   79.21498000
+_cell_angle_gamma   90.00739000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   65.89106211
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.01565412  0.79327266  1.00348663  1
+  C  C1  1  0.30336552  0.52246241  0.40904920  1
+  C  C2  1  0.46658146  0.93166548  0.09918950  1
+  C  C3  1  0.34126969  0.87041633  0.34489834  1
+  C  C4  1  0.00827208  0.43941914  0.01963620  1
+  C  C5  1  0.79763680  0.36303066  0.42222036  1
+  C  C6  1  0.79351218  0.01024537  0.43940744  1
+  C  C7  1  0.13054614  -0.11351730  0.77274910  1
+  C  C8  1  0.68193348  0.92109223  0.66984168  1
+  C  C9  1  0.50075691  0.27984092  1.03543256  1
+",-154.276005
+7960,C-47629-544-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.44998000
+_cell_length_b   4.65983000
+_cell_length_c   5.02951000
+_cell_angle_alpha   80.52989000
+_cell_angle_beta   63.72739000
+_cell_angle_gamma   56.28689000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   59.95234601
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.00887649  0.38868544  0.11394835  1
+  C  C1  1  1.01087380  0.69990168  0.10981975  1
+  C  C2  1  0.24255398  0.83692933  0.87718767  1
+  C  C3  1  0.71842894  -0.13785794  0.39959785  1
+  C  C4  1  0.69609255  0.38302408  0.42709989  1
+  C  C5  1  0.53473063  0.67464793  0.58751075  1
+  C  C6  1  0.24451603  0.14827275  0.87271553  1
+  C  C7  1  0.55709018  0.15387813  0.55983330  1
+",-154.20081375
+4269,C-113036-345-51,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43272000
+_cell_length_b   4.20203000
+_cell_length_c   6.09236000
+_cell_angle_alpha   109.34777000
+_cell_angle_beta   102.18933000
+_cell_angle_gamma   89.82904000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.28476842
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.13679350  1.00964353  1.11013154  1
+  C  C1  1  0.80708677  0.10420839  0.60887711  1
+  C  C2  1  0.30643235  -0.06301201  0.60891033  1
+  C  C3  1  0.30708336  0.60423277  0.60886903  1
+  C  C4  1  0.80643299  0.43699992  0.60891492  1
+  C  C5  1  0.63744792  0.17686393  0.11009833  1
+  C  C6  1  0.13744728  0.67685200  0.11009374  1
+  C  C7  1  0.63679691  0.50961916  0.11013963  1
+",-154.45402875
+4700,C-136241-2721-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.57008000
+_cell_length_b   6.59466000
+_cell_length_c   4.73446000
+_cell_angle_alpha   119.53152000
+_cell_angle_beta   73.82055000
+_cell_angle_gamma   113.45048000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   63.70890089
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.18600419  0.81953008  0.58125369  1
+  C  C1  1  0.34057403  0.81876604  0.27242915  1
+  C  C2  1  0.97013703  0.42386860  0.21945370  1
+  C  C3  1  0.77925761  0.15399509  1.05983166  1
+  C  C4  1  -0.03613605  0.57840271  0.54651825  1
+  C  C5  1  0.31219831  0.07474321  0.83797805  1
+  C  C6  1  0.55483142  0.21415555  0.63482269  1
+  C  C7  1  0.56167298  0.05981702  0.30764847  1
+  C  C8  1  0.74577019  0.48395833  0.79413401  1
+  C  C9  1  0.21302110  0.56342577  0.01617724  1
+",-154.10905
+9076,C-157701-8688-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48998000
+_cell_length_b   3.93888000
+_cell_length_c   6.68649000
+_cell_angle_alpha   118.13176000
+_cell_angle_beta   100.74873000
+_cell_angle_gamma   90.00557000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.52338099
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.54437986  0.43050315  0.15279128  1
+  C  C1  1  0.32481238  0.20205283  0.71263429  1
+  C  C2  1  1.13749108  0.08457044  0.34309085  1
+  C  C3  1  0.25990168  0.41810437  0.58337305  1
+  C  C4  1  0.64341115  0.85779855  0.35509690  1
+  C  C5  1  0.44703597  0.53366082  0.95330404  1
+  C  C6  1  0.80518335  0.65332194  0.67467251  1
+  C  C7  1  0.77967608  0.96703735  0.62177154  1
+  C  C8  1  1.03970810  0.18678257  1.14326574  1
+  C  C9  1  -0.05851984  0.76135476  -0.05799450  1
+",-154.337242
+5074,C-92154-4888-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48117000
+_cell_length_b   3.68943000
+_cell_length_c   4.84394000
+_cell_angle_alpha   111.54192000
+_cell_angle_beta   75.14303000
+_cell_angle_gamma   70.34183000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99694717
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.56275845  0.84791208  0.91402860  1
+  C  C1  1  0.52484817  0.42998223  0.40990873  1
+  C  C2  1  0.54676548  1.08671881  0.70768608  1
+  C  C3  1  0.23341739  0.14253330  0.27909752  1
+  C  C4  1  0.24949672  0.90371052  0.48566467  1
+  C  C5  1  0.27290809  0.55992766  0.78281959  1
+",-154.31036533333335
+2509,C-130546-1595-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47816000
+_cell_length_b   4.12758000
+_cell_length_c   6.06944000
+_cell_angle_alpha   101.70965000
+_cell_angle_beta   90.01059000
+_cell_angle_gamma   89.99753000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   60.79107520
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.28297795  0.32170613  0.30137260  1
+  C  C1  1  0.28264606  0.69691480  0.99213345  1
+  C  C2  1  -0.21689008  -0.12940254  0.46684888  1
+  C  C3  1  0.78227278  0.94808723  0.72659259  1
+  C  C4  1  0.28228733  0.73882585  0.73729133  1
+  C  C5  1  0.78271977  0.89424833  0.07469455  1
+  C  C6  1  0.78298451  0.10575074  0.30983418  1
+  C  C7  1  0.28305349  0.65007439  0.46195782  1
+  C  C8  1  0.28251427  0.36185797  0.04090135  1
+  C  C9  1  0.78245451  1.17769591  0.94845275  1
+",-154.135472
+8430,C-92107-2920-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45352000
+_cell_length_b   6.35872000
+_cell_length_c   7.88775000
+_cell_angle_alpha   130.67690000
+_cell_angle_beta   108.12840000
+_cell_angle_gamma   90.00061000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   85.11085574
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71607244  0.11032160  0.50301878  1
+  C  C1  1  0.23404272  -0.09836941  0.01979411  1
+  C  C2  1  0.62934375  0.38682292  0.91464107  1
+  C  C3  1  0.19915304  0.10451818  -0.01835225  1
+  C  C4  1  0.32812663  0.51216399  0.61498021  1
+  C  C5  1  0.21185706  0.62516179  0.49813511  1
+  C  C6  1  0.67015396  0.18446104  0.95349413  1
+  C  C7  1  0.53433167  0.77702174  0.31960036  1
+  C  C8  1  -0.13203166  0.93385826  0.15350839  1
+  C  C9  1  0.14361510  0.17871359  0.43104698  1
+  C  C10  1  0.98229475  0.59085433  0.76915842  1
+  C  C11  1  0.87998180  0.69790818  0.16524221  1
+  C  C12  1  -0.00492265  0.35466723  0.78082895  1
+  C  C13  1  0.64910529  0.66407716  0.43644035  1
+",-154.34547500000002
+3832,C-152581-906-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43044000
+_cell_length_b   3.95712000
+_cell_length_c   4.74399000
+_cell_angle_alpha   94.76951000
+_cell_angle_beta   107.89200000
+_cell_angle_gamma   93.17484000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.11076939
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.39020367  0.11460544  0.90437201  1
+  C  C1  1  0.61232287  0.66846892  0.34840005  1
+  C  C2  1  -0.05417799  0.00256838  0.01561452  1
+  C  C3  1  0.05622656  0.77980416  0.23681973  1
+  C  C4  1  0.27835289  0.33335884  0.68068532  1
+  C  C5  1  0.72257039  0.44516566  0.56933917  1
+",-154.45442816666667
+8659,C-9608-2433-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.54656000
+_cell_length_b   3.65135000
+_cell_length_c   6.39269000
+_cell_angle_alpha   120.12663000
+_cell_angle_beta   90.04552000
+_cell_angle_gamma   110.39500000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.04385146
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.31192344  0.05578687  0.08513026  1
+  C  C1  1  0.55889923  0.55222656  0.58163002  1
+  C  C2  1  0.18886197  0.81306924  0.58175446  1
+  C  C3  1  0.34557277  0.12311940  0.33349241  1
+  C  C4  1  0.15585389  0.74535949  0.33348428  1
+  C  C5  1  1.04047801  0.51438422  0.91321972  1
+  C  C6  1  0.46053429  0.35536604  0.75415018  1
+  C  C7  1  -0.05808361  0.31642137  0.08517667  1
+",-154.17937
+9652,C-152581-906-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50640000
+_cell_length_b   4.21835000
+_cell_length_c   5.98429000
+_cell_angle_alpha   93.58828000
+_cell_angle_beta   102.21224000
+_cell_angle_gamma   72.72123000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   59.04859990
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36990162  0.68273328  0.83046287  1
+  C  C1  1  0.55850957  0.29914459  0.83024258  1
+  C  C2  1  0.95759230  0.87474979  0.19775538  1
+  C  C3  1  0.13393595  0.29901445  -0.02077183  1
+  C  C4  1  0.16134109  0.87494478  0.61209389  1
+  C  C5  1  0.54729209  0.10601933  0.61216029  1
+  C  C6  1  0.94532407  0.68256438  -0.02058072  1
+  C  C7  1  0.34393009  0.10588287  0.19767390  1
+  C  C8  1  0.16596755  0.66143692  0.40525574  1
+  C  C9  1  0.34020977  0.31873351  0.40517171  1
+",-154.15510999999998
+8623,C-41284-7510-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48069000
+_cell_length_b   3.68978000
+_cell_length_c   4.83821000
+_cell_angle_alpha   111.48154000
+_cell_angle_beta   104.77440000
+_cell_angle_gamma   109.69086000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99365035
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.23753780  0.86320408  0.93540562  1
+  C  C1  1  -0.09310370  0.56763307  0.57038207  1
+  C  C2  1  -0.05317529  0.15096598  0.06633747  1
+  C  C3  1  0.22177417  0.62426493  0.14221994  1
+  C  C4  1  0.92364006  0.80670535  0.36394990  1
+  C  C5  1  1.19827946  0.27996100  0.43970671  1
+",-154.31093133333334
+151,C-130524-1316-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51063000
+_cell_length_b   4.17293000
+_cell_length_c   5.63116000
+_cell_angle_alpha   90.07461000
+_cell_angle_beta   90.07360000
+_cell_angle_gamma   90.00875000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.99578023
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.00560059  0.02846017  0.78171966  1
+  C  C1  1  0.99287542  0.52345543  0.27858094  1
+  C  C2  1  0.49446244  0.15780154  0.66208405  1
+  C  C3  1  -0.00578253  0.65416925  0.78085010  1
+  C  C4  1  0.49366318  0.65534625  0.40828870  1
+  C  C5  1  0.49440955  0.52535548  0.66132941  1
+  C  C6  1  0.49403252  0.02688241  0.40877602  1
+  C  C7  1  0.99317157  0.15796287  0.27885928  1
+  C  C8  1  -0.00699947  0.68034073  0.04639999  1
+  C  C9  1  0.99335650  0.99790166  0.04702565  1
+",-154.207656
+4609,C-136245-2409-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43647000
+_cell_length_b   5.02401000
+_cell_length_c   7.96468000
+_cell_angle_alpha   92.81594000
+_cell_angle_beta   72.21069000
+_cell_angle_gamma   104.13757000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   89.98685081
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.20790570  0.51415157  0.62554580  1
+  C  C1  1  0.63275318  0.54154281  0.71473819  1
+  C  C2  1  0.22386530  -0.00631005  0.84414493  1
+  C  C3  1  0.57038374  0.18735907  1.09716923  1
+  C  C4  1  -0.27832531  0.83994467  0.27083825  1
+  C  C5  1  0.28901769  0.34945742  0.46122731  1
+  C  C6  1  0.64896954  0.02188060  0.93351254  1
+  C  C7  1  0.43370100  0.51518273  0.90159199  1
+  C  C8  1  0.92056131  0.38845095  0.34883319  1
+  C  C9  1  0.93907433  0.14805078  0.20944995  1
+  C  C10  1  0.81387027  0.44293164  0.98383729  1
+  C  C11  1  0.42750032  0.02224575  0.65768566  1
+  C  C12  1  0.04627123  0.09414024  0.57550309  1
+  C  C13  1  0.13385438  0.69567712  0.28651488  1
+",-154.09983000000005
+4243,C-92118-6527-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.04822000
+_cell_length_b   2.42980000
+_cell_length_c   6.41021000
+_cell_angle_alpha   79.32049000
+_cell_angle_beta   77.90003000
+_cell_angle_gamma   105.47015000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.25020727
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.59082738  0.73098777  0.45232020  1
+  C  C1  1  0.59862188  0.40071933  0.11763706  1
+  C  C2  1  0.60010386  0.51224333  0.89537572  1
+  C  C3  1  0.59677773  0.84425475  0.22953666  1
+  C  C4  1  0.59213011  0.17600476  0.56338019  1
+  C  C5  1  0.59555034  1.06589496  0.78494716  1
+",-154.43913716666663
+7984,C-92105-6529-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.44353000
+_cell_length_b   3.87909000
+_cell_length_c   3.62700000
+_cell_angle_alpha   107.89943000
+_cell_angle_beta   100.49258000
+_cell_angle_gamma   97.77672000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.37526439
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.85390612  0.44451129  0.32991206  1
+  C  C1  1  0.04666460  0.63812013  0.73709238  1
+  C  C2  1  0.85493827  0.44529022  0.94966635  1
+  C  C3  1  0.54780873  0.13809396  0.29601444  1
+  C  C4  1  0.35496898  0.94461486  0.88881509  1
+  C  C5  1  0.54695501  0.13769394  0.67666008  1
+",-154.120337
+6882,C-72732-3061-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42854000
+_cell_length_b   3.95302000
+_cell_length_c   5.66978000
+_cell_angle_alpha   126.58859000
+_cell_angle_beta   101.24972000
+_cell_angle_gamma   90.78362000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.27660549
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.72628034  0.82312250  0.10765993  1
+  C  C1  1  0.39344320  0.48980641  0.44102115  1
+  C  C2  1  0.61599218  0.37912340  0.88447418  1
+  C  C3  1  -0.05088995  0.71289766  0.55047600  1
+  C  C4  1  0.28194140  1.04603041  0.21702454  1
+  C  C5  1  0.06004163  0.15668732  0.77422799  1
+",-154.4337935
+2603,C-47644-8979-58,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43075000
+_cell_length_b   5.71298000
+_cell_length_c   6.67983000
+_cell_angle_alpha   83.95435000
+_cell_angle_beta   71.96109000
+_cell_angle_gamma   79.66427000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   86.64797915
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46224606  0.92917654  0.59881281  1
+  C  C1  1  0.46310111  0.48426969  0.82049233  1
+  C  C2  1  0.46384991  0.26189952  -0.06913899  1
+  C  C3  1  -0.03474302  0.15006341  -0.01450210  1
+  C  C4  1  0.46425776  0.81713877  0.15268942  1
+  C  C5  1  0.96307149  0.48432403  0.32055797  1
+  C  C6  1  0.96245776  0.92902008  0.09852083  1
+  C  C7  1  0.46517777  0.15016670  0.48570510  1
+  C  C8  1  -0.03591320  0.81725209  0.65293071  1
+  C  C9  1  -0.03620630  0.26199268  0.43103282  1
+  C  C10  1  0.96174956  0.59615841  0.76582154  1
+  C  C11  1  0.46182381  0.59614458  0.26576805  1
+",-154.46689666666666
+3977,C-80155-5756-59,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.07736000
+_cell_length_b   4.20806000
+_cell_length_c   4.73428000
+_cell_angle_alpha   81.44992000
+_cell_angle_beta   73.38565000
+_cell_angle_gamma   76.75647000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.95787293
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.78692464  0.50033530  0.25243726  1
+  C  C1  1  0.29155307  0.49935343  0.75344892  1
+  C  C2  1  0.54217790  0.99920946  0.50366724  1
+  C  C3  1  1.03774225  1.00019287  1.00263948  1
+  C  C4  1  0.78925661  0.16618843  0.25335316  1
+  C  C5  1  0.54436460  0.66514132  0.50436383  1
+  C  C6  1  0.29379732  0.16523795  0.75429739  1
+  C  C7  1  0.03996521  0.66608675  0.00333541  1
+",-154.4392275
+1072,C-136210-9760-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45786000
+_cell_length_b   6.95138000
+_cell_length_c   4.89093000
+_cell_angle_alpha   79.95018000
+_cell_angle_beta   90.02933000
+_cell_angle_gamma   79.86178000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   80.95510118
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46884430  0.65810387  0.74663418  1
+  C  C1  1  0.30438218  -0.01860445  0.89800774  1
+  C  C2  1  0.93925554  0.72444158  0.17193909  1
+  C  C3  1  1.03285424  0.53350250  0.38131708  1
+  C  C4  1  0.36120803  0.87583657  0.65936888  1
+  C  C5  1  0.26599308  0.06706389  0.44997716  1
+  C  C6  1  -0.24994118  0.09652505  0.26872037  1
+  C  C7  1  1.08817280  0.42044529  0.12783746  1
+  C  C8  1  0.64447435  0.30511753  1.07669597  1
+  C  C9  1  1.20664287  0.18012369  0.70323509  1
+  C  C10  1  0.82459688  -0.05815516  1.08480885  1
+  C  C11  1  0.64895323  0.29507604  0.75450770  1
+  C  C12  1  -0.01141512  0.61938662  0.93325032  1
+  C  C13  1  0.54667689  0.50387408  0.56273701  1
+",-154.14199785714283
+2006,C-113070-261-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.79594000
+_cell_length_b   4.67103000
+_cell_length_c   5.30964000
+_cell_angle_alpha   97.49846000
+_cell_angle_beta   61.37949000
+_cell_angle_gamma   81.55387000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.57723994
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36912707  0.73560595  0.48039258  1
+  C  C1  1  0.53031556  0.44539157  0.31847217  1
+  C  C2  1  1.05850490  0.73066552  0.79150590  1
+  C  C3  1  0.82218012  0.28343556  1.02836586  1
+  C  C4  1  0.49962078  -0.03119831  0.34527090  1
+  C  C5  1  0.04959533  0.42030679  0.79668180  1
+  C  C6  1  0.33841832  0.25907406  0.50642869  1
+  C  C7  1  0.81307121  -0.02657463  0.03435319  1
+",-154.1791925
+6729,C-28248-2845-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48118000
+_cell_length_b   3.68733000
+_cell_length_c   4.89492000
+_cell_angle_alpha   113.01876000
+_cell_angle_beta   120.43064000
+_cell_angle_gamma   70.36660000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99846519
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.75056533  0.84181420  0.60978781  1
+  C  C1  1  0.71015251  0.92814434  0.11363903  1
+  C  C2  1  1.04150521  -0.00175662  0.47877679  1
+  C  C3  1  0.72596985  0.48273989  0.90709611  1
+  C  C4  1  0.00120117  0.08529489  0.98289173  1
+  C  C5  1  0.02501464  0.44388959  0.68545524  1
+",-154.30975083333334
+5525,C-126163-8054-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.26081000
+_cell_length_b   4.06715000
+_cell_length_c   5.78819000
+_cell_angle_alpha   79.36814000
+_cell_angle_beta   58.25991000
+_cell_angle_gamma   75.75787000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   63.13565059
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.13087102  0.47210347  0.20910468  1
+  C  C1  1  0.64647381  -0.02479314  0.94028623  1
+  C  C2  1  0.34066720  0.21993017  0.83876248  1
+  C  C3  1  0.72636160  0.44989137  0.70996184  1
+  C  C4  1  1.11482243  0.12265734  0.70314657  1
+  C  C5  1  -0.21820549  0.65418319  0.45903090  1
+  C  C6  1  0.46472463  -0.06044411  0.45310280  1
+  C  C7  1  0.90440308  0.37553366  0.07351053  1
+  C  C8  1  0.59850556  0.62009795  0.97199330  1
+  C  C9  1  0.51975194  0.14415939  0.20218608  1
+",-154.097172
+8244,C-126138-5994-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.67025000
+_cell_length_b   6.55383000
+_cell_length_c   4.57664000
+_cell_angle_alpha   101.60565000
+_cell_angle_beta   88.68515000
+_cell_angle_gamma   116.09426000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   70.26276032
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.57676476  0.69267276  0.74079222  1
+  C  C1  1  -0.07517965  1.03955755  0.17262612  1
+  C  C2  1  0.32080863  0.43870805  0.27972566  1
+  C  C3  1  0.68400642  0.79859967  0.03425613  1
+  C  C4  1  0.70744314  0.82194666  0.52513871  1
+  C  C5  1  0.13447683  0.25101659  0.73027411  1
+  C  C6  1  0.12377443  0.23970005  0.04681368  1
+  C  C7  1  0.93794041  1.05217831  0.49644942  1
+  C  C8  1  0.33406628  0.45164227  0.60435986  1
+  C  C9  1  0.55377536  0.66910810  0.25007679  1
+",-154.132522
+9737,C-28244-7753-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48120000
+_cell_length_b   4.68499000
+_cell_length_c   10.41368000
+_cell_angle_alpha   92.57523000
+_cell_angle_beta   69.06460000
+_cell_angle_gamma   58.01391000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   91.60920186
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.38706841  0.45377335  1.01098080  1
+  C  C1  1  0.39754768  0.60515603  0.90324404  1
+  C  C2  1  -0.11248525  0.36828142  0.06774743  1
+  C  C3  1  0.25701807  0.17651657  0.61605629  1
+  C  C4  1  0.09020297  0.72964798  0.69113804  1
+  C  C5  1  0.27288928  0.01964399  0.37612682  1
+  C  C6  1  0.48172331  0.35628707  0.67970853  1
+  C  C7  1  0.61129061  0.81068262  0.62302978  1
+  C  C8  1  0.65697332  0.62309721  0.38389375  1
+  C  C9  1  -0.14075161  1.22903984  0.17896370  1
+  C  C10  1  0.98673901  0.62727153  0.82892033  1
+  C  C11  1  1.47797889  0.18772116  0.46084429  1
+  C  C12  1  1.08347412  0.57303984  0.46631541  1
+  C  C13  1  0.23138239  0.23488939  0.26024318  1
+",-154.19806642857142
+4584,C-13897-9657-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47742000
+_cell_length_b   2.47766000
+_cell_length_c   6.77825000
+_cell_angle_alpha   89.97367000
+_cell_angle_beta   68.58210000
+_cell_angle_gamma   59.96786000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.66383227
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.09081343  0.11859605  0.24040304  1
+  C  C1  1  0.53505044  0.39580797  0.65875258  1
+  C  C2  1  0.31222910  0.00722674  0.57541592  1
+  C  C3  1  0.20605783  0.56069490  0.90601658  1
+  C  C4  1  0.64521431  0.84118516  0.32457918  1
+  C  C5  1  0.42736489  0.95023968  0.98950690  1
+",-154.53404433333333
+6783,C-53812-2634-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.73956000
+_cell_length_b   4.80616000
+_cell_length_c   3.62036000
+_cell_angle_alpha   112.02497000
+_cell_angle_beta   89.96509000
+_cell_angle_gamma   90.00763000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.18959883
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.44392934  0.26819840  0.71508590  1
+  C  C1  1  0.44442502  0.45919782  1.11992656  1
+  C  C2  1  0.44412725  0.76880921  0.27599076  1
+  C  C3  1  0.44456784  0.96007293  0.06259084  1
+  C  C4  1  0.44438868  -0.04020472  0.68088534  1
+  C  C5  1  0.44400556  0.26811876  0.33351639  1
+",-154.08361433333332
+4954,C-189692-2339-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42467000
+_cell_length_b   6.19936000
+_cell_length_c   6.22907000
+_cell_angle_alpha   59.26794000
+_cell_angle_beta   67.06636000
+_cell_angle_gamma   78.66745000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   74.12061798
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.22737040  0.78811090  0.46274022  1
+  C  C1  1  0.25864568  0.78792072  0.93264070  1
+  C  C2  1  -0.21289265  0.39767555  0.59933881  1
+  C  C3  1  0.91240581  0.15596879  0.59348729  1
+  C  C4  1  0.70374212  0.39650689  0.18149019  1
+  C  C5  1  0.70174331  0.91428017  0.42574849  1
+  C  C6  1  0.78306823  0.91461972  -0.15493441  1
+  C  C7  1  0.22816585  0.52293129  0.09376837  1
+  C  C8  1  0.57288419  0.15505006  0.43301547  1
+  C  C9  1  0.26144006  0.52358811  0.56231087  1
+",-154.196845
+2974,C-184035-5891-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48137000
+_cell_length_b   3.68936000
+_cell_length_c   4.21724000
+_cell_angle_alpha   104.71369000
+_cell_angle_beta   89.94021000
+_cell_angle_gamma   109.63603000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.01889799
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.81230526  0.88480810  0.43579497  1
+  C  C1  1  0.27377122  0.80040674  -0.06768349  1
+  C  C2  1  0.85227329  -0.04264240  0.80128814  1
+  C  C3  1  0.59225934  0.43977002  0.22950817  1
+  C  C4  1  0.39070006  0.04136992  0.30466485  1
+  C  C5  1  0.07302723  0.40215981  1.00745296  1
+",-154.3106308333333
+9922,C-136210-9760-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51771000
+_cell_length_b   4.41757000
+_cell_length_c   5.70936000
+_cell_angle_alpha   94.23818000
+_cell_angle_beta   69.74108000
+_cell_angle_gamma   78.81758000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.75064071
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.02691450  0.26408628  0.17715673  1
+  C  C1  1  0.55826878  0.84197309  0.33813626  1
+  C  C2  1  0.43316485  0.67543805  0.96261969  1
+  C  C3  1  0.86800462  0.60303493  0.11235390  1
+  C  C4  1  0.38473753  1.02799479  0.92982924  1
+  C  C5  1  0.39956611  0.78844099  0.57154941  1
+  C  C6  1  0.43451680  0.18653825  0.32485198  1
+  C  C7  1  0.55083999  0.51805997  0.68515101  1
+  C  C8  1  0.04430461  0.05726021  0.76553636  1
+  C  C9  1  0.15251139  0.32480493  0.61372302  1
+",-154.110466
+9476,C-142763-5042-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47360000
+_cell_length_b   4.80243000
+_cell_length_c   4.28114000
+_cell_angle_alpha   63.51627000
+_cell_angle_beta   89.99735000
+_cell_angle_gamma   75.07901000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.59613008
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.44479261  0.33509723  1.01487772  1
+  C  C1  1  0.00755849  0.20927175  0.91093947  1
+  C  C2  1  0.25747946  0.70926441  0.82741809  1
+  C  C3  1  0.50755849  0.20927175  0.41093947  1
+  C  C4  1  0.69468324  0.83509041  0.59804793  1
+  C  C5  1  0.19468324  0.83509041  0.09804793  1
+  C  C6  1  0.75747946  0.70926441  0.32741809  1
+  C  C7  1  -0.05520739  0.33509723  0.51487772  1
+",-154.520015
+5785,C-73667-436-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42989000
+_cell_length_b   4.20704000
+_cell_length_c   5.76668000
+_cell_angle_alpha   81.00801000
+_cell_angle_beta   77.34250000
+_cell_angle_gamma   90.08849000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.77197843
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.48550897  0.10231772  0.34664114  1
+  C  C1  1  0.98616227  0.26925507  0.34473236  1
+  C  C2  1  0.98550897  0.60231772  0.34664114  1
+  C  C3  1  0.22454669  0.31354900  0.84570092  1
+  C  C4  1  0.72454669  0.81354900  0.84570092  1
+  C  C5  1  0.22519999  0.98048636  0.84379214  1
+  C  C6  1  0.48616227  0.76925507  0.34473236  1
+  C  C7  1  0.72519999  0.48048636  0.84379214  1
+",-154.43653125
+9531,C-56493-1674-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45314000
+_cell_length_b   5.30223000
+_cell_length_c   6.21596000
+_cell_angle_alpha   107.52595000
+_cell_angle_beta   113.28824000
+_cell_angle_gamma   89.96673000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   70.16635918
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.72089511  0.80040212  0.32301713  1
+  C  C1  1  0.19250835  1.03346563  0.79187728  1
+  C  C2  1  0.54368407  0.95088893  0.14576585  1
+  C  C3  1  0.22319360  0.52101103  0.82452419  1
+  C  C4  1  0.07219394  0.12641015  0.17492500  1
+  C  C5  1  0.94759367  1.04644804  0.54720079  1
+  C  C6  1  0.83245769  0.17952650  0.93277483  1
+  C  C7  1  0.86656139  0.46419680  0.96673197  1
+  C  C8  1  1.27786504  0.80313388  0.87784834  1
+  C  C9  1  0.29475172  0.38168775  0.39637152  1
+  C  C10  1  0.16693833  0.61627566  0.26833459  1
+  C  C11  1  0.94634499  0.34311240  0.54698391  1
+",-154.0873525
+8637,C-134204-8080-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49414000
+_cell_length_b   3.42095000
+_cell_length_c   7.21312000
+_cell_angle_alpha   110.35492000
+_cell_angle_beta   99.98434000
+_cell_angle_gamma   111.36784000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   50.46105337
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40324399  0.52535803  0.89034265  1
+  C  C1  1  0.98719457  0.29970912  0.28483115  1
+  C  C2  1  -0.28840170  0.24667973  0.78490490  1
+  C  C3  1  0.50717239  0.23235808  0.39042050  1
+  C  C4  1  1.15550579  0.69165260  0.22983860  1
+  C  C5  1  0.74085877  0.46568523  0.62415621  1
+  C  C6  1  0.63618750  0.75930299  0.12410860  1
+  C  C7  1  0.43393040  0.74496143  0.72993439  1
+",-154.08875625
+6699,C-145325-7931-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.30131000
+_cell_length_b   3.30340000
+_cell_length_c   5.22593000
+_cell_angle_alpha   94.91056000
+_cell_angle_beta   115.74515000
+_cell_angle_gamma   100.21222000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.66382326
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64913738  0.68879166  0.39128715  1
+  C  C1  1  0.50769826  0.00485942  0.56547617  1
+  C  C2  1  0.27248142  0.47085860  0.10596656  1
+  C  C3  1  1.01229606  0.05136219  0.39140225  1
+  C  C4  1  0.86998498  0.36719176  0.56534904  1
+  C  C5  1  0.94548830  1.14515704  0.10614331  1
+  C  C6  1  0.57528172  0.91218503  0.85031330  1
+  C  C7  1  0.24716059  0.58698029  -0.14976537  1
+",-154.21860625
+8122,C-76058-7769-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48808000
+_cell_length_b   5.45377000
+_cell_length_c   7.19068000
+_cell_angle_alpha   78.39469000
+_cell_angle_beta   94.09406000
+_cell_angle_gamma   86.23546000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   95.01444765
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55808111  0.65167547  0.99383793  1
+  C  C1  1  1.01464303  0.45085362  0.40539793  1
+  C  C2  1  0.92986244  0.29335163  0.25605153  1
+  C  C3  1  0.72251475  0.38366522  0.06602216  1
+  C  C4  1  0.61736004  0.34091251  0.71256893  1
+  C  C5  1  0.49298145  0.87370678  0.09755503  1
+  C  C6  1  1.03865983  0.01545044  0.55661948  1
+  C  C7  1  0.02207795  0.75967526  0.88364450  1
+  C  C8  1  0.08639621  0.26070152  0.60555061  1
+  C  C9  1  0.99420447  0.01920739  0.35056979  1
+  C  C10  1  0.54218062  0.62233298  0.63065832  1
+  C  C11  1  -0.04608293  0.98324478  -0.01284149  1
+  C  C12  1  -0.22284636  0.24980761  0.92083927  1
+  C  C13  1  0.50106893  0.87452096  0.30193029  1
+  C  C14  1  0.50827528  0.61137644  0.42106150  1
+  C  C15  1  1.03017087  0.76172047  0.67747174  1
+",-154.077386875
+8112,C-57146-9403-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47987000
+_cell_length_b   2.48030000
+_cell_length_c   8.30082000
+_cell_angle_alpha   89.99099000
+_cell_angle_beta   81.40912000
+_cell_angle_gamma   59.97183000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.54177025
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.38918917  0.45571380  0.65768883  1
+  C  C1  1  0.43320117  0.93352967  0.09168593  1
+  C  C2  1  0.72411936  0.28801151  0.15463275  1
+  C  C3  1  0.22313318  0.03838827  0.40638837  1
+  C  C4  1  0.55705862  0.87151583  0.90587996  1
+  C  C5  1  0.09813940  0.10131546  0.59475155  1
+  C  C6  1  0.59903667  0.35063415  0.34298212  1
+  C  C7  1  0.26580634  0.51726772  0.84338308  1
+",-154.5312925
+507,C-13941-680-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48244000
+_cell_length_b   3.74561000
+_cell_length_c   3.84362000
+_cell_angle_alpha   90.05245000
+_cell_angle_beta   90.02489000
+_cell_angle_gamma   90.01980000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.73892721
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.74462208  0.44807420  0.64667037  1
+  C  C1  1  0.24479969  0.67692718  0.64682441  1
+  C  C2  1  -0.25424177  0.18095055  0.94186016  1
+  C  C3  1  0.24370167  -0.05666934  0.35263773  1
+  C  C4  1  0.74440639  0.18033861  0.35255933  1
+  C  C5  1  0.24551723  0.94390689  0.94153800  1
+",-154.154389
+8426,C-34611-1398-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48407000
+_cell_length_b   3.55776000
+_cell_length_c   6.77951000
+_cell_angle_alpha   97.07215000
+_cell_angle_beta   111.48897000
+_cell_angle_gamma   69.50099000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.21946510
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.48295308  0.18118020  0.48546839  1
+  C  C1  1  0.27678803  0.17479661  0.27592528  1
+  C  C2  1  0.64838078  0.17347198  0.14726820  1
+  C  C3  1  0.07018143  0.54805417  0.75626186  1
+  C  C4  1  0.44132725  0.80668838  0.75647690  1
+  C  C5  1  0.32112796  0.54491387  0.00557012  1
+  C  C6  1  0.69256801  0.80356204  1.00610309  1
+  C  C7  1  0.11285906  0.17998665  0.61448266  1
+",-154.15115
+3245,C-28246-1719-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.62398000
+_cell_length_b   4.68987000
+_cell_length_c   3.66341000
+_cell_angle_alpha   112.88934000
+_cell_angle_beta   90.37134000
+_cell_angle_gamma   106.61745000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.44250868
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.97349870  0.48139605  0.98039827  1
+  C  C1  1  0.09027913  0.71327369  0.40979851  1
+  C  C2  1  0.36108087  0.26870248  0.87401051  1
+  C  C3  1  0.24479438  0.03685944  0.44633639  1
+  C  C4  1  0.24568028  1.03747226  0.07196757  1
+  C  C5  1  0.08893014  0.71381689  0.78491955  1
+",-154.07744516666665
+9802,C-184046-597-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42468000
+_cell_length_b   4.21334000
+_cell_length_c   6.44874000
+_cell_angle_alpha   131.14376000
+_cell_angle_beta   112.06382000
+_cell_angle_gamma   89.85005000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.06392860
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.88038011  0.18237874  0.96852662  1
+  C  C1  1  0.53588107  0.31005446  0.12414411  1
+  C  C2  1  0.88378133  0.59685467  0.47171910  1
+  C  C3  1  0.53230565  0.89505603  0.62098364  1
+  C  C4  1  0.47195790  0.18228322  0.56058017  1
+  C  C5  1  0.94351614  0.30957368  0.53200667  1
+",-154.305597
+4928,C-72736-7953-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45131000
+_cell_length_b   4.00967000
+_cell_length_c   4.54878000
+_cell_angle_alpha   89.25149000
+_cell_angle_beta   105.66604000
+_cell_angle_gamma   90.00434000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.04487690
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.00062006  0.25532079  0.20538816  1
+  C  C1  1  0.41419610  0.76326880  0.03530338  1
+  C  C2  1  0.94356464  0.95091613  0.09343668  1
+  C  C3  1  0.25813216  0.63132223  0.71988668  1
+  C  C4  1  0.52942131  0.44199032  0.26455119  1
+  C  C5  1  0.68929996  0.57098473  0.58107340  1
+",-154.2521545
+3439,C-104350-5208-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46968000
+_cell_length_b   7.24890000
+_cell_length_c   7.38495000
+_cell_angle_alpha   99.15237000
+_cell_angle_beta   98.00482000
+_cell_angle_gamma   100.22021000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C22
+_cell_volume   126.53183265
+_cell_formula_units_Z   22
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.85942433  0.23585212  0.67351968  1
+  C  C1  1  0.72019761  1.01244529  0.61965167  1
+  C  C2  1  1.09410748  0.41988589  0.06152427  1
+  C  C3  1  -0.02728687  0.80427697  0.34395122  1
+  C  C4  1  0.16171372  0.58282439  -0.04839966  1
+  C  C5  1  0.79371404  1.26177699  0.46539769  1
+  C  C6  1  -0.05125625  0.45772937  0.43567448  1
+  C  C7  1  0.51709077  0.29983037  -0.01215774  1
+  C  C8  1  0.14548695  -0.01761183  0.49342750  1
+  C  C9  1  0.19466303  0.15238871  0.38610448  1
+  C  C10  1  0.59088257  0.54391548  0.82956132  1
+  C  C11  1  0.12739437  0.49703025  0.25424632  1
+  C  C12  1  0.48353970  0.11139375  0.05613014  1
+  C  C13  1  0.74717419  0.89245757  0.77575171  1
+  C  C14  1  0.44565561  0.31903404  0.77736317  1
+  C  C15  1  0.62359433  0.67854568  0.70013550  1
+  C  C16  1  0.52481555  0.58308065  0.51164566  1
+  C  C17  1  0.02643016  0.07671533  0.17190381  1
+  C  C18  1  0.90183615  0.85690571  0.15329118  1
+  C  C19  1  0.42535770  0.68910083  0.35698771  1
+  C  C20  1  0.31434599  0.79038070  0.04050778  1
+  C  C21  1  0.32331957  0.92885473  0.90126091  1
+",-154.19579454545453
+7990,C-130544-211-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42718000
+_cell_length_b   5.36059000
+_cell_length_c   6.47565000
+_cell_angle_alpha   125.75632000
+_cell_angle_beta   79.34562000
+_cell_angle_gamma   90.02550000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   66.58107258
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.14772967  0.05839508  0.20198252  1
+  C  C1  1  0.61914109  0.71721554  0.26667934  1
+  C  C2  1  0.88178283  0.76442166  0.72706471  1
+  C  C3  1  0.62740548  -0.03294077  0.24520986  1
+  C  C4  1  0.37991439  0.37404585  0.73593643  1
+  C  C5  1  0.38776983  0.62412618  0.71514677  1
+  C  C6  1  0.20919739  0.22473124  0.08083848  1
+  C  C7  1  0.79784099  0.11657903  0.90018444  1
+  C  C8  1  0.85995073  0.28230246  0.77878632  1
+  C  C9  1  0.12514810  0.57688713  0.25440813  1
+",-154.20054
+9754,C-184068-6075-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46062000
+_cell_length_b   3.40364000
+_cell_length_c   5.31809000
+_cell_angle_alpha   96.26178000
+_cell_angle_beta   90.00556000
+_cell_angle_gamma   111.30358000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.21037909
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.18847557  0.38251845  0.63000425  1
+  C  C1  1  0.21469371  0.44359350  0.90594420  1
+  C  C2  1  0.59046985  0.18704781  0.50254335  1
+  C  C3  1  0.76258080  0.53126559  0.30894631  1
+  C  C4  1  0.72594773  0.46637006  0.03266260  1
+  C  C5  1  0.36214894  0.72850798  0.43510289  1
+",-154.15643966666667
+3267,C-80155-5756-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.75160000
+_cell_length_b   4.13784000
+_cell_length_c   4.66801000
+_cell_angle_alpha   78.35344000
+_cell_angle_beta   58.26790000
+_cell_angle_gamma   71.55697000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.40973061
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.69498689  0.81328966  0.89707015  1
+  C  C1  1  0.59584494  0.04038503  0.13060164  1
+  C  C2  1  0.13402251  0.19238182  0.27775191  1
+  C  C3  1  0.89470415  0.43126609  0.51809784  1
+  C  C4  1  -0.02957666  0.04711686  0.12444908  1
+  C  C5  1  0.33479109  0.81856256  -0.10769982  1
+  C  C6  1  0.05821354  0.57937400  0.66940582  1
+  C  C7  1  0.43252534  0.58546389  0.66373738  1
+",-154.08963875
+9929,C-157668-5131-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46935000
+_cell_length_b   3.23513000
+_cell_length_c   5.18078000
+_cell_angle_alpha   92.00954000
+_cell_angle_beta   90.00611000
+_cell_angle_gamma   112.48468000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   38.21371484
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.89447517  0.50635348  0.37046329  1
+  C  C1  1  0.06655564  0.85159370  0.15094237  1
+  C  C2  1  0.08409059  0.88410834  0.58967182  1
+  C  C3  1  0.25658664  0.22914846  0.37211356  1
+  C  C4  1  0.58398404  0.88404278  0.74258230  1
+  C  C5  1  0.56692413  0.85241454  -0.00187974  1
+",-154.25315733333335
+8736,C-106859-2905-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47198000
+_cell_length_b   6.24650000
+_cell_length_c   6.38183000
+_cell_angle_alpha   69.25390000
+_cell_angle_beta   75.45365000
+_cell_angle_gamma   86.36428000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   89.16408503
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.37133964  0.54214271  0.57378575  1
+  C  C1  1  0.56151035  0.25339631  0.91906703  1
+  C  C2  1  0.73628114  0.49524863  0.73550135  1
+  C  C3  1  -0.11371178  0.89025760  0.31785870  1
+  C  C4  1  0.48753478  0.72676467  0.05097384  1
+  C  C5  1  0.19070603  0.84239836  0.68164726  1
+  C  C6  1  0.97668787  0.86531119  0.07840550  1
+  C  C7  1  0.64057428  0.71749479  0.80647087  1
+  C  C8  1  0.68502478  0.43932155  0.39510536  1
+  C  C9  1  0.31627269  0.48527285  0.23447038  1
+  C  C10  1  0.16620001  0.08998552  0.65192356  1
+  C  C11  1  0.72375766  0.18610095  0.51058099  1
+  C  C12  1  0.32896206  0.79434085  0.45924842  1
+  C  C13  1  0.41354937  0.26316702  0.16343055  1
+  C  C14  1  1.07192192  0.11513240  0.89153607  1
+  C  C15  1  -0.13472773  0.13873889  0.28786975  1
+",-154.28285625
+400,C-194844-3110-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44565000
+_cell_length_b   8.62856000
+_cell_length_c   8.00100000
+_cell_angle_alpha   57.55928000
+_cell_angle_beta   85.23482000
+_cell_angle_gamma   88.06539000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C22
+_cell_volume   141.98826811
+_cell_formula_units_Z   22
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.94515776  0.07678959  0.76856986  1
+  C  C1  1  0.88654924  0.68211953  0.32955628  1
+  C  C2  1  0.14218795  0.04092106  0.42228521  1
+  C  C3  1  0.45631718  0.79931958  0.82721341  1
+  C  C4  1  -0.10510514  0.77395119  1.10823138  1
+  C  C5  1  0.73034380  0.82690615  0.37564455  1
+  C  C6  1  0.40552977  0.71279447  0.05143614  1
+  C  C7  1  0.41278592  0.37278295  0.57066179  1
+  C  C8  1  0.37267428  0.51388889  0.11878338  1
+  C  C9  1  0.48124772  0.01066961  0.71282953  1
+  C  C10  1  0.59853114  0.05508016  0.50057077  1
+  C  C11  1  0.88593144  -0.00835739  0.00046693  1
+  C  C12  1  0.87586100  0.30645760  1.04957747  1
+  C  C13  1  0.87421309  0.44211047  1.10345629  1
+  C  C14  1  0.91754331  0.28144894  0.63827134  1
+  C  C15  1  1.00267284  0.65223710  0.68257992  1
+  C  C16  1  0.23447324  0.94442286  0.30819853  1
+  C  C17  1  0.40519756  0.57395621  0.45341835  1
+  C  C18  1  0.97177570  0.73952714  0.77772615  1
+  C  C19  1  0.35573161  0.04974808  0.06677678  1
+  C  C20  1  0.38451968  0.23838968  1.02844819  1
+  C  C21  1  0.52020402  0.65172303  0.58613116  1
+",-154.1063768181818
+1737,C-141033-8048-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42993000
+_cell_length_b   2.43029000
+_cell_length_c   8.46550000
+_cell_angle_alpha   82.34274000
+_cell_angle_beta   84.58394000
+_cell_angle_gamma   59.98126000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.87816952
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.61266393  0.36879139  0.36164054  1
+  C  C1  1  0.27997787  0.03544454  0.36109840  1
+  C  C2  1  0.09622886  -0.13901047  0.02628058  1
+  C  C3  1  -0.19490123  0.63539421  0.69538997  1
+  C  C4  1  0.42949043  0.19425573  0.02622423  1
+  C  C5  1  0.47178184  0.30199890  0.69536278  1
+",-154.45910516666666
+8095,C-9628-9669-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47346000
+_cell_length_b   4.28217000
+_cell_length_c   6.43520000
+_cell_angle_alpha   131.75136000
+_cell_angle_beta   112.56942000
+_cell_angle_gamma   89.99752000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.60632321
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.13647616  0.87572259  0.35753342  1
+  C  C1  1  0.63647616  0.37572259  0.35753342  1
+  C  C2  1  0.13628775  0.20906776  0.85753747  1
+  C  C3  1  0.63628775  0.70906776  0.85753747  1
+  C  C4  1  0.51113058  0.25002864  0.73182139  1
+  C  C5  1  0.01127071  0.08335781  0.23180916  1
+  C  C6  1  0.01113058  0.75002864  0.73182139  1
+  C  C7  1  0.51127071  0.58335781  0.23180916  1
+",-154.5226575
+6154,C-73626-2668-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43335000
+_cell_length_b   4.22307000
+_cell_length_c   4.81781000
+_cell_angle_alpha   90.62617000
+_cell_angle_beta   104.71920000
+_cell_angle_gamma   73.33110000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.76924091
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.72695154  0.26305602  0.92797751  1
+  C  C1  1  0.43219289  0.31568016  0.38763064  1
+  C  C2  1  0.67405051  0.08991638  0.64665817  1
+  C  C3  1  0.23179561  0.68079248  0.35829069  1
+  C  C4  1  0.37279487  0.15507318  0.11135567  1
+  C  C5  1  0.28839984  0.85363130  0.64010572  1
+  C  C6  1  0.53071780  0.62750570  0.89895476  1
+  C  C7  1  0.58724414  0.78787379  0.17495084  1
+",-154.22906125
+41,C-28224-863-55,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.74379000
+_cell_length_b   4.46997000
+_cell_length_c   6.05005000
+_cell_angle_alpha   101.04331000
+_cell_angle_beta   131.13608000
+_cell_angle_gamma   88.77558000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   74.08716256
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.23945940  0.28027451  0.41323052  1
+  C  C1  1  0.83642749  0.17922785  0.12103157  1
+  C  C2  1  1.12379638  -0.07559411  0.66011613  1
+  C  C3  1  0.45678455  0.93817511  -0.01590595  1
+  C  C4  1  0.32293096  1.15354072  0.62983685  1
+  C  C5  1  0.69081797  0.72480307  0.42688089  1
+  C  C6  1  -0.04832658  0.53555852  0.87459607  1
+  C  C7  1  0.38368352  0.73566886  0.10828367  1
+  C  C8  1  0.61848931  0.52193834  0.55095970  1
+  C  C9  1  0.75276852  0.30567613  0.90423594  1
+",-154.193004
+515,C-13902-2321-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.07989000
+_cell_length_b   3.85050000
+_cell_length_c   5.90356000
+_cell_angle_alpha   79.40255000
+_cell_angle_beta   85.21282000
+_cell_angle_gamma   39.04532000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.15036886
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.75034124  0.62670393  0.17154079  1
+  C  C1  1  1.41898496  0.29342385  0.83855684  1
+  C  C2  1  -0.13475657  0.73695748  0.94997049  1
+  C  C3  1  0.19965090  0.07049226  0.28345970  1
+  C  C4  1  0.08590972  0.96013528  0.50527894  1
+  C  C5  1  0.53421535  0.40390250  0.61704593  1
+",-154.46503783333333
+5237,C-92109-5617-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.53656000
+_cell_length_b   6.15032000
+_cell_length_c   4.19144000
+_cell_angle_alpha   70.01039000
+_cell_angle_beta   75.41891000
+_cell_angle_gamma   84.98695000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   59.47059551
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.29876396  0.66076349  1.03593786  1
+  C  C1  1  0.23345041  0.43361950  0.00461217  1
+  C  C2  1  0.29833063  0.40403905  0.66446014  1
+  C  C3  1  0.72883931  1.03238598  0.94684214  1
+  C  C4  1  0.05371772  0.82228020  0.49037104  1
+  C  C5  1  0.05389568  0.24301074  0.28005808  1
+  C  C6  1  0.84840120  0.80757502  0.85947255  1
+  C  C7  1  0.23299962  0.63118945  0.40549841  1
+  C  C8  1  0.11864105  1.03249355  0.18062224  1
+  C  C9  1  0.84769453  0.25750152  0.63469628  1
+",-154.086769
+8054,C-176685-9184-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48822000
+_cell_length_b   3.51665000
+_cell_length_c   4.30558000
+_cell_angle_alpha   114.08411000
+_cell_angle_beta   106.76207000
+_cell_angle_gamma   90.02320000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.63166930
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.95895791  0.80924637  0.68144509  1
+  C  C1  1  0.12575970  0.72604171  0.01481738  1
+  C  C2  1  0.62564303  0.47590588  1.01477976  1
+  C  C3  1  0.45909284  0.05938099  0.68148501  1
+  C  C4  1  0.79244482  0.39270121  0.34815205  1
+  C  C5  1  0.29230990  0.14256659  0.34811213  1
+",-154.55222916666665
+1761,C-189703-1540-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.14577000
+_cell_length_b   2.43155000
+_cell_length_c   6.26769000
+_cell_angle_alpha   89.95501000
+_cell_angle_beta   78.43525000
+_cell_angle_gamma   112.72109000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.16131548
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.89688132  0.74951921  0.01529506  1
+  C  C1  1  0.67801348  0.63974427  0.23770933  1
+  C  C2  1  0.34520048  -0.02667554  0.57108998  1
+  C  C3  1  0.23068222  0.41646359  0.68200992  1
+  C  C4  1  1.01152241  0.30648373  0.90436832  1
+  C  C5  1  0.56373160  0.08297403  0.34867209  1
+",-154.47502583333332
+6870,C-176685-9184-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.30551000
+_cell_length_b   3.91876000
+_cell_length_c   5.84983000
+_cell_angle_alpha   113.03293000
+_cell_angle_beta   116.63188000
+_cell_angle_gamma   73.68177000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   61.82081123
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.78148134  0.32255617  0.34341864  1
+  C  C1  1  0.83809205  0.36732812  0.96459300  1
+  C  C2  1  0.47649613  1.00681000  0.22537212  1
+  C  C3  1  0.68855274  0.58789445  0.57567841  1
+  C  C4  1  0.13877847  0.05570236  0.96558080  1
+  C  C5  1  0.80467752  0.61840527  0.22570521  1
+  C  C6  1  0.51624221  0.43709860  0.71039444  1
+  C  C7  1  0.12038888  0.76669185  0.71403943  1
+  C  C8  1  0.21823688  0.80376720  0.48304921  1
+  C  C9  1  0.25883398  0.13581570  0.44647314  1
+",-154.089073
+6181,C-13897-9657-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47365000
+_cell_length_b   4.47179000
+_cell_length_c   4.24931000
+_cell_angle_alpha   68.60103000
+_cell_angle_beta   89.99246000
+_cell_angle_gamma   56.38099000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.18683682
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.84312298  0.82679841  0.82258259  1
+  C  C1  1  1.00019436  0.67013038  0.54474780  1
+  C  C2  1  0.40796489  0.26180934  0.54467129  1
+  C  C3  1  0.88822203  0.28144752  0.32180905  1
+  C  C4  1  0.29681830  0.87321548  0.32175185  1
+  C  C5  1  0.45396904  0.71592467  0.04410243  1
+",-154.29952633333332
+9352,C-72710-1910-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43025000
+_cell_length_b   3.09450000
+_cell_length_c   7.55090000
+_cell_angle_alpha   116.85167000
+_cell_angle_beta   104.09855000
+_cell_angle_gamma   107.10380000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.44885890
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.58314974  0.15952067  0.02018091  1
+  C  C1  1  0.25081550  1.05100594  0.46441798  1
+  C  C2  1  0.25059273  0.38344518  0.13125482  1
+  C  C3  1  0.25027703  0.71557499  0.79812025  1
+  C  C4  1  0.58358296  0.82796422  0.35320116  1
+  C  C5  1  0.58314864  0.49295461  0.68683698  1
+",-154.45235716666667
+4529,C-92118-6527-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48520000
+_cell_length_b   4.59798000
+_cell_length_c   6.02352000
+_cell_angle_alpha   64.54899000
+_cell_angle_beta   65.62035000
+_cell_angle_gamma   74.30260000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.24406642
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.83139550  -0.02933515  0.29177336  1
+  C  C1  1  1.18486769  0.53510563  0.65619241  1
+  C  C2  1  0.27076658  0.51801557  0.07968389  1
+  C  C3  1  0.20676382  -0.12876172  0.46630616  1
+  C  C4  1  0.70510049  0.35362566  0.22736891  1
+  C  C5  1  0.12156894  0.88929620  0.04306275  1
+  C  C6  1  -0.31233200  0.05354502  0.89509890  1
+  C  C7  1  0.55880356  0.43668069  0.83074439  1
+  C  C8  1  0.44508259  0.30437103  0.51248130  1
+  C  C9  1  0.94840274  0.10209146  0.61027442  1
+",-154.386349
+6452,C-40134-7379-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.55198000
+_cell_length_b   2.46020000
+_cell_length_c   6.29053000
+_cell_angle_alpha   78.77940000
+_cell_angle_beta   77.26930000
+_cell_angle_gamma   90.06346000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   37.74711650
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.09878564  0.40058962  0.31469462  1
+  C  C1  1  0.69150078  0.48025328  0.15415179  1
+  C  C2  1  0.03075635  -0.16455467  0.44597560  1
+  C  C3  1  0.91912568  0.72030284  0.67556182  1
+  C  C4  1  -0.24163167  0.04651551  0.02283873  1
+  C  C5  1  0.86329982  0.16134512  0.79336015  1
+",-154.18608883333334
+2469,C-41278-5784-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47502000
+_cell_length_b   4.24789000
+_cell_length_c   3.72186000
+_cell_angle_alpha   115.96468000
+_cell_angle_beta   90.00156000
+_cell_angle_gamma   90.00108000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.18055352
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.35657615  0.33046117  0.60532409  1
+  C  C1  1  0.35694386  0.60857799  0.44895659  1
+  C  C2  1  0.85657462  -0.16868571  0.06020973  1
+  C  C3  1  0.85673857  0.83141195  0.65156567  1
+  C  C4  1  0.85664857  0.10915219  0.49460711  1
+  C  C5  1  0.35673243  0.60818380  1.04011052  1
+",-154.28741183333332
+6704,C-141055-6281-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.79823000
+_cell_length_b   4.19879000
+_cell_length_c   4.19948000
+_cell_angle_alpha   119.99301000
+_cell_angle_beta   90.55911000
+_cell_angle_gamma   93.52899000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.60515636
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.24215636  0.60249771  0.76014843  1
+  C  C1  1  0.24200310  0.26915819  1.09347499  1
+  C  C2  1  0.24212737  -0.06415960  0.42682090  1
+  C  C3  1  0.24221493  0.60245002  0.42671985  1
+  C  C4  1  0.24209067  0.93576780  0.09337395  1
+  C  C5  1  0.24206168  0.26911049  0.76004641  1
+",-154.34133366666666
+1324,C-136235-2385-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.24710000
+_cell_length_b   3.22358000
+_cell_length_c   4.82064000
+_cell_angle_alpha   100.25304000
+_cell_angle_beta   104.64771000
+_cell_angle_gamma   111.15252000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.45553786
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.56905707  -0.17025179  0.78065389  1
+  C  C1  1  0.62715832  0.88681141  0.27943560  1
+  C  C2  1  0.22223974  0.48110973  0.08561547  1
+  C  C3  1  0.84027867  1.09820585  0.08541350  1
+  C  C4  1  0.18619470  0.44676013  0.78010205  1
+  C  C5  1  0.78165231  0.04096837  0.58652329  1
+",-154.13585816666668
+4484,C-152585-9341-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.41314000
+_cell_length_b   3.57765000
+_cell_length_c   8.83417000
+_cell_angle_alpha   98.22926000
+_cell_angle_beta   105.80866000
+_cell_angle_gamma   70.22931000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   68.94867922
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.17450239  -0.04433730  0.05889617  1
+  C  C1  1  0.63937988  0.16958779  0.13183652  1
+  C  C2  1  0.52586473  -0.23679139  0.81440235  1
+  C  C3  1  -0.07916017  0.50716822  0.57953850  1
+  C  C4  1  0.44656581  0.59567124  0.15044979  1
+  C  C5  1  -0.11811134  1.04550636  0.31203783  1
+  C  C6  1  0.45680966  0.58754914  0.65661271  1
+  C  C7  1  1.05606580  0.85061559  0.88945278  1
+  C  C8  1  -0.20589956  0.41946164  0.41037277  1
+  C  C9  1  0.52371521  0.76772171  0.31332830  1
+",-154.094255
+3270,C-126165-3752-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48755000
+_cell_length_b   4.30473000
+_cell_length_c   4.30419000
+_cell_angle_alpha   48.19748000
+_cell_angle_beta   73.20760000
+_cell_angle_gamma   73.21980000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.59298725
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.59206168  0.52208542  0.68301947  1
+  C  C1  1  0.92539501  0.18875209  0.34968614  1
+  C  C2  1  0.09212119  0.77197106  0.43313383  1
+  C  C3  1  0.25872835  0.85541876  0.01635280  1
+  C  C4  1  0.75878785  0.10530439  0.76646717  1
+  C  C5  1  0.42545452  0.43863773  0.09980050  1
+",-154.542463
+8898,C-90829-2589-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47335000
+_cell_length_b   4.27984000
+_cell_length_c   5.94086000
+_cell_angle_alpha   43.87145000
+_cell_angle_beta   90.00128000
+_cell_angle_gamma   90.00259000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.58353175
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.18508623  0.88727429  0.49098202  1
+  C  C1  1  0.68508623  0.38727429  0.49098202  1
+  C  C2  1  0.18511399  1.09477212  0.61675560  1
+  C  C3  1  0.68508434  0.76138398  0.11678197  1
+  C  C4  1  0.68511399  0.59477212  0.61675560  1
+  C  C5  1  0.18508434  0.26138398  0.11678197  1
+  C  C6  1  0.68508969  0.22083126  0.99097620  1
+  C  C7  1  0.18508969  0.72083126  -0.00902380  1
+",-154.51904125
+5912,C-172919-5077-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48206000
+_cell_length_b   3.68929000
+_cell_length_c   4.89714000
+_cell_angle_alpha   66.96472000
+_cell_angle_beta   59.53112000
+_cell_angle_gamma   70.33322000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.02527391
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.06151546  0.11224747  0.32002171  1
+  C  C1  1  0.10159548  1.02543920  0.82402649  1
+  C  C2  1  0.35300783  0.26859393  0.45083405  1
+  C  C3  1  0.39163941  0.18257957  0.95493592  1
+  C  C4  1  0.07757524  0.66657897  0.52651145  1
+  C  C5  1  0.37541528  0.62789146  0.74846888  1
+",-154.31305416666666
+6213,C-53836-3159-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47238000
+_cell_length_b   3.23404000
+_cell_length_c   5.92457000
+_cell_angle_alpha   60.38159000
+_cell_angle_beta   77.96362000
+_cell_angle_gamma   67.50853000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   38.03817578
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.11352314  0.66080212  0.56140890  1
+  C  C1  1  0.61231851  0.81667169  0.40813662  1
+  C  C2  1  0.13367787  0.36058997  0.81550739  1
+  C  C3  1  0.80380356  0.65171791  0.18662638  1
+  C  C4  1  0.44269520  0.37115804  0.19033789  1
+  C  C5  1  0.63415143  0.20607088  -0.03120508  1
+",-154.2275235
+3434,C-170900-9651-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.53377000
+_cell_length_b   3.76743000
+_cell_length_c   5.05225000
+_cell_angle_alpha   89.83436000
+_cell_angle_beta   90.16697000
+_cell_angle_gamma   90.02002000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.22736454
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.24468046  0.56893216  0.50120730  1
+  C  C1  1  0.74671469  0.46198199  0.66124846  1
+  C  C2  1  0.74215608  0.26358777  0.12362599  1
+  C  C3  1  0.74482082  0.58654391  0.93836822  1
+  C  C4  1  0.24440653  0.96688448  0.50222428  1
+  C  C5  1  0.74640661  0.07321546  0.66190070  1
+  C  C6  1  0.24262608  0.26498366  0.29369873  1
+  C  C7  1  0.74442004  0.94288266  0.93864982  1
+",-154.1285925
+6719,C-177276-5156-51,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45362000
+_cell_length_b   5.10131000
+_cell_length_c   4.16413000
+_cell_angle_alpha   105.58784000
+_cell_angle_beta   89.98620000
+_cell_angle_gamma   104.00379000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.59478377
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17869338  0.45514387  0.76435669  1
+  C  C1  1  0.61329754  0.32451000  0.22725768  1
+  C  C2  1  1.14135621  0.38195595  0.43048683  1
+  C  C3  1  0.40609913  -0.07139531  0.67715977  1
+  C  C4  1  0.70716959  0.51278827  0.96756166  1
+  C  C5  1  0.44102791  0.98565443  1.04241964  1
+  C  C6  1  0.87355654  0.85167806  0.15021797  1
+  C  C7  1  -0.10332458  -0.09188465  0.51579597  1
+",-154.16843125
+8527,C-76014-6220-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48310000
+_cell_length_b   6.80843000
+_cell_length_c   6.86855000
+_cell_angle_alpha   118.05787000
+_cell_angle_beta   94.76989000
+_cell_angle_gamma   107.79772000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   93.94280121
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.27287119  0.67645396  0.21391504  1
+  C  C1  1  0.63089458  0.52366579  1.15757898  1
+  C  C2  1  0.05955170  0.44455158  0.67521850  1
+  C  C3  1  0.54727221  0.12103078  -0.02246164  1
+  C  C4  1  0.49138653  0.41438297  0.31573233  1
+  C  C5  1  0.35718474  0.76854131  0.58472500  1
+  C  C6  1  -0.56315694  0.30234727  0.68567502  1
+  C  C7  1  0.24892802  0.70073329  0.86731058  1
+  C  C8  1  0.36832250  0.86884749  0.80421016  1
+  C  C9  1  0.14790898  0.15830076  0.13474235  1
+  C  C10  1  0.49924525  0.88935723  0.45983960  1
+  C  C11  1  1.02336544  0.98437813  0.21579902  1
+  C  C12  1  0.13384541  1.03827951  0.47295565  1
+  C  C13  1  0.52054899  0.30724033  0.91519649  1
+  C  C14  1  0.36499834  0.82147811  0.11125326  1
+  C  C15  1  1.09799906  0.49648061  0.46810757  1
+",-154.08443875
+9137,C-130530-3416-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49038000
+_cell_length_b   3.59333000
+_cell_length_c   4.35266000
+_cell_angle_alpha   95.70329000
+_cell_angle_beta   73.38735000
+_cell_angle_gamma   110.32623000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.00083485
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87920076  0.56534866  0.42383646  1
+  C  C1  1  1.16788284  0.93502934  0.21794952  1
+  C  C2  1  0.06124571  0.30587185  0.80008036  1
+  C  C3  1  0.24923005  0.30570074  0.42392299  1
+  C  C4  1  0.77448098  0.93531180  1.00559526  1
+  C  C5  1  0.69230697  0.56576851  0.79965271  1
+",-154.19507000000002
+4113,C-13655-7913-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48738000
+_cell_length_b   3.51526000
+_cell_length_c   4.97388000
+_cell_angle_alpha   90.00253000
+_cell_angle_beta   89.99241000
+_cell_angle_gamma   90.00311000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.49054888
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.35185204  0.63751553  1.05319996  1
+  C  C1  1  0.35186353  0.63754420  0.55311052  1
+  C  C2  1  0.35185035  0.88748389  0.30320061  1
+  C  C3  1  0.85180964  0.38744125  0.05320011  1
+  C  C4  1  0.85188669  0.13747870  0.30321091  1
+  C  C5  1  0.85190424  0.13758683  0.80311103  1
+  C  C6  1  0.35186184  0.88751256  0.80311117  1
+  C  C7  1  -0.14817281  0.38754939  0.55310023  1
+",-154.54544
+183,C-34643-7107-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.03142000
+_cell_length_b   4.20089000
+_cell_length_c   6.42224000
+_cell_angle_alpha   130.91369000
+_cell_angle_beta   111.27823000
+_cell_angle_gamma   80.35911000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.30457838
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.57394011  0.77357268  0.53760149  1
+  C  C1  1  0.57394011  0.27357268  0.03760149  1
+  C  C2  1  0.57228856  0.35679137  0.28722711  1
+  C  C3  1  0.57394011  1.02357268  0.28760149  1
+  C  C4  1  0.57394011  0.52357268  0.78760149  1
+  C  C5  1  0.57228856  0.60679137  0.03722711  1
+  C  C6  1  0.57228856  0.85679137  0.78722711  1
+  C  C7  1  0.57228856  1.10679137  0.53722711  1
+",-154.4391475
+169,C-142789-7601-61,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47510000
+_cell_length_b   4.21090000
+_cell_length_c   6.93151000
+_cell_angle_alpha   96.22356000
+_cell_angle_beta   79.70200000
+_cell_angle_gamma   89.98990000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   70.64618562
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.25266139  0.16953681  0.17314665  1
+  C  C1  1  1.00573628  0.90627934  0.66696836  1
+  C  C2  1  0.76749249  0.65200273  0.14458770  1
+  C  C3  1  0.86782253  0.47417482  0.94570628  1
+  C  C4  1  0.22772980  0.83079367  0.22167158  1
+  C  C5  1  0.36641638  0.25628770  -0.05166070  1
+  C  C6  1  0.47459059  0.09392495  0.72788190  1
+  C  C7  1  0.96705328  0.58148624  0.74427992  1
+  C  C8  1  0.61648869  0.52619421  0.44888172  1
+  C  C9  1  0.71385878  0.34833468  0.25014501  1
+  C  C10  1  0.11746283  0.74415388  0.44638371  1
+  C  C11  1  0.51535417  0.41836278  0.64985187  1
+",-154.26590916666666
+6217,C-136251-4147-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.20983000
+_cell_length_b   4.06424000
+_cell_length_c   6.41224000
+_cell_angle_alpha   67.45020000
+_cell_angle_beta   70.86594000
+_cell_angle_gamma   46.76177000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   73.46962621
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.48229076  0.77346812  0.96146304  1
+  C  C1  1  0.68150837  0.77457572  0.56145694  1
+  C  C2  1  0.21694611  -0.22856456  0.16201076  1
+  C  C3  1  0.08184700  0.77402165  0.76164147  1
+  C  C4  1  0.81660775  0.77237622  0.96162522  1
+  C  C5  1  0.88263731  0.77256309  0.16192520  1
+  C  C6  1  0.41608151  0.77291334  0.76178756  1
+  C  C7  1  0.28221936  0.77375260  0.36146963  1
+  C  C8  1  0.61636170  0.77266287  0.36166181  1
+  C  C9  1  1.01588154  -0.22656974  0.56154138  1
+",-154.44814100000002
+7059,C-136214-3679-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49751000
+_cell_length_b   4.44394000
+_cell_length_c   7.74808000
+_cell_angle_alpha   93.24925000
+_cell_angle_beta   90.02508000
+_cell_angle_gamma   106.28981000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   82.39737926
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.10479888  0.29535866  0.79215550  1
+  C  C1  1  -0.09537396  0.90197962  0.29200165  1
+  C  C2  1  0.79468339  0.68251629  0.12254585  1
+  C  C3  1  0.36412304  0.81880795  0.39889577  1
+  C  C4  1  0.64497060  0.38101239  0.54046725  1
+  C  C5  1  0.46558133  1.02356472  0.56347905  1
+  C  C6  1  -0.04466143  1.00139676  0.67650259  1
+  C  C7  1  0.18918159  0.46765826  0.43975609  1
+  C  C8  1  0.89421419  0.88616500  0.97314323  1
+  C  C9  1  0.08678101  0.26255376  0.27585980  1
+  C  C10  1  0.84192407  0.77205923  0.80401889  1
+  C  C11  1  0.05923712  0.21353850  0.97338076  1
+  C  C12  1  0.17988750  0.44900198  0.12003033  1
+  C  C13  1  0.68806326  0.46005539  0.73608502  1
+",-154.18339
+7250,C-40114-7976-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46335000
+_cell_length_b   3.39725000
+_cell_length_c   5.29496000
+_cell_angle_alpha   94.29755000
+_cell_angle_beta   89.99306000
+_cell_angle_gamma   111.27345000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.15850590
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.85138854  0.06602822  0.73011751  1
+  C  C1  1  0.47480900  0.32077794  0.13202571  1
+  C  C2  1  0.70377539  0.77583301  0.20202040  1
+  C  C3  1  0.88050199  1.13099507  1.00614984  1
+  C  C4  1  0.29929005  -0.03326620  0.32779045  1
+  C  C5  1  0.33533994  0.03421596  0.60385679  1
+",-154.16389166666667
+9040,C-134173-4385-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43110000
+_cell_length_b   4.20122000
+_cell_length_c   5.89099000
+_cell_angle_alpha   86.70668000
+_cell_angle_beta   71.32792000
+_cell_angle_gamma   89.75238000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.90083339
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.29216100  0.39599030  0.82370461  1
+  C  C1  1  -0.20780055  0.89599108  0.82367560  1
+  C  C2  1  0.95098671  0.38430852  0.32221922  1
+  C  C3  1  0.44997483  0.21699735  0.32274915  1
+  C  C4  1  0.45094825  0.88430774  0.32224823  1
+  C  C5  1  0.94997518  0.71698533  0.32271753  1
+  C  C6  1  0.29317253  0.06331349  0.82320630  1
+  C  C7  1  0.79317288  0.56330147  0.82317468  1
+",-154.43426875
+9903,C-53830-4868-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50588000
+_cell_length_b   5.56688000
+_cell_length_c   4.67893000
+_cell_angle_alpha   95.67497000
+_cell_angle_beta   89.97395000
+_cell_angle_gamma   63.38463000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.99475955
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17478376  -0.01524912  0.11026714  1
+  C  C1  1  0.45562606  0.70334781  0.93884159  1
+  C  C2  1  0.63262848  1.02702787  0.29207576  1
+  C  C3  1  0.35859266  0.30212232  0.46006858  1
+  C  C4  1  0.37672575  0.28305353  0.78226354  1
+  C  C5  1  1.03720657  0.12134242  0.83556972  1
+  C  C6  1  1.13266166  0.52320909  0.31411332  1
+  C  C7  1  0.31753849  0.83942988  0.66376915  1
+  C  C8  1  0.85969634  0.79742138  0.48219820  1
+  C  C9  1  0.11709323  0.54119732  0.99115628  1
+",-154.239172
+6550,C-41284-7510-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.58986000
+_cell_length_b   4.69109000
+_cell_length_c   4.43564000
+_cell_angle_alpha   57.54825000
+_cell_angle_beta   73.25136000
+_cell_angle_gamma   70.52037000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.86233967
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.04229760  0.58307795  0.20604427  1
+  C  C1  1  0.47610189  1.04146046  0.48039568  1
+  C  C2  1  0.29058881  0.85142675  0.11422670  1
+  C  C3  1  0.45557540  0.37037203  0.12580121  1
+  C  C4  1  0.25875636  0.80742723  0.49213819  1
+  C  C5  1  0.84318809  0.77344914  0.63938601  1
+  C  C6  1  0.90223052  0.44831004  0.60069384  1
+  C  C7  1  0.26822892  0.18063822  0.75992272  1
+  C  C8  1  0.48552928  0.41499875  0.74790296  1
+  C  C9  1  0.70235823  0.63911602  0.03404152  1
+",-154.154773
+2586,C-130499-1826-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.49838000
+_cell_length_b   2.44820000
+_cell_length_c   9.38444000
+_cell_angle_alpha   105.07142000
+_cell_angle_beta   127.09037000
+_cell_angle_gamma   69.55736000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   59.94509427
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.33264742  0.34782078  0.53881175  1
+  C  C1  1  0.24138476  0.83582426  0.98256782  1
+  C  C2  1  0.58165337  0.25241452  0.06903729  1
+  C  C3  1  0.90171458  0.28693267  0.26347421  1
+  C  C4  1  0.51238933  0.87286812  0.65412664  1
+  C  C5  1  0.78531851  0.04474337  0.96347781  1
+  C  C6  1  0.07627423  0.71630363  0.78089103  1
+  C  C7  1  0.33967363  0.08209980  0.77762148  1
+  C  C8  1  0.75060021  0.49169360  0.39341049  1
+  C  C9  1  0.45992585  0.13607865  0.39315328  1
+",-154.081749
+8908,C-127234-5571-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.35369000
+_cell_length_b   5.50489000
+_cell_length_c   6.67325000
+_cell_angle_alpha   88.32629000
+_cell_angle_beta   111.63143000
+_cell_angle_gamma   89.80875000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C20
+_cell_volume   114.46105600
+_cell_formula_units_Z   20
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.85225003  0.05703331  0.80373455  1
+  C  C1  1  0.23842527  1.01175988  0.26893286  1
+  C  C2  1  0.46697413  0.60991345  0.57055044  1
+  C  C3  1  0.64261538  0.06222967  0.96874953  1
+  C  C4  1  0.50059395  0.80918385  0.00368847  1
+  C  C5  1  0.44624299  0.56861872  0.33727483  1
+  C  C6  1  0.68163023  0.57247534  0.96453545  1
+  C  C7  1  0.50269451  0.80215470  0.23189783  1
+  C  C8  1  0.51447941  0.12388501  0.60477944  1
+  C  C9  1  0.63841560  0.13142298  0.41218262  1
+  C  C10  1  1.04289447  0.19256985  0.10404845  1
+  C  C11  1  0.80427657  0.38065948  0.37641380  1
+  C  C12  1  0.92256808  -0.06645918  0.38057968  1
+  C  C13  1  0.23657006  -0.14333678  0.59449348  1
+  C  C14  1  0.24070584  0.42972309  0.82109831  1
+  C  C15  1  0.09045828  0.83212710  0.79426284  1
+  C  C16  1  0.22992576  0.20326218  0.92760149  1
+  C  C17  1  0.98479253  0.43220698  0.19092022  1
+  C  C18  1  -0.12904216  0.60255853  0.78471256  1
+  C  C19  1  0.23790495  0.38048904  0.59573585  1
+",-154.0759085
+1053,C-142751-9264-65,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48453000
+_cell_length_b   3.82251000
+_cell_length_c   5.22690000
+_cell_angle_alpha   98.79853000
+_cell_angle_beta   89.96502000
+_cell_angle_gamma   108.93844000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.33703295
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.15291781  0.99955099  0.68281083  1
+  C  C1  1  0.36771180  0.42756199  0.73947818  1
+  C  C2  1  0.40566301  0.50251851  0.46035205  1
+  C  C3  1  0.64451236  -0.01982707  0.23843687  1
+  C  C4  1  0.03445552  0.75816596  0.13213612  1
+  C  C5  1  0.97807790  0.64997998  0.84532859  1
+  C  C6  1  0.86015578  0.40882505  0.29525356  1
+  C  C7  1  0.60768502  0.90613168  0.51777060  1
+",-154.22292125
+6321,C-13651-5621-55,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43205000
+_cell_length_b   6.16606000
+_cell_length_c   4.09916000
+_cell_angle_alpha   69.90829000
+_cell_angle_beta   88.03215000
+_cell_angle_gamma   87.35881000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.65820980
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.34026915  0.66985500  0.37872369  1
+  C  C1  1  0.84034368  0.41910661  -0.12170521  1
+  C  C2  1  0.84042856  0.58623919  0.54638977  1
+  C  C3  1  0.34030459  0.83687852  0.04665733  1
+  C  C4  1  0.84074101  1.08601927  0.54620999  1
+  C  C5  1  0.84024924  -0.08090680  0.87831301  1
+  C  C6  1  0.34047765  0.33667735  0.04645682  1
+  C  C7  1  0.34062421  1.16952788  0.37843290  1
+",-154.45967125
+1142,C-41276-8743-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.84494000
+_cell_length_b   3.59765000
+_cell_length_c   3.62100000
+_cell_angle_alpha   100.54569000
+_cell_angle_beta   107.19156000
+_cell_angle_gamma   99.28477000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   45.78794060
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.01410760  0.03858665  0.17962472  1
+  C  C1  1  1.01311942  0.03749252  0.55995351  1
+  C  C2  1  0.31754695  0.34646918  0.21247065  1
+  C  C3  1  0.51337265  0.53834919  0.61984133  1
+  C  C4  1  0.81828190  0.84670664  0.77225404  1
+  C  C5  1  0.31853512  0.34756331  0.83214186  1
+",-154.145334
+8120,C-136247-3248-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43132000
+_cell_length_b   3.94554000
+_cell_length_c   4.68605000
+_cell_angle_alpha   95.84200000
+_cell_angle_beta   105.65096000
+_cell_angle_gamma   90.40085000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.03328388
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.18600287  0.15570070  0.63187437  1
+  C  C1  1  0.51855793  0.48633481  0.29675936  1
+  C  C2  1  0.63096258  0.26819234  0.52126346  1
+  C  C3  1  0.85239798  0.82077554  0.96410135  1
+  C  C4  1  -0.03629494  0.59919966  0.18644705  1
+  C  C5  1  0.29724678  -0.06712895  0.85342391  1
+",-154.458703
+4864,C-56520-4842-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43147000
+_cell_length_b   4.46222000
+_cell_length_c   6.02154000
+_cell_angle_alpha   68.44958000
+_cell_angle_beta   92.34417000
+_cell_angle_gamma   75.90192000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.31615845
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79713313  0.60169685  0.61446565  1
+  C  C1  1  0.54707916  0.10181022  0.86436676  1
+  C  C2  1  0.04709765  0.10166001  0.36408870  1
+  C  C3  1  0.63047027  0.93456848  0.44810309  1
+  C  C4  1  0.88044433  0.43468534  0.19799159  1
+  C  C5  1  0.29713290  0.60175801  0.11454694  1
+  C  C6  1  0.38043293  0.43470466  0.69805446  1
+  C  C7  1  0.13044574  0.93471603  -0.05165558  1
+",-154.46211875
+4133,C-145389-5770-57,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.11456000
+_cell_length_b   3.39814000
+_cell_length_c   3.39847000
+_cell_angle_alpha   86.12470000
+_cell_angle_beta   101.47499000
+_cell_angle_gamma   78.52075000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.35057528
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.22118825  0.88898969  0.71081546  1
+  C  C1  1  0.22147792  0.40851413  0.23102963  1
+  C  C2  1  0.45638368  0.59865360  0.03874967  1
+  C  C3  1  0.66692209  0.21543212  0.90406254  1
+  C  C4  1  0.66944638  0.85983332  0.25917322  1
+  C  C5  1  1.01179810  0.27091509  0.84887819  1
+  C  C6  1  0.45661266  0.08027929  0.52081137  1
+  C  C7  1  1.00778421  0.62926447  0.49017262  1
+",-154.32800375
+7475,C-141039-9365-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.48911000
+_cell_length_b   5.85625000
+_cell_length_c   3.45166000
+_cell_angle_alpha   96.76462000
+_cell_angle_beta   91.89887000
+_cell_angle_gamma   117.14554000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   62.02063112
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.54543523  0.67351141  0.54249172  1
+  C  C1  1  0.50751381  0.07140175  0.30121508  1
+  C  C2  1  -0.03040655  0.22772677  0.17752889  1
+  C  C3  1  -0.10407519  0.79204310  0.82902237  1
+  C  C4  1  0.37778140  0.79232220  0.31265245  1
+  C  C5  1  0.18721477  0.07119398  0.98024181  1
+  C  C6  1  1.03415630  0.64596251  0.02813769  1
+  C  C7  1  0.92560939  0.38127795  0.87161008  1
+  C  C8  1  0.25414538  0.39009643  0.55280670  1
+  C  C9  1  0.46882335  0.22946929  0.67566220  1
+",-154.260571
+3174,C-157724-4895-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48093000
+_cell_length_b   3.68899000
+_cell_length_c   4.21754000
+_cell_angle_alpha   75.26980000
+_cell_angle_beta   89.90877000
+_cell_angle_gamma   70.37890000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.01412639
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.69123429  0.11214154  0.67907477  1
+  C  C1  1  0.43076478  0.62920546  0.10723224  1
+  C  C2  1  0.11303769  0.26843799  0.81041458  1
+  C  C3  1  0.91199208  0.66703274  0.88524919  1
+  C  C4  1  0.22973993  0.02726990  0.18265280  1
+  C  C5  1  0.65107994  0.18460556  0.31356972  1
+",-154.31047366666667
+7902,C-73657-5503-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48947000
+_cell_length_b   5.19399000
+_cell_length_c   5.97010000
+_cell_angle_alpha   78.28075000
+_cell_angle_beta   65.32324000
+_cell_angle_gamma   89.99785000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   68.37083640
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46202953  0.60486586  0.80907305  1
+  C  C1  1  0.78937591  1.00282732  0.48266964  1
+  C  C2  1  0.56523412  0.42330671  0.20617730  1
+  C  C3  1  0.12726712  0.32127365  0.64403934  1
+  C  C4  1  0.27165681  0.09351854  1.00197298  1
+  C  C5  1  0.83780042  -0.05281924  -0.06450947  1
+  C  C6  1  0.77622759  0.70643295  0.49853899  1
+  C  C7  1  0.81936538  0.65159922  -0.04853459  1
+  C  C8  1  0.04376225  0.22901338  0.22836996  1
+  C  C9  1  0.14660576  0.05022493  0.62495053  1
+  C  C10  1  0.48053567  0.33359751  0.79037468  1
+  C  C11  1  0.34347583  0.56062328  0.43171240  1
+",-154.18108416666666
+1559,C-73621-2756-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43117000
+_cell_length_b   4.02019000
+_cell_length_c   6.72959000
+_cell_angle_alpha   107.89057000
+_cell_angle_beta   112.26937000
+_cell_angle_gamma   89.22281000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.52790353
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.54786896  0.54745443  0.67096594  1
+  C  C1  1  0.46550592  0.37943922  1.08852231  1
+  C  C2  1  0.04786896  0.54745443  0.17096594  1
+  C  C3  1  0.21550592  0.87943922  0.33852231  1
+  C  C4  1  0.71550592  0.87943922  0.83852231  1
+  C  C5  1  0.29786896  0.04745443  0.92096594  1
+  C  C6  1  0.79786896  0.04745443  0.42096594  1
+  C  C7  1  -0.03449408  0.37943922  0.58852231  1
+",-154.46688125
+6774,C-184062-776-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48075000
+_cell_length_b   3.68593000
+_cell_length_c   4.20831000
+_cell_angle_alpha   104.34641000
+_cell_angle_beta   89.97031000
+_cell_angle_gamma   70.37089000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.96555449
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.16174488  0.53301309  0.63846404  1
+  C  C1  1  0.70435217  0.45095532  0.13547680  1
+  C  C2  1  0.48030324  0.89544591  0.34145945  1
+  C  C3  1  0.96177119  0.93225994  0.56497771  1
+  C  C4  1  0.28240089  0.29449239  0.26757052  1
+  C  C5  1  0.73962994  0.37638356  0.77031338  1
+",-154.3036455
+8199,C-193960-2739-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47564000
+_cell_length_b   4.24875000
+_cell_length_c   4.24803000
+_cell_angle_alpha   51.94175000
+_cell_angle_beta   89.99309000
+_cell_angle_gamma   89.99554000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.18220576
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.05107933  0.53122488  0.40499178  1
+  C  C1  1  1.05116300  0.37416896  0.83999741  1
+  C  C2  1  0.55109305  0.48492298  0.95054612  1
+  C  C3  1  1.05103394  0.93936110  -0.00317830  1
+  C  C4  1  0.55121921  0.32810446  0.38537632  1
+  C  C5  1  0.55120626  0.91989342  0.79348647  1
+",-154.29087833333332
+2145,C-134213-109-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43876000
+_cell_length_b   4.68727000
+_cell_length_c   4.69112000
+_cell_angle_alpha   112.78290000
+_cell_angle_beta   74.85116000
+_cell_angle_gamma   105.11055000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.95026522
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.04976449  0.38159480  0.63161056  1
+  C  C1  1  0.13887456  0.49963715  0.37048551  1
+  C  C2  1  0.63439441  1.06673638  -0.05482310  1
+  C  C3  1  0.29198805  -0.13991574  0.42504988  1
+  C  C4  1  0.89356840  0.59388344  0.95550915  1
+  C  C5  1  0.79167341  0.03737757  0.60221347  1
+  C  C6  1  0.69236109  0.39096986  0.15710010  1
+  C  C7  1  0.44608337  0.80699414  1.06475673  1
+",-154.16575625
+1598,C-141031-4766-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51329000
+_cell_length_b   4.18541000
+_cell_length_c   4.18729000
+_cell_angle_alpha   121.18916000
+_cell_angle_beta   72.49256000
+_cell_angle_gamma   107.43099000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.37252054
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20223154  0.73538377  0.62881615  1
+  C  C1  1  0.20247510  0.36724839  0.26023709  1
+  C  C2  1  1.01000842  0.02269510  0.30390068  1
+  C  C3  1  0.81316391  -0.02144140  0.64825454  1
+  C  C4  1  1.00949893  0.69168011  0.97303498  1
+  C  C5  1  0.81329580  0.34734014  0.01705397  1
+",-154.23239433333333
+4390,C-172953-2094-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.54737000
+_cell_length_b   3.55648000
+_cell_length_c   5.74124000
+_cell_angle_alpha   99.07265000
+_cell_angle_beta   89.43831000
+_cell_angle_gamma   135.84393000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.37430380
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.75863926  0.57385498  0.16620080  1
+  C  C1  1  0.91030436  0.23201479  0.48178601  1
+  C  C2  1  0.33358235  0.15107846  0.32055222  1
+  C  C3  1  0.60977902  0.92249160  0.86196821  1
+  C  C4  1  0.18203321  0.49369974  0.00522972  1
+  C  C5  1  0.48117600  0.80289293  0.62426224  1
+",-154.28278366666666
+3276,C-170904-2880-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48762000
+_cell_length_b   4.30393000
+_cell_length_c   6.57859000
+_cell_angle_alpha   77.38650000
+_cell_angle_beta   79.09577000
+_cell_angle_gamma   73.19825000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   65.19818495
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.75882368  0.34155211  0.72782960  1
+  C  C1  1  0.92522330  0.71678183  1.01887686  1
+  C  C2  1  0.75807593  0.84168965  0.22785360  1
+  C  C3  1  0.25803431  0.71675098  0.35278681  1
+  C  C4  1  0.42532860  0.84174595  0.89392757  1
+  C  C5  1  0.42506863  0.34198743  0.39393983  1
+  C  C6  1  1.09172230  0.84184644  0.56072833  1
+  C  C7  1  0.59191854  0.71673932  0.68562548  1
+  C  C8  1  0.09191999  0.34173094  1.06070762  1
+  C  C9  1  0.25886484  0.21650414  0.85275107  1
+  C  C10  1  0.92517963  0.21691845  0.51886957  1
+  C  C11  1  0.59180374  0.21683225  0.18563928  1
+",-154.543545
+2324,C-73655-1582-59,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.25852000
+_cell_length_b   4.85391000
+_cell_length_c   4.85721000
+_cell_angle_alpha   60.07230000
+_cell_angle_beta   97.70516000
+_cell_angle_gamma   70.14192000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.11705081
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.29875581  0.78110063  0.90372478  1
+  C  C1  1  0.29882220  0.78106981  0.40374412  1
+  C  C2  1  0.30026406  0.11375931  0.23751155  1
+  C  C3  1  1.29873892  0.28110050  0.40372239  1
+  C  C4  1  0.30019768  0.11379013  0.73749221  1
+  C  C5  1  1.30027126  0.61375767  0.23750818  1
+  C  C6  1  0.30028096  0.61375944  0.73751394  1
+  C  C7  1  0.29874862  0.28110227  0.90372815  1
+",-154.452355
+4443,C-107760-8155-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49331000
+_cell_length_b   4.24757000
+_cell_length_c   7.18132000
+_cell_angle_alpha   104.65946000
+_cell_angle_beta   90.02952000
+_cell_angle_gamma   72.97184000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   70.12945547
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63094327  0.57063333  0.77192668  1
+  C  C1  1  0.57054193  0.68554363  0.58922543  1
+  C  C2  1  1.34750021  0.14152151  0.08768208  1
+  C  C3  1  -0.04187107  0.91181789  0.59567464  1
+  C  C4  1  0.95996263  0.91496914  0.08111606  1
+  C  C5  1  0.71599515  0.39431035  0.40140550  1
+  C  C6  1  1.28791821  0.25583855  0.90425086  1
+  C  C7  1  0.89098631  1.04224762  0.42303702  1
+  C  C8  1  0.10038616  0.63449222  0.89819547  1
+  C  C9  1  -0.18160531  0.19237899  0.77850584  1
+  C  C10  1  0.20137454  0.43279659  0.27512486  1
+  C  C11  1  0.02570839  0.78513149  0.25434484  1
+",-154.19602333333333
+5759,C-107764-2694-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43054000
+_cell_length_b   4.27635000
+_cell_length_c   6.16303000
+_cell_angle_alpha   109.23409000
+_cell_angle_beta   100.00403000
+_cell_angle_gamma   99.06392000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.95174908
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.37140364  0.22931937  0.42546577  1
+  C  C1  1  0.03830812  0.56183321  1.09222319  1
+  C  C2  1  0.78873733  0.06183939  0.34289010  1
+  C  C3  1  0.53823284  0.56194390  0.59196001  1
+  C  C4  1  1.12182563  0.72909688  0.67649592  1
+  C  C5  1  0.87145706  0.22911475  0.92585321  1
+  C  C6  1  0.28877568  1.06164171  0.84317297  1
+  C  C7  1  0.62185600  0.72907128  0.17659683  1
+",-154.44907875
+361,C-152571-7702-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.47125000
+_cell_length_b   3.53775000
+_cell_length_c   4.28772000
+_cell_angle_alpha   88.66901000
+_cell_angle_beta   116.37234000
+_cell_angle_gamma   107.19691000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.58372711
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.07970606  0.67483467  0.57407072  1
+  C  C1  1  -0.14104472  0.90043067  0.32215997  1
+  C  C2  1  0.72416071  0.71644666  0.92947584  1
+  C  C3  1  0.24982526  0.47410816  0.18538007  1
+  C  C4  1  0.12571164  0.32276415  0.45154001  1
+  C  C5  1  0.50353562  0.94209722  0.67750117  1
+  C  C6  1  0.53332900  0.89701895  0.34625385  1
+  C  C7  1  0.33312801  0.14183294  0.06617665  1
+  C  C8  1  0.45740002  0.29392332  0.80020208  1
+  C  C9  1  1.04978891  0.71958565  0.90536954  1
+",-154.16128
+8239,C-13935-8914-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.32627000
+_cell_length_b   3.31764000
+_cell_length_c   7.24980000
+_cell_angle_alpha   102.26808000
+_cell_angle_beta   54.22755000
+_cell_angle_gamma   101.01206000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   63.20313819
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.25383350  0.43354564  0.48899290  1
+  C  C1  1  0.44384264  -0.02313925  0.71477004  1
+  C  C2  1  0.77324828  0.32811577  0.07723167  1
+  C  C3  1  -0.09213981  0.10259828  0.85160412  1
+  C  C4  1  0.80652075  0.34012703  0.71478691  1
+  C  C5  1  0.54474182  0.73957441  0.85155171  1
+  C  C6  1  0.57730041  0.75781578  0.48895908  1
+  C  C7  1  0.33889932  0.20925862  0.28317571  1
+  C  C8  1  1.09668075  0.65139719  0.07751448  1
+  C  C9  1  1.01021474  0.87919342  0.28334298  1
+",-154.257937
+9244,C-90835-6350-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48897000
+_cell_length_b   4.94635000
+_cell_length_c   6.09361000
+_cell_angle_alpha   69.29316000
+_cell_angle_beta   78.19399000
+_cell_angle_gamma   89.94272000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   68.48087796
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.42328261  0.08287312  0.42555761  1
+  C  C1  1  0.28717836  -0.01682578  0.69651773  1
+  C  C2  1  0.58034834  0.94407888  0.11302963  1
+  C  C3  1  0.78656502  0.47460709  0.69815592  1
+  C  C4  1  0.74022882  0.77583487  0.78921872  1
+  C  C5  1  0.60767096  0.67713179  0.05998276  1
+  C  C6  1  0.24115368  0.28488715  0.78796886  1
+  C  C7  1  0.45010645  0.81482286  0.37386828  1
+  C  C8  1  0.03542955  0.53443292  0.20405548  1
+  C  C9  1  0.92245421  0.63615800  0.42961290  1
+  C  C10  1  0.99464427  0.22494332  0.28233092  1
+  C  C11  1  1.10878042  0.12365569  0.05632029  1
+",-154.21362416666668
+1098,C-137385-5334-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.57800000
+_cell_length_b   5.87500000
+_cell_length_c   4.87679000
+_cell_angle_alpha   114.66320000
+_cell_angle_beta   105.48747000
+_cell_angle_gamma   88.21324000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C20
+_cell_volume   114.38807737
+_cell_formula_units_Z   20
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.81532000  0.92066816  0.50770789  1
+  C  C1  1  0.49946716  0.80901288  0.96304019  1
+  C  C2  1  -0.07591612  0.18684311  0.24862470  1
+  C  C3  1  1.04412899  0.74151880  0.55100357  1
+  C  C4  1  0.48961583  0.39207373  0.99936431  1
+  C  C5  1  -0.07121028  0.18943103  0.74982350  1
+  C  C6  1  1.03424194  0.73660475  0.05917317  1
+  C  C7  1  1.06346621  0.56907519  0.22670315  1
+  C  C8  1  0.26475226  0.16399274  0.24123782  1
+  C  C9  1  0.49340217  0.39197330  0.48832215  1
+  C  C10  1  0.35167845  -0.09289318  0.72452544  1
+  C  C11  1  0.04722273  0.58214152  0.72716572  1
+  C  C12  1  -0.15191111  0.34264615  0.55649889  1
+  C  C13  1  0.32388904  0.90202000  0.20066316  1
+  C  C14  1  0.26884488  1.16518463  0.90493605  1
+  C  C15  1  0.39943968  0.52608075  0.78889211  1
+  C  C16  1  0.82540193  0.32784900  0.04536655  1
+  C  C17  1  0.49806904  0.83655746  0.46170741  1
+  C  C18  1  0.41569820  0.54905919  0.30306964  1
+  C  C19  1  0.80981801  0.91422690  0.16704919  1
+",-154.343354
+7404,C-13669-3058-56,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48478000
+_cell_length_b   4.67763000
+_cell_length_c   4.08658000
+_cell_angle_alpha   83.34325000
+_cell_angle_beta   89.99948000
+_cell_angle_gamma   105.39529000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.46125442
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.16155740  0.52895970  0.16707627  1
+  C  C1  1  0.16759603  0.18661212  0.87247615  1
+  C  C2  1  0.38088749  0.61512972  0.33620212  1
+  C  C3  1  0.66883180  0.18840634  1.09803089  1
+  C  C4  1  0.55097646  0.95675583  0.40468734  1
+  C  C5  1  0.05194063  0.95933019  0.62995499  1
+  C  C6  1  0.32207942  0.50086947  0.69185458  1
+  C  C7  1  0.89397627  0.64491074  0.81145526  1
+",-154.3667825
+5953,C-76008-2415-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50750000
+_cell_length_b   4.82869000
+_cell_length_c   8.19963000
+_cell_angle_alpha   103.78026000
+_cell_angle_beta   94.57414000
+_cell_angle_gamma   75.33838000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   93.26319838
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.77964720  0.41062801  0.70692676  1
+  C  C1  1  0.02085690  0.98217252  0.27169649  1
+  C  C2  1  0.16041791  0.65332600  0.18341732  1
+  C  C3  1  0.68553251  0.70732282  0.79115443  1
+  C  C4  1  1.28638796  0.46711055  0.31340510  1
+  C  C5  1  0.04907800  0.01517347  0.46018875  1
+  C  C6  1  0.75314691  0.19741215  0.79391673  1
+  C  C7  1  0.79562582  0.25598973  -0.01922651  1
+  C  C8  1  0.42926301  0.13815787  0.22475630  1
+  C  C9  1  0.39390637  0.10551818  0.03660834  1
+  C  C10  1  0.88646316  0.33017578  0.53816365  1
+  C  C11  1  0.64821934  0.86385299  0.51589198  1
+  C  C12  1  0.70038920  0.92080456  0.70263297  1
+  C  C13  1  0.55695306  0.78977031  0.95857414  1
+  C  C14  1  -0.33615677  0.58366568  0.07056309  1
+  C  C15  1  0.78227613  0.53622709  0.42594466  1
+",-154.287376875
+7949,C-113094-8253-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46583000
+_cell_length_b   5.92786000
+_cell_length_c   5.81064000
+_cell_angle_alpha   110.03075000
+_cell_angle_beta   102.24323000
+_cell_angle_gamma   102.03705000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   74.23505297
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.68284140  0.93901871  0.93748818  1
+  C  C1  1  0.23184945  0.07640869  0.89967829  1
+  C  C2  1  0.02790822  0.48172891  0.08250271  1
+  C  C3  1  0.04509992  0.99787644  0.60658180  1
+  C  C4  1  0.44349179  0.35569169  0.03711346  1
+  C  C5  1  0.78409526  0.89878332  0.18213598  1
+  C  C6  1  0.63437347  0.29529263  0.48787053  1
+  C  C7  1  0.82937734  0.54189565  0.63016829  1
+  C  C8  1  0.03570683  0.14706940  0.43799730  1
+  C  C9  1  0.23310139  0.76089171  0.21920739  1
+  C  C10  1  0.43006428  0.69038256  0.68138209  1
+  C  C11  1  0.41927885  0.83960068  0.51288607  1
+",-154.28049333333334
+10084,C-152585-9341-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43734000
+_cell_length_b   4.22672000
+_cell_length_c   6.53071000
+_cell_angle_alpha   85.05014000
+_cell_angle_beta   100.73581000
+_cell_angle_gamma   89.96801000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   65.84543089
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.26308370  0.43881295  0.97458829  1
+  C  C1  1  0.80939466  0.57928256  1.07006024  1
+  C  C2  1  0.61001960  0.00270513  0.64933235  1
+  C  C3  1  0.29270295  0.09213491  0.03847732  1
+  C  C4  1  0.59688489  0.35590604  0.63271886  1
+  C  C5  1  0.11693467  0.84360959  0.66546720  1
+  C  C6  1  0.79797938  0.93293045  1.05170480  1
+  C  C7  1  0.47643707  0.44751082  0.40216023  1
+  C  C8  1  -0.07376494  0.48607898  0.29953725  1
+  C  C9  1  0.14377452  0.49592978  0.72882925  1
+",-154.27730400000002
+4283,C-56510-2784-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48453000
+_cell_length_b   6.56135000
+_cell_length_c   4.68115000
+_cell_angle_alpha   46.72384000
+_cell_angle_beta   105.38260000
+_cell_angle_gamma   79.07609000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.45960359
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.58890464  0.13278751  0.53481880  1
+  C  C1  1  0.37860498  0.07165565  1.05400007  1
+  C  C2  1  0.92575935  0.95284950  1.02909808  1
+  C  C3  1  -0.03483965  0.42742765  0.58271090  1
+  C  C4  1  0.33902010  0.59714036  0.49954331  1
+  C  C5  1  0.86379951  0.35880695  0.31050365  1
+  C  C6  1  0.44178372  0.66477165  0.77258656  1
+  C  C7  1  0.71648206  0.89092043  0.54877662  1
+",-154.36636
+9165,C-106102-5152-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46993000
+_cell_length_b   7.65675000
+_cell_length_c   8.10645000
+_cell_angle_alpha   74.66128000
+_cell_angle_beta   88.21489000
+_cell_angle_gamma   60.38473000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C22
+_cell_volume   127.62160785
+_cell_formula_units_Z   22
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.10397990  0.37309939  0.17301483  1
+  C  C1  1  0.61824046  -0.03595732  0.35929576  1
+  C  C2  1  0.34164436  0.15457933  0.21538975  1
+  C  C3  1  0.29194430  0.18182178  0.59135899  1
+  C  C4  1  0.63204991  0.61632331  0.61881009  1
+  C  C5  1  0.58456790  0.32223686  0.55569634  1
+  C  C6  1  0.37840485  0.78187627  0.99657675  1
+  C  C7  1  -0.51616438  0.34760687  0.86320500  1
+  C  C8  1  0.32132214  0.51342607  0.39250000  1
+  C  C9  1  0.45469689  0.06210808  0.78224287  1
+  C  C10  1  0.33033925  0.47914738  0.67851350  1
+  C  C11  1  0.15849596  0.92492063  0.11037367  1
+  C  C12  1  0.28875369  0.85204297  0.31398146  1
+  C  C13  1  0.17203799  0.92119986  0.80929003  1
+  C  C14  1  0.44387759  1.06362157  1.07252737  1
+  C  C15  1  0.63128589  0.63150765  0.41973187  1
+  C  C16  1  0.19931673  0.46209887  -0.01201890  1
+  C  C17  1  0.21474673  0.20452773  0.89390779  1
+  C  C18  1  0.08190847  0.65000480  1.03739282  1
+  C  C19  1  0.40241783  0.48511627  0.21720458  1
+  C  C20  1  1.28788170  -0.15278799  0.63844993  1
+  C  C21  1  0.61387425  -0.03359227  0.54332729  1
+",-154.15953454545453
+5118,C-41314-763-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52424000
+_cell_length_b   4.66428000
+_cell_length_c   4.97247000
+_cell_angle_alpha   83.89953000
+_cell_angle_beta   90.09840000
+_cell_angle_gamma   90.06242000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.21303472
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.96683866  0.63896136  0.89776305  1
+  C  C1  1  0.46633172  0.09579038  0.99077788  1
+  C  C2  1  0.46539829  0.26577109  0.70940621  1
+  C  C3  1  -0.03446005  0.61230766  0.39265410  1
+  C  C4  1  0.46608252  0.98869643  0.57246786  1
+  C  C5  1  0.96555979  -0.06293469  0.41095659  1
+  C  C6  1  0.96565696  0.44514182  0.66892479  1
+  C  C7  1  0.96692234  0.14707067  0.15227847  1
+  C  C8  1  0.96706579  0.47130895  0.17476326  1
+  C  C9  1  0.46703318  0.81820513  0.85562160  1
+",-154.251378
+5059,C-72740-7131-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45011000
+_cell_length_b   3.96104000
+_cell_length_c   4.55182000
+_cell_angle_alpha   86.86687000
+_cell_angle_beta   74.32795000
+_cell_angle_gamma   90.02935000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.46412143
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.98831218  0.44783371  0.69668160  1
+  C  C1  1  0.30647222  0.77022474  0.06313050  1
+  C  C2  1  0.71213551  0.25061802  0.25139589  1
+  C  C3  1  0.55542693  0.38136090  0.56179134  1
+  C  C4  1  0.83523864  0.58267795  0.00621226  1
+  C  C5  1  0.24135382  0.06490287  0.19263152  1
+",-154.26652933333335

--- a/data/ocp/train.csv
+++ b/data/ocp/train.csv
@@ -1,0 +1,25559 @@
+,material_id,cif,energy_per_atom
+9251,C-130499-1826-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48053000
+_cell_length_b   5.09056000
+_cell_length_c   4.89497000
+_cell_angle_alpha   57.97521000
+_cell_angle_beta   59.51109000
+_cell_angle_gamma   43.04559000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99453900
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.01706897  0.71072668  0.70544499  1
+  C  C1  1  0.68025235  0.06989044  1.00318540  1
+  C  C2  1  0.14234414  0.62471612  0.20939241  1
+  C  C3  1  0.34433233  0.10871703  0.78081493  1
+  C  C4  1  -0.11663885  0.55405962  0.57440517  1
+  C  C5  1  0.00817595  0.46805771  0.07810120  1
+",-154.3118905
+6412,C-13904-4247-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48986000
+_cell_length_b   4.65679000
+_cell_length_c   5.94592000
+_cell_angle_alpha   90.03290000
+_cell_angle_beta   77.93642000
+_cell_angle_gamma   57.67568000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.44264567
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63628756  0.17653474  0.74659929  1
+  C  C1  1  0.07535339  0.47745056  0.26783806  1
+  C  C2  1  0.47656240  0.62130397  0.17699556  1
+  C  C3  1  0.06673747  -0.03265767  0.30664321  1
+  C  C4  1  0.46932917  0.11075260  0.21501637  1
+  C  C5  1  0.76118709  0.95179661  0.94805867  1
+  C  C6  1  0.03982870  0.87451288  0.54687266  1
+  C  C7  1  0.90702757  0.41074852  0.73684904  1
+  C  C8  1  0.78466636  0.63535708  0.53492922  1
+  C  C9  1  0.50570438  0.71315951  0.93646533  1
+",-154.332183
+3301,C-92138-4782-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44168000
+_cell_length_b   4.79849000
+_cell_length_c   5.95909000
+_cell_angle_alpha   119.73602000
+_cell_angle_beta   101.56104000
+_cell_angle_gamma   75.51457000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.45546221
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.56087068  0.98174403  0.47974027  1
+  C  C1  1  -0.00468803  0.20581332  0.57242993  1
+  C  C2  1  0.10601614  0.54447837  0.11818192  1
+  C  C3  1  0.24636631  0.94304704  0.81685708  1
+  C  C4  1  1.35930436  0.00018133  0.08565585  1
+  C  C5  1  0.27834010  0.35580160  0.27822078  1
+  C  C6  1  0.82177471  0.43862322  0.45647310  1
+  C  C7  1  1.09775665  0.28398424  0.84967659  1
+  C  C8  1  0.52976238  0.76893040  0.19162340  1
+  C  C9  1  0.73345471  0.79690556  0.64274427  1
+",-154.178157
+4777,C-192672-505-73,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47518000
+_cell_length_b   4.18933000
+_cell_length_c   11.18377000
+_cell_angle_alpha   100.54005000
+_cell_angle_beta   77.38712000
+_cell_angle_gamma   89.87842000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C20
+_cell_volume   111.15331676
+_cell_formula_units_Z   20
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.99425098  -0.05270840  0.87298760  1
+  C  C1  1  0.20780895  0.98257598  0.48645625  1
+  C  C2  1  0.55903991  0.76830293  0.66196963  1
+  C  C3  1  0.98045613  0.87377968  0.21382739  1
+  C  C4  1  0.54531871  0.40571605  0.62029106  1
+  C  C5  1  0.70048026  0.20680529  0.48557149  1
+  C  C6  1  0.14597751  0.31635265  0.87666066  1
+  C  C7  1  0.70956686  -0.05319318  1.01440936  1
+  C  C8  1  0.55630748  0.78170833  0.80820666  1
+  C  C9  1  0.97056021  0.28574060  0.67845460  1
+  C  C10  1  -0.07019528  0.23869702  0.25287497  1
+  C  C11  1  -0.20381595  0.43478246  0.39097401  1
+  C  C12  1  0.08176142  0.93163262  0.62383187  1
+  C  C13  1  1.13574889  0.44150227  1.01530047  1
+  C  C14  1  0.70770196  0.42040658  0.81350039  1
+  C  C15  1  0.47735730  0.36638362  0.19963017  1
+  C  C16  1  1.29694166  0.66063079  0.39252762  1
+  C  C17  1  0.14328388  0.80094160  1.06294396  1
+  C  C18  1  0.60348283  0.30110751  0.06362084  1
+  C  C19  1  0.43587779  0.71862349  0.25595082  1
+",-154.309339
+3764,C-193956-5355-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.39500000
+_cell_length_b   4.81978000
+_cell_length_c   3.65211000
+_cell_angle_alpha   112.26885000
+_cell_angle_beta   128.35152000
+_cell_angle_gamma   77.74360000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.34806182
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.35890301  0.71636072  -0.04863116  1
+  C  C1  1  0.35903523  0.41031263  0.67934984  1
+  C  C2  1  0.35837196  0.21649154  0.89199672  1
+  C  C3  1  0.35956628  -0.08981820  0.73872197  1
+  C  C4  1  0.35652350  0.41000961  0.29657729  1
+  C  C5  1  0.36141474  0.71666373  0.33414139  1
+",-154.14183549999998
+9492,C-176661-8591-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.17840000
+_cell_length_b   4.67784000
+_cell_length_c   4.67703000
+_cell_angle_alpha   77.42149000
+_cell_angle_beta   89.78550000
+_cell_angle_gamma   90.21686000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   89.22094520
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79319063  0.75164920  0.50167715  1
+  C  C1  1  0.92914556  0.01359753  1.23955906  1
+  C  C2  1  0.29882896  1.00669402  0.24672037  1
+  C  C3  1  0.43484571  -0.00660858  0.93996386  1
+  C  C4  1  0.42363742  0.76146923  0.49182577  1
+  C  C5  1  -0.21426580  0.28554450  0.30859291  1
+  C  C6  1  0.36825967  0.29477952  0.77952112  1
+  C  C7  1  0.93591250  0.47736558  0.43605272  1
+  C  C8  1  0.78567653  0.94405452  -0.03227782  1
+  C  C9  1  0.28790823  0.77196915  0.80058604  1
+  C  C10  1  0.28791864  0.45300393  0.48067330  1
+  C  C11  1  0.36841926  0.47322437  0.95859398  1
+  C  C12  1  0.43496050  0.31287983  0.25987177  1
+  C  C13  1  -0.06412471  0.81644950  0.77597978  1
+",-154.19794285714286
+1138,C-177252-751-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43246000
+_cell_length_b   7.19986000
+_cell_length_c   6.61497000
+_cell_angle_alpha   48.50971000
+_cell_angle_beta   89.98176000
+_cell_angle_gamma   90.01706000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   86.77982369
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40261223  0.01807284  1.04725383  1
+  C  C1  1  -0.09739547  0.07391724  0.10248974  1
+  C  C2  1  0.40265280  0.35139691  0.38048140  1
+  C  C3  1  0.90267751  0.85139371  0.88048986  1
+  C  C4  1  0.90244280  0.18441847  0.21416081  1
+  C  C5  1  -0.09740558  0.51813482  0.54721643  1
+  C  C6  1  0.90238827  0.74072587  -0.23076476  1
+  C  C7  1  0.40268026  -0.09238242  0.93549619  1
+  C  C8  1  0.40258565  0.57401109  0.60241192  1
+  C  C9  1  0.40237900  0.68444962  0.71413438  1
+  C  C10  1  0.40244503  0.24074398  0.26921995  1
+  C  C11  1  -0.09735208  0.40763976  0.43548095  1
+",-154.45401
+2373,C-170900-9651-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50566000
+_cell_length_b   4.79040000
+_cell_length_c   5.85223000
+_cell_angle_alpha   80.64259000
+_cell_angle_beta   84.75947000
+_cell_angle_gamma   78.56324000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.80708353
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.08518132  0.42152882  0.49143519  1
+  C  C1  1  0.51293181  0.55044378  0.06567351  1
+  C  C2  1  1.01513524  0.41468154  0.74991714  1
+  C  C3  1  0.52406816  0.77846661  0.20318916  1
+  C  C4  1  0.43829299  0.57697684  0.81668329  1
+  C  C5  1  0.11408789  0.09959496  0.87850026  1
+  C  C6  1  0.58762462  0.28583830  0.17628415  1
+  C  C7  1  0.29095733  0.89079217  0.69808539  1
+  C  C8  1  0.66169676  0.25930284  0.42477088  1
+  C  C9  1  0.57257741  1.05746080  0.03991210  1
+  C  C10  1  0.98220076  0.73641704  0.36422617  1
+  C  C11  1  0.80345800  0.94564431  0.54456226  1
+",-154.24175416666665
+797,C-130544-211-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51187000
+_cell_length_b   4.11132000
+_cell_length_c   4.19172000
+_cell_angle_alpha   119.40794000
+_cell_angle_beta   107.68747000
+_cell_angle_gamma   89.97152000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.34653644
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.88337144  -0.01253937  -0.06422459  1
+  C  C1  1  0.69344258  0.64316186  0.54808990  1
+  C  C2  1  0.88375561  0.31824804  0.93622004  1
+  C  C3  1  0.07853375  0.03151198  0.32403354  1
+  C  C4  1  0.69374621  0.27459721  0.54827215  1
+  C  C5  1  0.07865101  0.66282007  0.32457766  1
+",-154.230684
+4936,C-136247-3248-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42598000
+_cell_length_b   4.21658000
+_cell_length_c   4.21834000
+_cell_angle_alpha   89.81438000
+_cell_angle_beta   90.09485000
+_cell_angle_gamma   90.02212000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.15054012
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.11835710  0.85251298  0.04028423  1
+  C  C1  1  1.11845508  0.26260183  0.63447763  1
+  C  C2  1  0.61829350  0.76611122  0.54451852  1
+  C  C3  1  0.61860782  0.82417919  0.19597045  1
+  C  C4  1  0.11855651  0.91403223  0.69252010  1
+  C  C5  1  0.61841519  0.41828915  0.60603087  1
+",-154.31424083333334
+5113,C-76016-983-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48323000
+_cell_length_b   5.01052000
+_cell_length_c   4.05185000
+_cell_angle_alpha   113.84982000
+_cell_angle_beta   101.04279000
+_cell_angle_gamma   85.59381000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.25552491
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.65287413  0.17231346  1.02348198  1
+  C  C1  1  0.84135427  0.69688931  0.20675196  1
+  C  C2  1  0.34146157  0.88861297  0.30232728  1
+  C  C3  1  0.20614060  0.17242783  0.25442291  1
+  C  C4  1  0.02317843  0.69666059  0.59591900  1
+  C  C5  1  0.52337639  0.88825382  0.69153013  1
+  C  C6  1  0.15214374  0.41290596  0.64353932  1
+  C  C7  1  0.70552068  0.41309976  0.87472784  1
+",-154.0695325
+8674,C-170888-2365-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49384000
+_cell_length_b   6.33553000
+_cell_length_c   4.21185000
+_cell_angle_alpha   49.57982000
+_cell_angle_beta   106.80393000
+_cell_angle_gamma   92.38066000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.51722070
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.26492476  0.37765370  -0.10238934  1
+  C  C1  1  0.46680058  0.34972112  0.28721479  1
+  C  C2  1  0.09679529  0.63260396  0.42676769  1
+  C  C3  1  0.45547303  0.62873460  0.19055833  1
+  C  C4  1  0.10210604  0.16327286  0.58257971  1
+  C  C5  1  1.14259414  -0.11235612  0.36597416  1
+  C  C6  1  0.21064563  0.88372132  0.71305188  1
+  C  C7  1  0.21196503  0.13086785  0.97355498  1
+",-154.112675
+776,C-141037-8469-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48146000
+_cell_length_b   3.68878000
+_cell_length_c   4.83759000
+_cell_angle_alpha   111.45597000
+_cell_angle_beta   104.85401000
+_cell_angle_gamma   109.66537000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98263957
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.54426967  0.58392061  -0.04551283  1
+  C  C1  1  1.21388278  0.28760396  0.58967780  1
+  C  C2  1  0.22925589  0.52670183  0.38291244  1
+  C  C3  1  0.25358016  -0.12859349  0.08531528  1
+  C  C4  1  0.50542073  1.00005146  0.45902031  1
+  C  C5  1  0.52817407  0.34495373  0.16107770  1
+",-154.30918283333332
+9407,C-157689-1881-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.11693000
+_cell_length_b   3.64860000
+_cell_length_c   4.81011000
+_cell_angle_alpha   112.15257000
+_cell_angle_beta   80.92832000
+_cell_angle_gamma   119.47547000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.08059748
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.11421540  0.13809637  0.99097078  1
+  C  C1  1  1.11143792  0.98449638  0.68480813  1
+  C  C2  1  0.11168754  0.57708035  0.49037524  1
+  C  C3  1  0.11128873  -0.07596283  0.18466237  1
+  C  C4  1  0.11436459  0.19855558  0.49111654  1
+  C  C5  1  1.11396578  0.54551239  0.18540367  1
+",-154.12132333333332
+8451,C-72730-1850-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42797000
+_cell_length_b   3.73386000
+_cell_length_c   4.81223000
+_cell_angle_alpha   96.60006000
+_cell_angle_beta   103.00715000
+_cell_angle_gamma   87.80120000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.22164306
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.16679949  0.19748271  0.96848991  1
+  C  C1  1  0.61225275  0.64270755  0.52475659  1
+  C  C2  1  0.49986617  0.86411551  0.30181068  1
+  C  C3  1  0.27892165  0.30940177  0.85810626  1
+  C  C4  1  0.94559006  -0.02395254  0.19142323  1
+  C  C5  1  0.16653887  0.53080319  0.63515903  1
+",-154.42057016666666
+156,C-41262-9862-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.67304000
+_cell_length_b   4.83440000
+_cell_length_c   4.87821000
+_cell_angle_alpha   112.53999000
+_cell_angle_beta   98.61853000
+_cell_angle_gamma   112.08562000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   69.62372542
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.18072049  0.31998879  0.01901675  1
+  C  C1  1  0.83962607  1.00855925  0.36834599  1
+  C  C2  1  1.14311238  0.34730364  0.52604264  1
+  C  C3  1  0.62274136  0.85513097  0.52500986  1
+  C  C4  1  0.31822407  0.51622492  0.36698641  1
+  C  C5  1  0.10439814  0.78801861  0.94425118  1
+  C  C6  1  0.28205759  0.54565798  0.87426150  1
+  C  C7  1  0.73852007  0.81404976  0.01679910  1
+  C  C8  1  0.72390126  0.05172457  0.87694868  1
+  C  C9  1  0.35580527  0.07579562  0.94647670  1
+",-154.147016
+774,C-76050-9799-65,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47199000
+_cell_length_b   4.15251000
+_cell_length_c   5.79723000
+_cell_angle_alpha   69.34630000
+_cell_angle_beta   64.87265000
+_cell_angle_gamma   90.01300000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.61759872
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.22825086  0.64699967  0.65526818  1
+  C  C1  1  0.67380098  0.43867165  0.71019758  1
+  C  C2  1  0.17384708  0.43850681  0.20996870  1
+  C  C3  1  0.84661767  0.19713386  0.53778559  1
+  C  C4  1  0.72832608  0.64671159  1.15496727  1
+  C  C5  1  0.79101223  0.98834501  0.09290385  1
+  C  C6  1  0.29149592  0.98873015  0.59265382  1
+  C  C7  1  0.34620018  0.19670605  0.03799280  1
+",-154.17215625
+8328,C-130538-6665-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44414000
+_cell_length_b   6.06030000
+_cell_length_c   7.21977000
+_cell_angle_alpha   99.10146000
+_cell_angle_beta   99.73600000
+_cell_angle_gamma   66.12052000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   95.89936901
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.33838512  0.85709877  0.16998172  1
+  C  C1  1  0.14873352  0.29525297  0.67886855  1
+  C  C2  1  0.84186816  0.24387039  0.95200616  1
+  C  C3  1  0.69324913  0.78021114  0.73473345  1
+  C  C4  1  0.43503675  0.20973416  0.06839786  1
+  C  C5  1  -0.03115874  0.54546457  0.81685280  1
+  C  C6  1  0.40773206  0.39792759  0.40098439  1
+  C  C7  1  0.56140352  0.51159374  0.93307287  1
+  C  C8  1  0.59259948  0.58927355  0.14611897  1
+  C  C9  1  0.25394033  0.45779219  0.20638431  1
+  C  C10  1  0.71074387  -0.02583692  0.15008633  1
+  C  C11  1  0.06520767  0.89647250  0.71393771  1
+  C  C12  1  -0.00699958  0.35415958  0.48418196  1
+  C  C13  1  -0.18983778  0.16430416  0.73913391  1
+",-154.27591214285715
+276,C-47644-8979-61,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42980000
+_cell_length_b   5.36077000
+_cell_length_c   7.45187000
+_cell_angle_alpha   84.83628000
+_cell_angle_beta   70.92882000
+_cell_angle_gamma   89.92150000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   91.32464801
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.88363235  0.28110706  0.59084580  1
+  C  C1  1  0.21093395  0.58034653  0.76333496  1
+  C  C2  1  0.40753032  0.54700948  0.06233863  1
+  C  C3  1  0.38761073  0.27556407  0.07776941  1
+  C  C4  1  0.88007909  0.87889832  0.08972441  1
+  C  C5  1  0.27751797  0.77280355  0.19460388  1
+  C  C6  1  0.78051988  0.49499067  0.69424803  1
+  C  C7  1  0.42441235  0.16617375  0.55063307  1
+  C  C8  1  0.09085909  0.85802939  0.38665949  1
+  C  C9  1  0.52548016  0.94807313  0.45244570  1
+  C  C10  1  -0.10442600  0.15142874  0.06978590  1
+  C  C11  1  0.01263641  0.65485341  0.95809762  1
+",-154.07433333333333
+3973,C-41262-9862-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49028000
+_cell_length_b   3.59355000
+_cell_length_c   4.35454000
+_cell_angle_alpha   84.29282000
+_cell_angle_beta   73.40105000
+_cell_angle_gamma   69.70179000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.02552446
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.52085800  0.21190059  0.93295444  1
+  C  C1  1  0.80703185  0.84248548  0.72730293  1
+  C  C2  1  0.62495027  0.58331102  0.35107459  1
+  C  C3  1  -0.00529257  0.84310728  0.35137413  1
+  C  C4  1  0.91365790  0.21240454  0.14527793  1
+  C  C5  1  0.43802485  0.58260800  0.72697958  1
+",-154.19843133333333
+3309,C-130532-5775-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51161000
+_cell_length_b   4.11307000
+_cell_length_c   4.19018000
+_cell_angle_alpha   119.39622000
+_cell_angle_beta   107.61574000
+_cell_angle_gamma   89.99932000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.36490942
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.60501894  0.73126181  0.82055281  1
+  C  C1  1  0.41216723  0.38684919  0.43234869  1
+  C  C2  1  0.21863125  0.34318025  0.04438963  1
+  C  C3  1  0.41230394  0.05682131  0.43266800  1
+  C  C4  1  0.21877726  0.71259788  1.04460296  1
+  C  C5  1  0.60502138  0.10043147  0.82064872  1
+",-154.2306565
+7596,C-176689-6597-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.63337000
+_cell_length_b   3.27351000
+_cell_length_c   3.27022000
+_cell_angle_alpha   80.81783000
+_cell_angle_beta   75.45314000
+_cell_angle_gamma   75.45300000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.24798648
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.93258729  0.15582344  0.75352579  1
+  C  C1  1  0.93272446  0.47247014  0.43617498  1
+  C  C2  1  0.31410658  0.52771653  0.16843057  1
+  C  C3  1  0.55120517  0.10057706  1.02127020  1
+  C  C4  1  0.55109854  0.73898052  0.38209415  1
+  C  C5  1  0.31421322  0.88931307  0.80760661  1
+",-154.202455
+2363,C-113078-2193-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45451000
+_cell_length_b   4.38792000
+_cell_length_c   5.17379000
+_cell_angle_alpha   52.14461000
+_cell_angle_beta   89.57146000
+_cell_angle_gamma   90.36451000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.99108543
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.47821987  0.08686824  0.02109644  1
+  C  C1  1  0.13420491  0.00971924  0.62852870  1
+  C  C2  1  0.63069642  0.39509552  0.07849970  1
+  C  C3  1  0.80647425  0.59245680  0.53168486  1
+  C  C4  1  0.65735801  0.76119553  0.71313138  1
+  C  C5  1  0.16172569  0.37582342  0.26345269  1
+  C  C6  1  -0.01777937  0.17740432  0.81095523  1
+  C  C7  1  0.31038512  0.68327433  0.32142789  1
+",-154.08797875
+1908,C-152605-7685-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43889000
+_cell_length_b   4.22919000
+_cell_length_c   6.52569000
+_cell_angle_alpha   90.13684000
+_cell_angle_beta   100.68330000
+_cell_angle_gamma   90.00136000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   66.14254110
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.90222510  0.22504225  0.48741675  1
+  C  C1  1  0.57455918  0.26720125  0.82278752  1
+  C  C2  1  0.23713271  0.37911711  0.14612965  1
+  C  C3  1  -0.10994271  0.87419979  0.47399507  1
+  C  C4  1  0.35684713  0.37809938  0.39412979  1
+  C  C5  1  1.02365681  0.26753779  0.71851834  1
+  C  C6  1  0.38431740  0.71732841  0.46014381  1
+  C  C7  1  0.70249086  0.87537851  1.06967905  1
+  C  C8  1  0.20696560  0.71834289  0.08112104  1
+  C  C9  1  0.69207801  0.22555293  1.05300398  1
+",-154.255816
+977,C-142789-7601-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50785000
+_cell_length_b   3.41812000
+_cell_length_c   9.62215000
+_cell_angle_alpha   84.73247000
+_cell_angle_beta   97.52798000
+_cell_angle_gamma   68.46338000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   75.18201078
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.03867874  0.33403379  0.34475501  1
+  C  C1  1  0.98891218  0.54215000  0.60891333  1
+  C  C2  1  0.65587142  0.54162692  0.94223582  1
+  C  C3  1  0.52064746  0.66149588  0.78729889  1
+  C  C4  1  0.32251608  0.54187437  0.27557418  1
+  C  C5  1  0.54819177  0.86937115  0.05138234  1
+  C  C6  1  1.29475697  0.33361917  0.01138890  1
+  C  C7  1  -0.11880716  0.86995398  0.71808935  1
+  C  C8  1  0.85410052  0.66147524  0.45395616  1
+  C  C9  1  -0.37224407  0.33423364  0.67808463  1
+  C  C10  1  0.18760851  0.66101292  0.12061614  1
+  C  C11  1  0.21473089  0.86979183  0.38472195  1
+",-154.125035
+5535,C-177264-2024-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47126000
+_cell_length_b   5.31271000
+_cell_length_c   4.80980000
+_cell_angle_alpha   111.27787000
+_cell_angle_beta   120.76299000
+_cell_angle_gamma   89.66479000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.27297022
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.01746276  0.92102745  0.83938254  1
+  C  C1  1  0.58820944  0.54233068  0.90938731  1
+  C  C2  1  1.08842092  0.04324393  0.41030329  1
+  C  C3  1  0.86450534  0.47399737  0.18620200  1
+  C  C4  1  0.43571089  0.09623186  0.25770985  1
+  C  C5  1  0.51776826  0.42129097  0.33912821  1
+  C  C6  1  0.93606584  0.59633990  0.75748528  1
+  C  C7  1  0.36482445  0.97487633  0.68718923  1
+",-154.17584375
+3463,C-9592-5537-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.39360000
+_cell_length_b   3.40154000
+_cell_length_c   4.11528000
+_cell_angle_alpha   78.54631000
+_cell_angle_beta   101.45376000
+_cell_angle_gamma   86.12945000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.34772403
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.12342705  0.11810136  0.69483105  1
+  C  C1  1  0.54945731  -0.07426961  0.14012894  1
+  C  C2  1  0.13743113  0.33855025  0.48156147  1
+  C  C3  1  0.90690034  0.56987060  0.14340713  1
+  C  C4  1  0.68652824  0.30862785  0.93057186  1
+  C  C5  1  0.35825140  0.59776245  0.69561494  1
+  C  C6  1  0.49393858  0.98077987  0.48494394  1
+  C  C7  1  0.16680686  0.79052083  0.92984247  1
+",-154.32579
+1024,C-104334-7299-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.55084000
+_cell_length_b   3.65341000
+_cell_length_c   8.99029000
+_cell_angle_alpha   74.89331000
+_cell_angle_beta   71.89721000
+_cell_angle_gamma   97.70929000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   133.34229324
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.69715622  0.45883803  0.10662051  1
+  C  C1  1  0.36400768  0.45861071  1.10730885  1
+  C  C2  1  0.46576170  0.08916152  0.74856577  1
+  C  C3  1  0.30547962  0.87594567  0.55320593  1
+  C  C4  1  0.25197055  0.34458555  -0.01040111  1
+  C  C5  1  0.13475778  0.56655750  0.22608524  1
+  C  C6  1  0.25491871  0.66768747  0.34067213  1
+  C  C7  1  0.58686636  0.79794469  0.47357166  1
+  C  C8  1  0.57070043  0.66611871  0.34071077  1
+  C  C9  1  0.81354625  0.86316053  0.53653321  1
+  C  C10  1  0.94649243  0.08942864  0.74886934  1
+  C  C11  1  0.48481859  0.23164164  0.87868044  1
+  C  C12  1  0.74511629  1.00460949  0.67082489  1
+  C  C13  1  0.10517327  0.79617683  0.47381355  1
+  C  C14  1  0.92506527  0.34443707  -0.01018283  1
+  C  C15  1  0.80108973  0.23037883  0.87859238  1
+  C  C16  1  0.23756911  1.02029962  0.68672008  1
+  C  C17  1  0.80756412  0.56647390  0.22629237  1
+",-154.22624444444443
+7053,C-92124-4005-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48102000
+_cell_length_b   3.69022000
+_cell_length_c   4.84442000
+_cell_angle_alpha   57.39669000
+_cell_angle_beta   75.08440000
+_cell_angle_gamma   70.28780000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.01402748
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.99287221  0.16938553  0.59180199  1
+  C  C1  1  0.21640632  0.93006948  0.38508743  1
+  C  C2  1  0.67365445  0.51359079  -0.11114006  1
+  C  C3  1  0.79491836  0.64246743  0.51597110  1
+  C  C4  1  0.25190759  0.22579397  1.01992680  1
+  C  C5  1  0.47309007  -0.01320871  0.81347274  1
+",-154.31160483333335
+8881,C-176661-8591-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48158000
+_cell_length_b   3.68816000
+_cell_length_c   4.21960000
+_cell_angle_alpha   74.95060000
+_cell_angle_beta   89.90189000
+_cell_angle_gamma   70.34620000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.96643919
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.58046399  0.96052700  0.67035304  1
+  C  C1  1  0.32167891  0.47363038  0.09910335  1
+  C  C2  1  0.10105063  0.91909000  0.89251246  1
+  C  C3  1  -0.21967324  0.56307086  0.59461386  1
+  C  C4  1  0.90026049  0.31626849  -0.03118258  1
+  C  C5  1  0.35871702  0.40631797  0.46404628  1
+",-154.30967266666667
+5577,C-72701-1899-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.94928000
+_cell_length_b   4.83750000
+_cell_length_c   5.76354000
+_cell_angle_alpha   66.20084000
+_cell_angle_beta   100.36573000
+_cell_angle_gamma   88.36475000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   73.54019299
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.57842633  0.51213477  0.40732071  1
+  C  C1  1  0.57815889  1.02996390  0.40775161  1
+  C  C2  1  0.09773855  0.75452786  0.92143511  1
+  C  C3  1  1.09690548  0.27291573  0.92171017  1
+  C  C4  1  0.69234028  0.71525011  0.51908603  1
+  C  C5  1  0.34197569  0.24331578  0.16386971  1
+  C  C6  1  0.95315292  0.58872613  0.77313667  1
+  C  C7  1  0.34119977  0.54121078  0.16383642  1
+  C  C8  1  0.72085129  0.19606392  0.55636265  1
+  C  C9  1  0.98150579  1.06936413  0.81040263  1
+",-154.252398
+7859,C-176679-1286-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48762000
+_cell_length_b   2.48761000
+_cell_length_c   6.57671000
+_cell_angle_alpha   67.74614000
+_cell_angle_beta   79.08109000
+_cell_angle_gamma   59.98402000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.61513352
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46708030  0.10725876  0.67448971  1
+  C  C1  1  0.13377176  0.85703362  0.59132662  1
+  C  C2  1  0.80018282  0.10664325  0.00837469  1
+  C  C3  1  0.46674999  0.85686302  -0.07520888  1
+  C  C4  1  -0.19927706  0.85621419  0.25853033  1
+  C  C5  1  1.13411407  0.10673965  0.34137762  1
+",-154.54276683333333
+2612,C-102915-7408-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43087000
+_cell_length_b   4.07727000
+_cell_length_c   6.79703000
+_cell_angle_alpha   108.95263000
+_cell_angle_beta   115.18719000
+_cell_angle_gamma   86.84643000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.38427488
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.78863023  0.22551465  0.16954705  1
+  C  C1  1  0.37096980  0.39307742  0.25201049  1
+  C  C2  1  0.53869831  0.72548263  0.41959815  1
+  C  C3  1  0.28863037  0.22552845  0.66955432  1
+  C  C4  1  0.62082166  0.89318283  1.00191881  1
+  C  C5  1  0.12097873  -0.10694214  0.50202528  1
+  C  C6  1  0.87087893  0.39314297  0.75194982  1
+  C  C7  1  0.03856247  0.72557199  0.91947359  1
+",-154.46037
+8770,C-76008-2415-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46312000
+_cell_length_b   4.98771000
+_cell_length_c   6.69667000
+_cell_angle_alpha   63.38295000
+_cell_angle_beta   100.60575000
+_cell_angle_gamma   90.01410000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   71.97822352
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.02824500  0.49754651  1.05410030  1
+  C  C1  1  0.79252910  0.33325730  0.58996074  1
+  C  C2  1  0.54325481  0.30605213  1.08618810  1
+  C  C3  1  0.11549445  0.62722283  0.22857425  1
+  C  C4  1  0.90574759  0.77411958  0.81255089  1
+  C  C5  1  0.34260108  0.80047129  0.68534324  1
+  C  C6  1  0.47684661  0.10383101  -0.04233451  1
+  C  C7  1  0.91153350  0.10817505  0.82723777  1
+  C  C8  1  0.65878325  1.00691573  0.32115281  1
+  C  C9  1  0.59423718  0.81911947  0.18627376  1
+  C  C10  1  0.23541546  0.40850730  0.47623295  1
+  C  C11  1  0.22603676  0.95067618  0.45649700  1
+",-154.24742
+9096,C-90796-891-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.67808000
+_cell_length_b   3.78465000
+_cell_length_c   4.29654000
+_cell_angle_alpha   89.15994000
+_cell_angle_beta   124.47009000
+_cell_angle_gamma   107.39485000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.67952891
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.81820730  0.42412962  0.82661591  1
+  C  C1  1  0.31271126  0.39857520  0.79747989  1
+  C  C2  1  0.63010809  0.95415530  0.35163111  1
+  C  C3  1  0.31314477  -0.04831183  0.34532746  1
+  C  C4  1  0.62931336  0.70845501  0.10950123  1
+  C  C5  1  -0.05338127  0.26432790  0.66344398  1
+  C  C6  1  0.44112171  0.23928728  0.63400049  1
+  C  C7  1  0.94628498  0.71123422  0.11563493  1
+",-154.200935
+1426,C-96663-8819-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43911000
+_cell_length_b   4.22873000
+_cell_length_c   6.52398000
+_cell_angle_alpha   89.76256000
+_cell_angle_beta   79.23673000
+_cell_angle_gamma   90.00714000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   66.10610632
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55893839  0.81465623  0.42468030  1
+  C  C1  1  0.37001429  0.81412757  0.83026440  1
+  C  C2  1  0.05356641  0.65726197  0.43759507  1
+  C  C3  1  0.69246088  1.20914817  0.18001211  1
+  C  C4  1  0.87461232  0.65669943  0.81855549  1
+  C  C5  1  0.02577512  0.31815265  0.50462884  1
+  C  C6  1  1.24358957  0.20827779  0.07624658  1
+  C  C7  1  1.36018365  0.16449387  0.84585087  1
+  C  C8  1  0.57137050  0.16553264  0.41127040  1
+  C  C9  1  0.90573767  0.31810697  0.75240374  1
+",-154.254901
+1464,C-96672-9795-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48312000
+_cell_length_b   3.63064000
+_cell_length_c   7.32306000
+_cell_angle_alpha   119.73560000
+_cell_angle_beta   90.00217000
+_cell_angle_gamma   89.99920000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.32644926
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.31601881  0.22227665  0.42734609  1
+  C  C1  1  0.31620638  -0.08769405  0.85644225  1
+  C  C2  1  0.81643169  0.23147119  0.67565623  1
+  C  C3  1  0.81656819  0.53996403  0.24555852  1
+  C  C4  1  0.81628508  0.15118624  0.85638086  1
+  C  C5  1  0.31644080  -0.14903743  0.05100106  1
+  C  C6  1  0.81652961  0.60106090  0.05076808  1
+  C  C7  1  0.31648281  0.30074839  0.24562904  1
+  C  C8  1  0.31636388  0.47116909  0.67547509  1
+  C  C9  1  0.81600444  0.98219329  0.42720908  1
+",-154.297055
+2694,C-9620-6892-54,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.97913000
+_cell_length_b   4.30411000
+_cell_length_c   4.84998000
+_cell_angle_alpha   84.72388000
+_cell_angle_beta   82.11366000
+_cell_angle_gamma   67.72619000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.95009472
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.03346921  0.89106805  0.18119230  1
+  C  C1  1  -0.03351914  0.89111166  0.68119429  1
+  C  C2  1  0.80087814  1.05843123  0.93084283  1
+  C  C3  1  0.30034783  0.55834022  0.18089994  1
+  C  C4  1  0.80092151  0.05842970  0.43084662  1
+  C  C5  1  0.46658944  0.39114941  0.43117503  1
+  C  C6  1  0.46651463  0.39113067  -0.06882509  1
+  C  C7  1  0.30036509  0.55833126  0.68089287  1
+",-154.42720125
+7011,C-176685-9184-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.64211000
+_cell_length_b   3.42975000
+_cell_length_c   4.83023000
+_cell_angle_alpha   122.66702000
+_cell_angle_beta   67.64276000
+_cell_angle_gamma   119.87714000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.52543017
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.84921735  0.78794674  0.41328311  1
+  C  C1  1  0.06388854  0.79101878  0.60444975  1
+  C  C2  1  0.12022403  0.78955785  0.10635909  1
+  C  C3  1  0.46515835  0.78829436  0.41428018  1
+  C  C4  1  0.90539763  0.78646740  0.91533298  1
+  C  C5  1  0.50391530  -0.21145083  0.10532448  1
+",-154.120246
+3289,C-73631-2702-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.08656000
+_cell_length_b   3.99484000
+_cell_length_c   5.58715000
+_cell_angle_alpha   82.23913000
+_cell_angle_beta   119.85025000
+_cell_angle_gamma   108.51357000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.63704826
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.21826036  0.81225444  0.05080529  1
+  C  C1  1  0.55353832  0.14317803  0.05047994  1
+  C  C2  1  0.71599869  0.81263833  0.55039130  1
+  C  C3  1  0.30252110  0.64329926  0.30044653  1
+  C  C4  1  0.05108856  0.14356170  0.55010658  1
+  C  C5  1  0.96755443  0.31247957  0.30070866  1
+  C  C6  1  0.46750481  0.31228959  0.80028820  1
+  C  C7  1  0.80297264  0.64316457  0.80017580  1
+",-154.43651875
+3172,C-96682-5217-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.66152000
+_cell_length_b   4.20260000
+_cell_length_c   4.19798000
+_cell_angle_alpha   119.97028000
+_cell_angle_beta   128.05131000
+_cell_angle_gamma   77.81593000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.62007579
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87642591  0.94850359  0.37901821  1
+  C  C1  1  0.87650932  0.94860529  0.71226102  1
+  C  C2  1  0.87649919  0.61520394  0.71241442  1
+  C  C3  1  0.87655529  0.61524347  1.04566373  1
+  C  C4  1  0.87657645  0.28185780  0.04578496  1
+  C  C5  1  -0.12343617  0.28190731  0.37902096  1
+",-154.42605233333333
+8983,C-53820-5674-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48481000
+_cell_length_b   4.17460000
+_cell_length_c   6.17730000
+_cell_angle_alpha   90.00153000
+_cell_angle_beta   113.90048000
+_cell_angle_gamma   90.02744000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.58304229
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36760491  0.42038617  0.00421938  1
+  C  C1  1  0.99887373  0.92489925  0.13433945  1
+  C  C2  1  0.87510880  0.54996554  0.50739682  1
+  C  C3  1  -0.00117348  0.55175180  0.13448336  1
+  C  C4  1  0.13478508  0.90062238  0.77167262  1
+  C  C5  1  0.25376762  0.42152924  0.38703553  1
+  C  C6  1  0.25402147  1.05469130  0.38709069  1
+  C  C7  1  0.36744519  1.05598958  1.00398586  1
+  C  C8  1  0.87533459  0.92536438  0.50750288  1
+  C  C9  1  0.13441899  0.57372355  0.77159231  1
+",-154.193535
+6199,C-157717-1262-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45217000
+_cell_length_b   3.33250000
+_cell_length_c   9.40976000
+_cell_angle_alpha   84.21950000
+_cell_angle_beta   90.02416000
+_cell_angle_gamma   68.20707000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   70.97703715
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.69993234  0.39822751  0.51914710  1
+  C  C1  1  0.26962565  0.25804683  0.15136095  1
+  C  C2  1  0.18997613  0.41916403  0.59058301  1
+  C  C3  1  0.71936631  0.35261274  0.37043618  1
+  C  C4  1  0.38258021  1.02920019  0.85795303  1
+  C  C5  1  0.17878823  0.44299674  0.74364729  1
+  C  C6  1  0.23453631  0.32235426  0.29881695  1
+  C  C7  1  0.78837047  0.22077837  0.08083238  1
+  C  C8  1  0.60092242  0.59697786  0.81400217  1
+  C  C9  1  0.80435744  0.18425607  0.92830814  1
+",-154.252138
+6095,C-176654-3153-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44808000
+_cell_length_b   5.85555000
+_cell_length_c   5.58182000
+_cell_angle_alpha   59.76776000
+_cell_angle_beta   77.30729000
+_cell_angle_gamma   65.25587000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   62.78054799
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.16492569  0.67288595  0.40396470  1
+  C  C1  1  0.99244764  0.23897247  0.95732259  1
+  C  C2  1  0.27923904  -0.05092921  0.96335238  1
+  C  C3  1  0.88762095  0.90988130  0.82456273  1
+  C  C4  1  0.80153324  0.55447531  0.70769680  1
+  C  C5  1  0.33195732  1.18655079  0.38364084  1
+  C  C6  1  -0.16276940  0.11259339  0.52322131  1
+  C  C7  1  1.17450632  0.62033656  0.82995958  1
+  C  C8  1  0.36560783  0.30446362  0.08011516  1
+  C  C9  1  0.32961754  0.74665332  0.26471171  1
+",-154.18036
+444,C-9646-232-63,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48462000
+_cell_length_b   4.67780000
+_cell_length_c   4.08675000
+_cell_angle_alpha   96.68474000
+_cell_angle_beta   89.99540000
+_cell_angle_gamma   105.44199000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.44884141
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.95462696  0.31320961  0.17978933  1
+  C  C1  1  0.89581376  1.19685370  0.82426397  1
+  C  C2  1  0.72443822  0.85602522  0.89253576  1
+  C  C3  1  0.11351364  0.62768258  0.36149619  1
+  C  C4  1  0.38194913  0.16900744  0.29862719  1
+  C  C5  1  0.44016504  0.28321786  0.65454386  1
+  C  C6  1  0.61224341  0.62491724  0.58620233  1
+  C  C7  1  0.22371475  0.85445124  0.11907298  1
+",-154.36781375
+1738,C-152587-3980-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.27774000
+_cell_length_b   3.27937000
+_cell_length_c   5.56821000
+_cell_angle_alpha   89.67002000
+_cell_angle_beta   89.66048000
+_cell_angle_gamma   81.14487000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   59.13711060
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.93800840  0.75941582  0.68796444  1
+  C  C1  1  0.90931639  0.72894424  0.21946963  1
+  C  C2  1  0.66445872  0.48615636  0.83076775  1
+  C  C3  1  0.29790836  0.39882771  0.68770205  1
+  C  C4  1  0.44764700  1.22197514  0.45406986  1
+  C  C5  1  0.18034814  0.00297649  0.07709044  1
+  C  C6  1  0.02626404  0.12584504  0.83082615  1
+  C  C7  1  0.27118054  0.36846050  0.21941047  1
+  C  C8  1  0.76436451  -0.09419608  0.45407461  1
+  C  C9  1  0.54148449  0.64255767  0.07671688  1
+",-154.26037300000002
+4238,C-177280-5724-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45885000
+_cell_length_b   5.77600000
+_cell_length_c   7.55007000
+_cell_angle_alpha   60.07500000
+_cell_angle_beta   81.91673000
+_cell_angle_gamma   87.22127000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   91.98005120
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.44593431  -0.06552987  0.62838081  1
+  C  C1  1  0.51669965  0.36873193  0.44617516  1
+  C  C2  1  0.54323841  0.15769989  0.39283401  1
+  C  C3  1  0.96768910  0.33046886  0.57156947  1
+  C  C4  1  0.58268692  0.64148874  0.27881649  1
+  C  C5  1  0.09432735  0.20876244  0.26139802  1
+  C  C6  1  0.21769733  0.50038475  0.06541702  1
+  C  C7  1  0.60029778  0.13218188  1.01008179  1
+  C  C8  1  0.97883563  0.60353715  0.56822326  1
+  C  C9  1  0.42645954  0.43559895  0.89669660  1
+  C  C10  1  0.69604330  0.65827879  0.07320797  1
+  C  C11  1  0.07918236  0.04973163  0.15944855  1
+  C  C12  1  0.45110910  0.64366400  0.67052503  1
+  C  C13  1  0.90108029  1.02292128  0.70874032  1
+  C  C14  1  0.73155361  -0.05258326  0.92293674  1
+  C  C15  1  1.05017684  0.75963124  0.31764407  1
+",-154.08288375
+2200,C-90811-1769-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.30757000
+_cell_length_b   4.27802000
+_cell_length_c   7.10948000
+_cell_angle_alpha   54.14623000
+_cell_angle_beta   61.20890000
+_cell_angle_gamma   73.85797000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   71.45564493
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76836260  0.32650931  0.52105961  1
+  C  C1  1  0.69427666  0.32817608  0.96301022  1
+  C  C2  1  0.39364501  0.65748760  0.50406494  1
+  C  C3  1  0.21226527  0.52421657  0.39712409  1
+  C  C4  1  0.35003242  0.64869281  0.88389397  1
+  C  C5  1  0.71384918  0.06513526  0.25053723  1
+  C  C6  1  0.63871244  0.99057134  -0.03136608  1
+  C  C7  1  0.68278040  0.34205455  0.31954986  1
+  C  C8  1  0.96152582  0.69398905  0.08517071  1
+  C  C9  1  0.14968907  0.85317081  0.16713376  1
+  C  C10  1  0.71012379  -0.04716476  0.75457819  1
+  C  C11  1  0.10341006  0.64753468  0.75056548  1
+",-154.11650749999998
+2014,C-13893-8599-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.62367000
+_cell_length_b   2.83337000
+_cell_length_c   4.81797000
+_cell_angle_alpha   84.90278000
+_cell_angle_beta   112.08675000
+_cell_angle_gamma   97.55562000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   45.39714243
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70616898  0.16271035  0.39466336  1
+  C  C1  1  0.32514674  0.16218454  0.39470465  1
+  C  C2  1  0.76537134  1.16218870  0.89438885  1
+  C  C3  1  0.36032797  0.16254647  0.70300539  1
+  C  C4  1  0.97897948  0.16166016  0.70290230  1
+  C  C5  1  0.92007899  0.16231678  0.20338975  1
+",-154.14665116666666
+7031,C-150699-6622-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45637000
+_cell_length_b   7.11258000
+_cell_length_c   7.73614000
+_cell_angle_alpha   65.77301000
+_cell_angle_beta   99.27453000
+_cell_angle_gamma   83.55453000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C20
+_cell_volume   119.23043491
+_cell_formula_units_Z   20
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.48984471  0.87320682  0.17912403  1
+  C  C1  1  0.55882100  0.07263489  0.77523825  1
+  C  C2  1  0.82287151  0.52410716  0.75593073  1
+  C  C3  1  0.12073010  0.75075423  0.48964153  1
+  C  C4  1  0.12563501  0.54038548  0.28400342  1
+  C  C5  1  -0.18700716  0.42013774  0.61135209  1
+  C  C6  1  -0.02338188  0.18035763  0.70370825  1
+  C  C7  1  0.44758535  0.49597892  0.03229380  1
+  C  C8  1  0.94682902  0.19428423  0.04268702  1
+  C  C9  1  0.92779650  0.41537869  -0.02673281  1
+  C  C10  1  0.29686767  0.72965486  0.87812922  1
+  C  C11  1  0.82315121  0.19914490  0.35637287  1
+  C  C12  1  0.98373590  0.77550955  0.13816195  1
+  C  C13  1  0.25400370  0.66397489  0.70770074  1
+  C  C14  1  0.52689300  0.86971291  0.38869915  1
+  C  C15  1  0.63990524  0.43838230  0.24819064  1
+  C  C16  1  0.77677902  0.83406036  0.90932699  1
+  C  C17  1  0.47113314  0.09541526  0.05755662  1
+  C  C18  1  0.37766227  0.09423172  0.36929901  1
+  C  C19  1  0.21210718  0.52618596  0.48945979  1
+",-154.181727
+4402,C-34643-7107-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48756000
+_cell_length_b   4.76294000
+_cell_length_c   5.31212000
+_cell_angle_alpha   63.09856000
+_cell_angle_beta   62.09592000
+_cell_angle_gamma   58.48080000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.57538367
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.86032976  -0.10136013  0.59929310  1
+  C  C1  1  0.51629821  0.44015494  0.90205340  1
+  C  C2  1  0.74711252  0.24708958  0.36388090  1
+  C  C3  1  1.10325591  0.23886087  1.01654210  1
+  C  C4  1  0.01696657  0.47239344  0.36887149  1
+  C  C5  1  0.09237056  0.70510349  0.06097827  1
+  C  C6  1  0.50547192  0.90624578  0.94663655  1
+  C  C7  1  0.59070555  0.67357934  0.59410679  1
+",-154.36224625
+6351,C-157691-3994-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45424000
+_cell_length_b   4.47124000
+_cell_length_c   7.05104000
+_cell_angle_alpha   87.39195000
+_cell_angle_beta   80.93604000
+_cell_angle_gamma   75.78664000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   74.06750542
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.98337186  0.30948339  0.86559936  1
+  C  C1  1  0.54520565  0.28910700  0.74916087  1
+  C  C2  1  0.78826528  0.63897064  0.93636024  1
+  C  C3  1  0.02985796  0.57714793  0.51222940  1
+  C  C4  1  0.55121638  0.45463759  0.58289186  1
+  C  C5  1  0.20983682  0.77643265  0.96872984  1
+  C  C6  1  0.44709577  0.95662542  0.32636070  1
+  C  C7  1  0.96699805  0.83586494  0.39872921  1
+  C  C8  1  1.01320774  0.10413621  0.04341055  1
+  C  C9  1  0.45309878  0.12129833  0.15968408  1
+",-154.107372
+3171,C-80191-3962-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.44032000
+_cell_length_b   4.83720000
+_cell_length_c   4.25193000
+_cell_angle_alpha   90.05547000
+_cell_angle_beta   90.06837000
+_cell_angle_gamma   134.86614000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   50.15041622
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.99646392  0.80029302  0.61522201  1
+  C  C1  1  0.68414113  0.86684694  0.78293426  1
+  C  C2  1  -0.16633952  0.95413058  0.11867380  1
+  C  C3  1  0.83320334  0.20450250  0.28000536  1
+  C  C4  1  0.84931633  0.46181516  0.11846688  1
+  C  C5  1  0.68382356  0.14378619  0.61510296  1
+  C  C6  1  0.84873615  0.71214668  0.27952403  1
+  C  C7  1  -0.00258241  0.52348963  0.78307628  1
+",-154.12251
+5933,C-189709-289-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44094000
+_cell_length_b   2.54908000
+_cell_length_c   7.71005000
+_cell_angle_alpha   118.02238000
+_cell_angle_beta   73.25978000
+_cell_angle_gamma   87.14599000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.56994625
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46895612  0.48696892  0.43582247  1
+  C  C1  1  0.64291336  0.98901340  0.76531276  1
+  C  C2  1  0.03760815  0.15316610  0.87332408  1
+  C  C3  1  0.69995354  0.14577241  0.20646152  1
+  C  C4  1  0.86380891  0.65141468  0.54371293  1
+  C  C5  1  0.80615201  0.49403829  0.10283453  1
+",-154.07497283333333
+1489,C-170898-6159-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.09071000
+_cell_length_b   4.85615000
+_cell_length_c   4.74049000
+_cell_angle_alpha   105.47607000
+_cell_angle_beta   106.75225000
+_cell_angle_gamma   112.10975000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.19312283
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.14185240  0.04670105  0.53428915  1
+  C  C1  1  0.35957016  0.04693683  0.03419769  1
+  C  C2  1  0.85815848  0.54671177  0.53427968  1
+  C  C3  1  0.69061045  0.71303501  0.36821486  1
+  C  C4  1  0.69057748  0.21303335  0.36821016  1
+  C  C5  1  0.18871065  0.21270336  0.86837308  1
+  C  C6  1  1.18872852  0.71271656  0.86836610  1
+  C  C7  1  0.35960426  0.54694098  0.03420238  1
+",-154.4464475
+1859,C-57133-9728-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43888000
+_cell_length_b   4.83125000
+_cell_length_c   8.76224000
+_cell_angle_alpha   85.06958000
+_cell_angle_beta   82.04823000
+_cell_angle_gamma   59.65622000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   88.22834631
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.25526279  1.14083367  0.82157704  1
+  C  C1  1  0.75641407  0.40307734  0.26912118  1
+  C  C2  1  0.11866163  0.05596869  0.23827161  1
+  C  C3  1  0.22197347  0.03871064  0.06666345  1
+  C  C4  1  1.07276512  0.32798992  0.79054418  1
+  C  C5  1  0.74099113  0.05834882  0.99054746  1
+  C  C6  1  1.09620163  0.55779118  0.27968758  1
+  C  C7  1  0.62892658  0.92716656  0.48035303  1
+  C  C8  1  1.11013948  0.90868741  0.55669055  1
+  C  C9  1  0.78013649  0.63929734  0.75731706  1
+  C  C10  1  0.10901837  0.82650582  0.72577065  1
+  C  C11  1  0.73398714  -0.09431789  0.30856331  1
+",-154.251485
+926,C-73671-1897-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45636000
+_cell_length_b   3.66196000
+_cell_length_c   6.47468000
+_cell_angle_alpha   73.11503000
+_cell_angle_beta   79.03665000
+_cell_angle_gamma   70.43840000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.23332657
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.83461924  0.90577635  -0.01474468  1
+  C  C1  1  0.61032692  0.30400847  0.03630871  1
+  C  C2  1  0.45806390  0.74518368  0.89826572  1
+  C  C3  1  0.82677267  0.67303214  0.23278233  1
+  C  C4  1  0.10481838  0.79470358  0.55585256  1
+  C  C5  1  0.55508205  0.78609240  0.66205366  1
+  C  C6  1  0.20354942  0.83344043  0.31984141  1
+  C  C7  1  1.05198592  0.27408835  0.18167719  1
+",-154.2862025
+6814,C-172967-546-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47969000
+_cell_length_b   3.68914000
+_cell_length_c   4.89598000
+_cell_angle_alpha   92.80397000
+_cell_angle_beta   120.46398000
+_cell_angle_gamma   109.61830000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.01432297
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.73662602  0.32251552  0.85632738  1
+  C  C1  1  0.99471830  0.28474789  0.63430001  1
+  C  C2  1  0.56641809  0.83957274  0.42800438  1
+  C  C3  1  0.11967465  0.68287291  0.55928178  1
+  C  C4  1  0.16536285  0.76751166  0.06281027  1
+  C  C5  1  0.61287749  0.92472978  0.93183518  1
+",-154.31643983333333
+4548,C-13919-5282-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49377000
+_cell_length_b   5.58591000
+_cell_length_c   5.58147000
+_cell_angle_alpha   60.34651000
+_cell_angle_beta   63.49445000
+_cell_angle_gamma   63.50848000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.87307638
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.88681050  0.01223200  0.05510903  1
+  C  C1  1  0.25452553  0.68570143  0.51415150  1
+  C  C2  1  0.25651791  0.82798459  0.86977831  1
+  C  C3  1  0.40194766  0.36808138  0.68369905  1
+  C  C4  1  0.25760755  0.55520975  0.14169892  1
+  C  C5  1  0.25402323  0.19900709  0.00139303  1
+  C  C6  1  0.74026515  0.19961667  0.51419256  1
+  C  C7  1  -0.11078643  0.88166148  0.68296628  1
+  C  C8  1  0.88770985  0.73941047  0.32705189  1
+  C  C9  1  0.88940615  0.36817614  0.19655083  1
+",-154.243904
+4385,C-136210-9760-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.07389000
+_cell_length_b   2.43105000
+_cell_length_c   6.40838000
+_cell_angle_alpha   79.30188000
+_cell_angle_beta   80.45686000
+_cell_angle_gamma   108.55747000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.29010291
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.16863927  0.66547679  0.50223671  1
+  C  C1  1  0.16939561  0.44263645  0.94701713  1
+  C  C2  1  0.16933850  -0.22345101  0.28023265  1
+  C  C3  1  0.16744297  0.33179648  0.16922808  1
+  C  C4  1  0.17101144  0.11038980  0.61308802  1
+  C  C5  1  0.16923160  0.99899359  0.83522682  1
+",-154.44786066666668
+805,C-176683-1873-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48734000
+_cell_length_b   3.51754000
+_cell_length_c   4.30524000
+_cell_angle_alpha   114.10426000
+_cell_angle_beta   106.79830000
+_cell_angle_gamma   89.98361000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.61604775
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.07671540  0.82020307  0.19332701  1
+  C  C1  1  0.74338207  0.48686973  0.52666035  1
+  C  C2  1  0.57658090  0.07051093  0.19337829  1
+  C  C3  1  0.41004873  0.15353640  0.85999368  1
+  C  C4  1  0.24324757  0.73717760  0.52671162  1
+  C  C5  1  0.90991423  0.40384427  0.86004495  1
+",-154.54566766666667
+1982,C-152601-7805-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45505000
+_cell_length_b   2.53411000
+_cell_length_c   6.38348000
+_cell_angle_alpha   97.05970000
+_cell_angle_beta   90.78107000
+_cell_angle_gamma   88.28707000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.39328686
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36446561  1.03409683  0.12760147  1
+  C  C1  1  0.36570936  -0.06234221  0.89620103  1
+  C  C2  1  0.36863213  0.40657291  0.79251216  1
+  C  C3  1  0.36933715  0.30577967  0.56120362  1
+  C  C4  1  -0.13234791  0.23821182  0.45477946  1
+  C  C5  1  0.86615846  0.09951657  0.23399126  1
+",-154.07778916666666
+369,C-80195-4794-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47344000
+_cell_length_b   4.11774000
+_cell_length_c   4.28084000
+_cell_angle_alpha   90.01627000
+_cell_angle_beta   90.02133000
+_cell_angle_gamma   90.05664000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.60025579
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.78861970  0.64153700  0.11680318  1
+  C  C1  1  0.78869486  0.14153262  0.78348895  1
+  C  C2  1  -0.21149572  1.01652950  0.11678109  1
+  C  C3  1  0.78857943  0.51652512  -0.21653314  1
+  C  C4  1  0.28861970  0.64153700  0.61680318  1
+  C  C5  1  0.28857943  0.51652512  0.28346686  1
+  C  C6  1  0.28850428  0.01652950  0.61678109  1
+  C  C7  1  0.28869486  0.14153262  0.28348895  1
+",-154.52300125
+3191,C-72716-3406-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48133000
+_cell_length_b   3.68850000
+_cell_length_c   4.21732000
+_cell_angle_alpha   104.90405000
+_cell_angle_beta   89.96525000
+_cell_angle_gamma   109.64933000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.97120631
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71839105  0.57530885  0.24427637  1
+  C  C1  1  0.04033326  0.21724068  0.54209921  1
+  C  C2  1  -0.08174741  0.97271668  0.16857136  1
+  C  C3  1  0.46210214  1.06091403  0.67309726  1
+  C  C4  1  0.49669169  1.12996781  1.03796824  1
+  C  C5  1  0.23808028  0.61511536  0.46669847  1
+",-154.3085715
+4539,C-102875-8418-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43219000
+_cell_length_b   4.22553000
+_cell_length_c   4.81571000
+_cell_angle_alpha   97.71599000
+_cell_angle_beta   75.39092000
+_cell_angle_gamma   106.68976000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.77263880
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79895491  0.90900698  0.10714926  1
+  C  C1  1  0.19566270  0.44686533  0.85440808  1
+  C  C2  1  -0.21671748  0.13591805  0.36641238  1
+  C  C3  1  1.02644020  0.08220275  0.82565352  1
+  C  C4  1  0.56321141  -0.02499490  0.64259363  1
+  C  C5  1  0.17914129  0.67362103  0.11356668  1
+  C  C6  1  0.41264021  0.60781808  0.57880490  1
+  C  C7  1  0.95147807  0.50071379  0.39525774  1
+",-154.225675
+4767,C-13911-8164-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48163000
+_cell_length_b   3.68952000
+_cell_length_c   4.84298000
+_cell_angle_alpha   122.57435000
+_cell_angle_beta   75.10760000
+_cell_angle_gamma   109.67241000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.02534144
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17749822  0.67768236  -0.06795249  1
+  C  C1  1  -0.14391188  0.33321121  0.22918960  1
+  C  C2  1  1.05264069  0.80647574  0.30512172  1
+  C  C3  1  0.59927702  0.38999606  0.80106604  1
+  C  C4  1  0.63101425  1.09394375  0.43592612  1
+  C  C5  1  0.37559120  0.15067849  0.00764902  1
+",-154.3136125
+5618,C-13691-2934-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52723000
+_cell_length_b   4.29869000
+_cell_length_c   5.39860000
+_cell_angle_alpha   121.08768000
+_cell_angle_beta   110.98258000
+_cell_angle_gamma   84.94964000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.54999207
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.06629176  0.37610945  0.67589523  1
+  C  C1  1  -0.09513825  -0.02693810  0.54591501  1
+  C  C2  1  0.30347112  1.17034497  0.19773779  1
+  C  C3  1  0.44515049  0.50539277  -0.00239739  1
+  C  C4  1  0.52603544  0.84394527  0.22411438  1
+  C  C5  1  0.48064794  0.47236745  0.55637675  1
+  C  C6  1  0.66737194  0.17894904  0.02424067  1
+  C  C7  1  0.49046627  0.87695155  0.66551246  1
+",-154.06815875
+7885,C-136247-3248-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47711000
+_cell_length_b   2.47756000
+_cell_length_c   6.77864000
+_cell_angle_alpha   89.98554000
+_cell_angle_beta   111.41276000
+_cell_angle_gamma   120.04054000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.65655271
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.10503111  0.64708921  0.65096997  1
+  C  C1  1  0.66318179  -0.07151263  0.06928712  1
+  C  C2  1  0.55039874  0.36998515  0.73504999  1
+  C  C3  1  -0.00850320  0.09225826  0.31661827  1
+  C  C4  1  0.88504080  0.53883155  0.98579457  1
+  C  C5  1  0.76988977  0.48076146  0.40016058  1
+",-154.53312350000002
+4859,C-176685-9184-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.70520000
+_cell_length_b   4.31972000
+_cell_length_c   4.81317000
+_cell_angle_alpha   109.30314000
+_cell_angle_beta   88.80719000
+_cell_angle_gamma   122.94162000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.64270082
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64423080  0.63511942  0.10946404  1
+  C  C1  1  1.04986016  1.03985626  0.30183485  1
+  C  C2  1  0.20476469  0.19464326  0.61078497  1
+  C  C3  1  0.61024177  0.59928907  0.80314449  1
+  C  C4  1  -0.00708094  -0.01811506  0.80300513  1
+  C  C5  1  0.26173642  0.25257335  0.10969472  1
+",-154.10971750000002
+681,C-28264-8801-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.39822000
+_cell_length_b   4.26598000
+_cell_length_c   5.94355000
+_cell_angle_alpha   108.59142000
+_cell_angle_beta   112.23788000
+_cell_angle_gamma   120.87945000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   67.63766818
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.21817318  0.71954400  0.29982383  1
+  C  C1  1  0.56576114  0.40701066  0.30579610  1
+  C  C2  1  0.38584812  0.15382039  0.80692607  1
+  C  C3  1  0.52600509  0.01461425  0.25314848  1
+  C  C4  1  -0.21457767  -0.03263750  0.20570673  1
+  C  C5  1  0.50376820  0.99197477  0.64827995  1
+  C  C6  1  -0.07464038  0.82813609  0.65188919  1
+  C  C7  1  0.80739498  -0.01009930  0.81051749  1
+  C  C8  1  0.74574187  0.57508347  0.15307158  1
+  C  C9  1  1.09312817  0.26240456  0.15899388  1
+",-154.140354
+9792,C-189748-4840-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.82869000
+_cell_length_b   3.62617000
+_cell_length_c   4.81526000
+_cell_angle_alpha   67.88668000
+_cell_angle_beta   87.91960000
+_cell_angle_gamma   95.63861000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   45.39291949
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20007791  -0.13296083  0.83803007  1
+  C  C1  1  0.20254894  0.52222581  0.52906017  1
+  C  C2  1  0.20039561  0.08141095  1.02883391  1
+  C  C3  1  0.19930463  0.48582862  0.83797882  1
+  C  C4  1  1.20158492  0.14084123  0.52921891  1
+  C  C5  1  0.20120509  0.92660732  0.33833642  1
+",-154.1441335
+7983,C-172971-7940-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.99226000
+_cell_length_b   4.21033000
+_cell_length_c   4.20638000
+_cell_angle_alpha   119.96836000
+_cell_angle_beta   80.80990000
+_cell_angle_gamma   113.55317000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.03068651
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.26663791  0.75244640  0.34580672  1
+  C  C1  1  0.26663012  0.41917093  0.67912143  1
+  C  C2  1  1.25854148  0.08306489  0.34577138  1
+  C  C3  1  0.26663037  0.08582813  0.01247528  1
+  C  C4  1  0.25853998  0.74974011  0.67912355  1
+  C  C5  1  0.25852893  0.41639984  0.01241454  1
+",-154.42551716666665
+3008,C-157715-9420-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45251000
+_cell_length_b   5.76904000
+_cell_length_c   4.11436000
+_cell_angle_alpha   51.52309000
+_cell_angle_beta   90.05447000
+_cell_angle_gamma   101.93249000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.96348702
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.10437904  0.80048696  0.14159136  1
+  C  C1  1  0.63357542  0.86110119  0.27262086  1
+  C  C2  1  0.37141162  0.34109523  -0.03267893  1
+  C  C3  1  1.06871934  0.73727057  0.88525132  1
+  C  C4  1  0.53859320  0.67540187  0.75570632  1
+  C  C5  1  0.79987538  0.19518127  0.06237377  1
+",-154.180409
+8988,C-40100-7984-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47770000
+_cell_length_b   2.47796000
+_cell_length_c   6.31085000
+_cell_angle_alpha   89.99148000
+_cell_angle_beta   101.32183000
+_cell_angle_gamma   120.02739000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.67293577
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.29927032  0.65274960  0.35760167  1
+  C  C1  1  0.40751549  0.20600213  0.02216114  1
+  C  C2  1  0.24377296  0.12450564  0.77119713  1
+  C  C3  1  0.85581860  0.43082761  0.68817847  1
+  C  C4  1  0.68966254  0.34809034  0.44111009  1
+  C  C5  1  1.12987568  0.56725329  0.10646121  1
+",-154.52698866666665
+3208,C-126136-4977-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48272000
+_cell_length_b   3.78278000
+_cell_length_c   7.99338000
+_cell_angle_alpha   109.52079000
+_cell_angle_beta   108.07398000
+_cell_angle_gamma   89.93674000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   66.82203752
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.80580691  0.71576187  0.33224417  1
+  C  C1  1  0.28503654  0.41403257  0.80974066  1
+  C  C2  1  0.04313071  0.82415974  0.06770411  1
+  C  C3  1  1.13526574  0.53325967  0.66225122  1
+  C  C4  1  0.55711782  0.60463562  0.58436699  1
+  C  C5  1  0.66698317  -0.08400300  0.19165988  1
+  C  C6  1  -0.34456006  0.32003046  0.18056946  1
+  C  C7  1  0.41185169  0.72855992  0.43843217  1
+  C  C8  1  0.89089834  0.42814989  0.91598457  1
+  C  C9  1  0.03286444  0.22828634  0.05676158  1
+",-154.095733
+6656,C-40134-7379-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48175000
+_cell_length_b   4.84618000
+_cell_length_c   3.69051000
+_cell_angle_alpha   57.31910000
+_cell_angle_beta   70.34600000
+_cell_angle_gamma   75.21913000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.03096907
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.16884963  0.94778897  0.43678598  1
+  C  C1  1  0.42882842  0.37629995  0.49187041  1
+  C  C2  1  0.38973136  0.74146723  0.19819101  1
+  C  C3  1  0.96819620  0.87267148  0.91022826  1
+  C  C4  1  0.64971016  0.16997820  0.25327544  1
+  C  C5  1  0.85036359  0.24509570  0.77983316  1
+",-154.31236666666666
+8914,C-56495-4082-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50862000
+_cell_length_b   4.28939000
+_cell_length_c   5.06301000
+_cell_angle_alpha   79.65819000
+_cell_angle_beta   111.01867000
+_cell_angle_gamma   115.18573000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.99736584
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20091308  0.75407751  0.90264845  1
+  C  C1  1  -0.19407277  0.79755964  0.39969864  1
+  C  C2  1  0.65353404  0.42808758  0.42797647  1
+  C  C3  1  1.21269743  0.32736421  0.61444731  1
+  C  C4  1  0.06035331  0.95814200  0.64355369  1
+  C  C5  1  0.66534848  0.00115473  0.14009741  1
+  C  C6  1  0.36604071  0.24198895  0.14445951  1
+  C  C7  1  0.50006662  0.51323708  -0.10208768  1
+",-154.13006125
+257,C-145340-6787-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47451000
+_cell_length_b   4.28168000
+_cell_length_c   4.80552000
+_cell_angle_alpha   116.48150000
+_cell_angle_beta   104.91835000
+_cell_angle_gamma   90.01009000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.64582062
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.12516896  -0.01476460  0.93545824  1
+  C  C1  1  0.68857219  0.88171938  0.06158202  1
+  C  C2  1  0.43867611  0.29833955  0.56159414  1
+  C  C3  1  0.62518393  0.48524787  0.93546826  1
+  C  C4  1  0.37506504  0.56861524  0.43544613  1
+  C  C5  1  0.93862594  0.79832006  0.56157236  1
+  C  C6  1  0.18855722  0.38170692  0.06157200  1
+  C  C7  1  0.87511521  0.06863473  0.43546790  1
+",-154.52737125
+5778,C-107717-3127-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42760000
+_cell_length_b   4.79968000
+_cell_length_c   6.38069000
+_cell_angle_alpha   77.77364000
+_cell_angle_beta   92.87337000
+_cell_angle_gamma   55.08525000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.20358092
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87277107  0.33861537  0.61777021  1
+  C  C1  1  0.45796956  0.25355819  0.53548947  1
+  C  C2  1  0.95696844  0.75438553  0.03507524  1
+  C  C3  1  0.20774796  1.00376559  0.28537919  1
+  C  C4  1  -0.29269388  0.50410677  0.78522255  1
+  C  C5  1  0.12197634  0.58927068  0.86744761  1
+  C  C6  1  0.37216986  0.83911163  0.11751669  1
+  C  C7  1  0.62287365  0.08854923  0.36779415  1
+",-154.46678625
+9514,C-107717-3127-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.83862000
+_cell_length_b   4.75310000
+_cell_length_c   4.91688000
+_cell_angle_alpha   117.87696000
+_cell_angle_beta   85.09085000
+_cell_angle_gamma   118.38205000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   86.57388720
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79518695  0.59028919  0.26512074  1
+  C  C1  1  0.63703651  0.09120148  0.42534969  1
+  C  C2  1  1.12426614  0.43570198  0.93393951  1
+  C  C3  1  0.30656425  0.93735272  0.75515315  1
+  C  C4  1  0.43091491  0.17550067  0.63116693  1
+  C  C5  1  0.00046724  0.67401796  0.05834012  1
+  C  C6  1  0.43080767  0.69948552  0.63171822  1
+  C  C7  1  0.33825576  0.43678684  0.72244249  1
+  C  C8  1  0.63686469  0.78321272  0.42555945  1
+  C  C9  1  0.09359614  0.93705305  0.96754915  1
+  C  C10  1  0.79532757  0.28213413  1.26479968  1
+  C  C11  1  0.00080466  0.19788295  1.05826058  1
+",-154.2734825
+5486,C-157691-3994-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46671000
+_cell_length_b   3.38116000
+_cell_length_c   5.24880000
+_cell_angle_alpha   89.19435000
+_cell_angle_beta   89.90303000
+_cell_angle_gamma   111.23058000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.80056668
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.49887559  0.79113473  0.21055761  1
+  C  C1  1  0.53580427  0.86499548  0.93560864  1
+  C  C2  1  0.90839836  0.60963423  0.33530561  1
+  C  C3  1  0.05691397  -0.09219542  0.81047555  1
+  C  C4  1  1.09729575  0.98092686  0.53534444  1
+  C  C5  1  0.68778346  0.16181752  0.41033866  1
+",-154.16077083333332
+8409,C-189700-5976-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48107000
+_cell_length_b   3.68928000
+_cell_length_c   4.21691000
+_cell_angle_alpha   104.81997000
+_cell_angle_beta   89.94189000
+_cell_angle_gamma   109.64361000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98984362
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.03318396  0.72471444  0.90292571  1
+  C  C1  1  0.99572381  0.65337784  0.53767386  1
+  C  C2  1  0.45473136  0.56818665  0.03393371  1
+  C  C3  1  0.57419040  0.81046866  0.40682881  1
+  C  C4  1  0.77491443  0.20846785  0.33155997  1
+  C  C5  1  0.25581874  0.17018835  0.10935534  1
+",-154.308633
+8571,C-96684-2672-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43223000
+_cell_length_b   3.00807000
+_cell_length_c   6.40374000
+_cell_angle_alpha   86.18147000
+_cell_angle_beta   79.30034000
+_cell_angle_gamma   108.91548000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.14413288
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.59753748  0.05578816  0.54124830  1
+  C  C1  1  0.04283175  0.06155263  0.65187081  1
+  C  C2  1  0.70741253  0.05729346  0.31924582  1
+  C  C3  1  0.37818611  1.06687436  -0.01506977  1
+  C  C4  1  0.93501102  0.06542315  0.87356232  1
+  C  C5  1  0.26576571  1.05905453  0.20733403  1
+",-154.43499266666666
+7124,C-141043-2496-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.79959000
+_cell_length_b   2.46392000
+_cell_length_c   8.64186000
+_cell_angle_alpha   73.50988000
+_cell_angle_beta   57.98700000
+_cell_angle_gamma   71.09409000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   64.26330727
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46151563  0.70267383  0.20246938  1
+  C  C1  1  0.27446128  0.18017440  0.31953190  1
+  C  C2  1  0.24826868  -0.12645884  0.63726789  1
+  C  C3  1  0.89720441  0.52329002  0.16255962  1
+  C  C4  1  0.53210330  0.93345036  0.43704724  1
+  C  C5  1  0.54490378  0.85874430  0.00303351  1
+  C  C6  1  0.82700549  0.29277106  0.92756049  1
+  C  C7  1  0.11024429  0.35316686  0.72704978  1
+  C  C8  1  0.08414944  0.04550661  1.04542789  1
+  C  C9  1  0.81387529  0.36756099  0.36192439  1
+",-154.217487
+7637,C-80155-5756-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45636000
+_cell_length_b   3.66418000
+_cell_length_c   6.97166000
+_cell_angle_alpha   113.56481000
+_cell_angle_beta   110.60801000
+_cell_angle_gamma   70.43198000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.43814540
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.80091092  0.09121879  0.84666876  1
+  C  C1  1  0.40398980  0.53379137  0.17099535  1
+  C  C2  1  -0.03334386  0.62232973  0.27786626  1
+  C  C3  1  0.97624387  0.63974547  0.79701734  1
+  C  C4  1  0.26309340  0.34291400  0.93400889  1
+  C  C5  1  0.39229861  0.51697028  0.65151233  1
+  C  C6  1  0.57003039  1.06520943  0.60172932  1
+  C  C7  1  1.10967938  0.81306264  0.51469244  1
+",-154.2842425
+664,C-53818-5632-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42250000
+_cell_length_b   4.17024000
+_cell_length_c   4.82289000
+_cell_angle_alpha   94.34985000
+_cell_angle_beta   119.94846000
+_cell_angle_gamma   89.67668000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.06618570
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.07628640  0.35327300  0.77150010  1
+  C  C1  1  0.57652839  0.31667797  0.92406321  1
+  C  C2  1  0.57877468  0.41236118  0.42640717  1
+  C  C3  1  -0.07703427  0.25529506  0.26875319  1
+  C  C4  1  0.52056915  0.75756747  0.36526585  1
+  C  C5  1  0.98142815  0.90965140  0.32725618  1
+",-154.23603383333332
+4623,C-40091-1213-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48021000
+_cell_length_b   3.68863000
+_cell_length_c   4.21763000
+_cell_angle_alpha   75.21604000
+_cell_angle_beta   89.99223000
+_cell_angle_gamma   70.33647000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.97624932
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.45768367  0.67357099  0.61936211  1
+  C  C1  1  0.23352046  0.11920344  0.41296313  1
+  C  C2  1  0.91392356  0.75920035  1.11561766  1
+  C  C3  1  0.71464729  0.15711109  0.19107894  1
+  C  C4  1  0.49211597  0.60242899  0.98455358  1
+  C  C5  1  0.03607056  0.51697874  0.48820587  1
+",-154.307399
+9524,C-172941-6659-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42550000
+_cell_length_b   4.85187000
+_cell_length_c   6.35485000
+_cell_angle_alpha   41.41342000
+_cell_angle_beta   67.69740000
+_cell_angle_gamma   60.08476000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.87641728
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.31260979  0.04904004  0.44537559  1
+  C  C1  1  0.03539814  0.64195243  0.50536773  1
+  C  C2  1  0.62746802  0.45628674  0.09822804  1
+  C  C3  1  0.69051385  0.45617504  0.53639882  1
+  C  C4  1  1.09688429  0.64171160  -0.05674543  1
+  C  C5  1  1.03733079  0.04912226  0.59619916  1
+",-154.29656316666666
+8337,C-152591-5216-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45594000
+_cell_length_b   4.49886000
+_cell_length_c   7.10749000
+_cell_angle_alpha   93.62258000
+_cell_angle_beta   79.96008000
+_cell_angle_gamma   105.97858000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   74.33043955
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.68472898  0.77587985  0.01162723  1
+  C  C1  1  0.45131682  0.12374234  0.82283874  1
+  C  C2  1  0.45507980  0.96183892  0.65505146  1
+  C  C3  1  0.92905862  0.83915556  0.58403006  1
+  C  C4  1  0.32407407  0.45414698  0.40096892  1
+  C  C5  1  0.85197795  0.57773725  0.47157774  1
+  C  C6  1  -0.11754408  0.10416979  -0.06156796  1
+  C  C7  1  0.89219868  0.31027976  0.11812130  1
+  C  C8  1  0.32386231  0.29070690  0.23366342  1
+  C  C9  1  0.09913765  0.63901295  1.04454259  1
+",-154.120229
+6414,C-28230-7089-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.35885000
+_cell_length_b   3.38886000
+_cell_length_c   4.83168000
+_cell_angle_alpha   84.65687000
+_cell_angle_beta   59.62380000
+_cell_angle_gamma   65.49027000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.69272689
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.47798957  0.25601900  0.34315796  1
+  C  C1  1  1.03933489  0.69939022  0.83976727  1
+  C  C2  1  0.63594085  0.10023462  0.02974321  1
+  C  C3  1  1.07509890  0.65707631  0.53293996  1
+  C  C4  1  0.68937601  0.04201084  0.53313881  1
+  C  C5  1  0.42417268  0.31403900  0.83986059  1
+",-154.0859575
+7646,C-57111-4456-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.56905000
+_cell_length_b   4.94550000
+_cell_length_c   7.62331000
+_cell_angle_alpha   89.98828000
+_cell_angle_beta   89.35966000
+_cell_angle_gamma   90.00717000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   96.84990697
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.01794958  0.08658620  1.02504899  1
+  C  C1  1  0.52515544  0.92554184  0.78384533  1
+  C  C2  1  1.03235470  0.87018001  0.47085471  1
+  C  C3  1  1.02137074  0.87011476  0.29173357  1
+  C  C4  1  0.03391076  0.12366696  0.55169538  1
+  C  C5  1  0.02955114  0.37287411  0.47235208  1
+  C  C6  1  1.02320973  0.29868775  0.88220135  1
+  C  C7  1  1.02839639  0.08700415  0.73838783  1
+  C  C8  1  0.51979664  0.92536862  -0.01983693  1
+  C  C9  1  1.01810408  0.12363451  0.21140024  1
+  C  C10  1  0.03119572  0.62121287  0.58714274  1
+  C  C11  1  0.51799457  0.64532505  1.05512614  1
+  C  C12  1  0.01993148  0.37283925  0.29033558  1
+  C  C13  1  0.52720511  0.64532503  0.70909955  1
+  C  C14  1  0.01645907  0.62120517  0.17631034  1
+  C  C15  1  0.52268433  0.46669911  0.88234490  1
+",-154.22301625
+5413,C-34627-4459-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.34027000
+_cell_length_b   3.70003000
+_cell_length_c   4.81909000
+_cell_angle_alpha   102.38703000
+_cell_angle_beta   89.21737000
+_cell_angle_gamma   127.20494000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   59.53113829
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.91023231  0.44534077  0.00679072  1
+  C  C1  1  0.42608421  1.12973396  0.72002854  1
+  C  C2  1  0.19824307  -0.32866557  0.23854608  1
+  C  C3  1  0.52227872  0.67098726  0.23861057  1
+  C  C4  1  0.14118094  -0.09149929  0.48548083  1
+  C  C5  1  0.75261198  0.13037999  0.71993573  1
+  C  C6  1  0.81685864  0.90860013  0.48548732  1
+  C  C7  1  0.58399732  0.44453703  1.00692391  1
+",-154.08448125
+5703,C-40128-4097-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47853000
+_cell_length_b   2.47814000
+_cell_length_c   6.77783000
+_cell_angle_alpha   68.56487000
+_cell_angle_beta   68.54572000
+_cell_angle_gamma   59.97219000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.67459942
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.82641875  0.58758811  0.71779346  1
+  C  C1  1  0.27122218  1.03016263  0.05221524  1
+  C  C2  1  0.38102073  0.13902044  0.38728985  1
+  C  C3  1  -0.00865172  0.75058928  0.47053798  1
+  C  C4  1  0.43776577  0.19873285  0.80113507  1
+  C  C5  1  0.54859170  0.30713819  0.13621861  1
+",-154.527101
+9237,C-107734-9364-54,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52326000
+_cell_length_b   4.45463000
+_cell_length_c   4.30678000
+_cell_angle_alpha   76.91974000
+_cell_angle_beta   85.32772000
+_cell_angle_gamma   97.58778000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.42831052
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17970259  0.24050665  1.01635178  1
+  C  C1  1  0.05208021  1.08845720  0.73453429  1
+  C  C2  1  0.64086211  0.11987204  0.21654243  1
+  C  C3  1  0.87910332  0.74820214  0.91359327  1
+  C  C4  1  0.54337615  0.54975649  0.50410523  1
+  C  C5  1  0.35441319  0.58074220  0.83746481  1
+  C  C6  1  0.59127908  0.20891906  0.53447984  1
+  C  C7  1  0.69081555  0.77938221  0.24690995  1
+",-154.09498875
+7553,C-47642-4937-56,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44720000
+_cell_length_b   6.56128000
+_cell_length_c   7.58442000
+_cell_angle_alpha   76.82001000
+_cell_angle_beta   107.58771000
+_cell_angle_gamma   105.51520000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   110.41289279
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.50769977  0.56860123  0.36565236  1
+  C  C1  1  0.10334816  0.69472428  0.38562606  1
+  C  C2  1  0.69032540  0.81274774  0.04486762  1
+  C  C3  1  0.74930995  0.27666421  0.24694031  1
+  C  C4  1  0.78313735  0.13067105  0.77085421  1
+  C  C5  1  0.35846573  0.37886856  0.30064292  1
+  C  C6  1  0.06483787  0.75364714  0.97478116  1
+  C  C7  1  0.58274869  1.04239322  0.21332375  1
+  C  C8  1  0.95561137  -0.08881507  0.58453207  1
+  C  C9  1  0.02127607  0.25245631  0.92908374  1
+  C  C10  1  0.34983351  0.82624698  0.53644859  1
+  C  C11  1  0.17725890  0.07127880  0.70074388  1
+  C  C12  1  0.79113997  0.58782089  0.86682723  1
+  C  C13  1  0.58677149  0.21206604  1.04790474  1
+  C  C14  1  0.18929438  0.48418615  0.85420183  1
+  C  C15  1  0.98997750  0.90787208  0.21587373  1
+",-154.068704375
+1743,C-92160-9421-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45461000
+_cell_length_b   4.77572000
+_cell_length_c   7.02800000
+_cell_angle_alpha   82.20500000
+_cell_angle_beta   81.87030000
+_cell_angle_gamma   79.30428000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   79.63278621
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.17644699  0.64889077  0.04492173  1
+  C  C1  1  0.71102307  -0.19205304  0.46686535  1
+  C  C2  1  0.87006670  0.47747462  0.77683336  1
+  C  C3  1  0.64072511  0.56539810  0.37196205  1
+  C  C4  1  0.75101464  0.08703093  0.35694104  1
+  C  C5  1  0.33657408  0.43206760  0.90566952  1
+  C  C6  1  0.12728960  0.95155197  0.74355478  1
+  C  C7  1  0.61983821  0.29633098  0.50856354  1
+  C  C8  1  0.42652301  0.12728489  0.02086413  1
+  C  C9  1  0.28896964  0.18371038  0.23432944  1
+  C  C10  1  0.71879094  0.78938521  0.68060402  1
+  C  C11  1  0.02657195  0.95757211  0.96485444  1
+  C  C12  1  0.19280461  0.51560018  0.24214395  1
+  C  C13  1  0.06601313  0.25833901  0.63395024  1
+",-154.1941192857143
+7987,C-172961-4783-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.41493000
+_cell_length_b   3.41632000
+_cell_length_c   5.41215000
+_cell_angle_alpha   98.86821000
+_cell_angle_beta   98.83194000
+_cell_angle_gamma   93.90800000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   61.37303547
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.80892180  0.24825513  0.07287377  1
+  C  C1  1  0.57134682  0.48772622  0.50501604  1
+  C  C2  1  0.53453060  0.93369995  0.89744922  1
+  C  C3  1  -0.18960899  0.73106314  0.73255977  1
+  C  C4  1  0.17959160  0.09958062  0.22079239  1
+  C  C5  1  0.32739113  0.73025626  0.07338405  1
+  C  C6  1  0.52666866  0.44718887  0.22562900  1
+  C  C7  1  1.01437937  0.45607984  0.89778179  1
+  C  C8  1  0.15910506  0.07985996  0.73707687  1
+  C  C9  1  0.27953935  0.19749222  0.50540480  1
+",-154.092769
+8021,C-28224-863-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46318000
+_cell_length_b   3.79861000
+_cell_length_c   7.36945000
+_cell_angle_alpha   90.12669000
+_cell_angle_beta   80.38326000
+_cell_angle_gamma   108.93463000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   64.20574720
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.13738833  0.20163869  0.90554778  1
+  C  C1  1  0.32572372  0.73553131  0.06336483  1
+  C  C2  1  0.73273814  0.66606181  0.18035486  1
+  C  C3  1  0.71832431  0.96001264  0.49807170  1
+  C  C4  1  1.14890107  0.91190255  0.58829587  1
+  C  C5  1  1.00979228  0.82722902  0.78855218  1
+  C  C6  1  0.54448972  0.13135615  0.02256871  1
+  C  C7  1  0.36890977  0.62039823  0.86375848  1
+  C  C8  1  0.50568046  0.24726441  0.22204284  1
+  C  C9  1  -0.13575209  0.04100939  0.29730946  1
+",-154.213322
+2506,C-28232-5757-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43212000
+_cell_length_b   4.25366000
+_cell_length_c   4.30464000
+_cell_angle_alpha   82.95722000
+_cell_angle_beta   80.00516000
+_cell_angle_gamma   83.81943000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.35617213
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.25326811  0.47577443  1.10369600  1
+  C  C1  1  0.58676484  0.80996522  0.43602981  1
+  C  C2  1  0.69788601  0.58771067  0.21501859  1
+  C  C3  1  0.36457086  0.25469279  0.88139735  1
+  C  C4  1  1.03137115  0.92204400  0.54721139  1
+  C  C5  1  -0.07994807  0.14305739  0.76959796  1
+",-154.4491325
+7632,C-56475-1508-55,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48420000
+_cell_length_b   3.82362000
+_cell_length_c   5.98137000
+_cell_angle_alpha   59.64675000
+_cell_angle_beta   78.04467000
+_cell_angle_gamma   71.03316000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.30107644
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.18543334  0.30749191  0.39356710  1
+  C  C1  1  0.67541497  -0.11710508  0.83828776  1
+  C  C2  1  0.46162776  0.25479508  0.89451498  1
+  C  C3  1  0.85125264  0.37068122  1.00088364  1
+  C  C4  1  0.96961524  0.67888348  0.45047791  1
+  C  C5  1  -0.20393384  1.19114387  0.28745409  1
+  C  C6  1  0.42344624  0.60809787  0.61545871  1
+  C  C7  1  0.22130525  0.95407446  0.67325431  1
+",-154.2219875
+1551,C-92160-9421-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.28224000
+_cell_length_b   3.64210000
+_cell_length_c   5.23874000
+_cell_angle_alpha   52.62387000
+_cell_angle_beta   64.11607000
+_cell_angle_gamma   65.08558000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.69120087
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53313050  0.91518002  0.26198723  1
+  C  C1  1  0.03619892  0.85432490  0.76204141  1
+  C  C2  1  0.84627715  0.06744115  0.95079999  1
+  C  C3  1  0.34196381  0.50972864  0.45311648  1
+  C  C4  1  0.34400140  1.12759449  0.45130510  1
+  C  C5  1  1.03816221  0.47223119  0.76024359  1
+",-154.12885166666666
+5968,C-75999-4861-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43255000
+_cell_length_b   4.31062000
+_cell_length_c   6.11025000
+_cell_angle_alpha   73.84051000
+_cell_angle_beta   81.44792000
+_cell_angle_gamma   102.15589000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.67496139
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.27079370  -0.00369753  0.80483312  1
+  C  C1  1  0.77194959  0.74799796  0.55361844  1
+  C  C2  1  0.77210478  0.24828390  1.05345617  1
+  C  C3  1  0.77294045  0.41519467  0.21925963  1
+  C  C4  1  0.77229052  0.91403699  0.71991655  1
+  C  C5  1  0.27175078  0.16332570  0.97059152  1
+  C  C6  1  0.27198062  0.66372175  0.47035739  1
+  C  C7  1  0.27149685  0.49754925  0.30411157  1
+",-154.46613875
+5567,C-136223-1797-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48397000
+_cell_length_b   3.92581000
+_cell_length_c   6.87519000
+_cell_angle_alpha   66.19638000
+_cell_angle_beta   90.03405000
+_cell_angle_gamma   71.56911000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.55626499
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.62222168  0.15349802  0.84777274  1
+  C  C1  1  0.82366846  0.74591799  0.67578362  1
+  C  C2  1  0.20715770  -0.01600812  0.98501124  1
+  C  C3  1  0.80643677  0.78066472  0.44523537  1
+  C  C4  1  0.41308263  0.56839601  0.80162904  1
+  C  C5  1  0.43244604  0.53253818  0.03233908  1
+  C  C6  1  0.06297041  0.26973523  0.12033740  1
+  C  C7  1  0.17581485  0.04364063  0.35693321  1
+  C  C8  1  1.03371489  0.32975283  0.49202113  1
+  C  C9  1  0.61819069  0.16097570  0.62899556  1
+",-154.23362600000002
+6179,C-106833-6336-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47381000
+_cell_length_b   4.28124000
+_cell_length_c   4.80173000
+_cell_angle_alpha   90.02054000
+_cell_angle_beta   120.99542000
+_cell_angle_gamma   89.98058000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.59333240
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70086284  0.13633178  0.12554689  1
+  C  C1  1  0.07451139  0.13625113  0.49957582  1
+  C  C2  1  0.07440603  0.30290034  -0.00042437  1
+  C  C3  1  0.57451139  0.63625113  0.49957582  1
+  C  C4  1  1.20086284  0.63633178  0.12554689  1
+  C  C5  1  0.70075748  0.30298099  0.62554671  1
+  C  C6  1  0.20075748  0.80298099  0.62554671  1
+  C  C7  1  0.57440603  0.80290034  -0.00042437  1
+",-154.51992875
+6435,C-90849-4956-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48743000
+_cell_length_b   4.30129000
+_cell_length_c   4.30391000
+_cell_angle_alpha   80.46422000
+_cell_angle_beta   89.94857000
+_cell_angle_gamma   106.74786000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.42794725
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.29805722  0.37897364  0.67898665  1
+  C  C1  1  0.79785960  0.37899875  0.17899596  1
+  C  C2  1  0.54807685  0.87897930  0.92921044  1
+  C  C3  1  0.98536937  0.75403577  0.11630279  1
+  C  C4  1  0.48545167  0.75401510  0.61629469  1
+  C  C5  1  0.73537304  0.25403915  0.86608310  1
+  C  C6  1  0.23517170  0.25402396  0.36607428  1
+  C  C7  1  1.04809815  0.87897713  0.42920687  1
+",-154.54236625
+4100,C-34613-7933-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47392000
+_cell_length_b   4.11760000
+_cell_length_c   4.28208000
+_cell_angle_alpha   90.00233000
+_cell_angle_beta   90.00190000
+_cell_angle_gamma   90.00297000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.61989164
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36592400  1.05912656  0.81532995  1
+  C  C1  1  0.86531153  0.68401738  0.31515669  1
+  C  C2  1  -0.13405922  0.18407779  -0.01799932  1
+  C  C3  1  0.86553141  0.05907796  0.31532235  1
+  C  C4  1  0.36553816  0.68406873  0.81516327  1
+  C  C5  1  0.36554309  0.18402343  0.48200175  1
+  C  C6  1  0.86554227  0.55911905  0.98182947  1
+  C  C7  1  0.36531417  0.55907451  0.48183254  1
+",-154.5256625
+7,C-113034-7981-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47546000
+_cell_length_b   4.78994000
+_cell_length_c   4.79740000
+_cell_angle_alpha   51.75103000
+_cell_angle_beta   89.98586000
+_cell_angle_gamma   89.95778000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   44.67277173
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46680910  1.02656110  0.33229266  1
+  C  C1  1  0.46683127  0.06310455  0.62918322  1
+  C  C2  1  0.96691144  0.44857127  0.75539626  1
+  C  C3  1  -0.03320702  0.64134941  0.20633883  1
+  C  C4  1  0.96666398  0.27109020  0.57634359  1
+  C  C5  1  0.46679395  0.69384378  0.99869043  1
+  C  C6  1  0.46684879  0.39572945  0.96294224  1
+  C  C7  1  0.96699980  0.81876273  0.38540448  1
+",-154.4087525
+1221,C-184054-4402-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47995000
+_cell_length_b   3.68752000
+_cell_length_c   4.89646000
+_cell_angle_alpha   93.01804000
+_cell_angle_beta   120.41969000
+_cell_angle_gamma   109.62088000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.97793709
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17660244  0.21562813  0.18734138  1
+  C  C1  1  1.05306211  0.81825923  0.26296068  1
+  C  C2  1  0.22469524  0.30460149  0.69163966  1
+  C  C3  1  0.79511116  0.85885902  0.48504762  1
+  C  C4  1  0.67270400  0.46207735  0.56132042  1
+  C  C5  1  0.62407665  0.37240108  1.05642444  1
+",-154.31641316666665
+6707,C-73649-6461-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45682000
+_cell_length_b   3.66566000
+_cell_length_c   6.40418000
+_cell_angle_alpha   74.60503000
+_cell_angle_beta   90.06010000
+_cell_angle_gamma   109.65570000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.11770510
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.75635602  0.39917389  0.24995768  1
+  C  C1  1  1.10219715  1.09366739  0.59070988  1
+  C  C2  1  -0.14805047  0.59473811  0.01347537  1
+  C  C3  1  0.47815434  0.84845683  0.67695668  1
+  C  C4  1  0.20518051  0.29626394  0.35519700  1
+  C  C5  1  0.69961751  0.28829915  0.87511121  1
+  C  C6  1  0.25498515  0.39995453  0.72942695  1
+  C  C7  1  0.47348839  -0.16012284  0.92583282  1
+",-154.28619
+7440,C-28258-8310-53,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.57449000
+_cell_length_b   3.64462000
+_cell_length_c   5.38500000
+_cell_angle_alpha   109.12215000
+_cell_angle_beta   63.65885000
+_cell_angle_gamma   88.85808000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.95973438
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.72402020  0.78938185  0.68671331  1
+  C  C1  1  0.91801464  0.38637928  0.49630867  1
+  C  C2  1  0.22126954  0.73341279  0.18783264  1
+  C  C3  1  -0.08215462  1.00171443  0.49610731  1
+  C  C4  1  0.22108674  0.34865914  0.18770772  1
+  C  C5  1  0.40959300  -0.05409319  -0.00302005  1
+",-154.0711796666667
+9876,C-134171-9685-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43242000
+_cell_length_b   4.20261000
+_cell_length_c   9.11955000
+_cell_angle_alpha   111.87966000
+_cell_angle_beta   94.74723000
+_cell_angle_gamma   90.06036000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   86.16154871
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79880104  0.48367091  1.01911053  1
+  C  C1  1  0.46338323  0.59704725  0.35304166  1
+  C  C2  1  0.05084829  0.68750110  0.68649214  1
+  C  C3  1  0.55103888  0.51974404  0.68578640  1
+  C  C4  1  -0.03661677  0.09704725  0.35304166  1
+  C  C5  1  0.46367974  0.26428991  0.35313003  1
+  C  C6  1  -0.20143764  0.15089169  1.01908268  1
+  C  C7  1  0.96367974  0.76428991  0.35313003  1
+  C  C8  1  0.29856236  0.65089169  1.01908268  1
+  C  C9  1  0.55084829  0.18750110  0.68649214  1
+  C  C10  1  1.05103888  1.01974404  0.68578640  1
+  C  C11  1  0.29880104  0.98367091  1.01911053  1
+",-154.45355583333333
+1250,C-75997-4752-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.66702000
+_cell_length_b   4.67672000
+_cell_length_c   3.77795000
+_cell_angle_alpha   72.37786000
+_cell_angle_beta   77.55787000
+_cell_angle_gamma   89.56012000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   60.18441415
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.50612528  0.97271164  0.62978225  1
+  C  C1  1  0.66638371  0.26214206  0.46805228  1
+  C  C2  1  0.98004564  -0.05472368  0.14981781  1
+  C  C3  1  0.69256509  0.78373411  0.44243178  1
+  C  C4  1  0.21388938  0.81245201  0.91817798  1
+  C  C5  1  -0.02462263  0.25838611  1.15503356  1
+  C  C6  1  0.21861332  0.50003647  0.91253763  1
+  C  C7  1  0.52904170  0.49525028  0.60085590  1
+",-154.20857125
+8265,C-40095-5757-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46366000
+_cell_length_b   3.39279000
+_cell_length_c   5.28789000
+_cell_angle_alpha   93.30115000
+_cell_angle_beta   90.00827000
+_cell_angle_gamma   111.17178000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.13757564
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.23861296  0.60958054  0.37661668  1
+  C  C1  1  0.87193175  0.86774453  0.77748238  1
+  C  C2  1  0.09987667  0.32080657  0.84834881  1
+  C  C3  1  0.27854189  0.68036145  0.65163329  1
+  C  C4  1  0.69308659  0.50857339  0.97459548  1
+  C  C5  1  0.72195424  0.57551272  0.24966415  1
+",-154.16841466666668
+2253,C-28242-4049-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.21964000
+_cell_length_b   2.48028000
+_cell_length_c   3.68915000
+_cell_angle_alpha   109.67281000
+_cell_angle_beta   104.86498000
+_cell_angle_gamma   90.00683000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98081560
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.26054255  0.04658454  0.74034665  1
+  C  C1  1  0.48216380  0.56577824  0.77924046  1
+  C  C2  1  0.68876511  0.79063536  0.22519221  1
+  C  C3  1  0.05390996  0.82391460  0.29477764  1
+  C  C4  1  0.55771537  0.36879346  0.38147900  1
+  C  C5  1  0.18464851  0.24554860  0.13762035  1
+",-154.30972066666666
+9400,C-176639-8613-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44939000
+_cell_length_b   6.16201000
+_cell_length_c   6.43184000
+_cell_angle_alpha   84.81254000
+_cell_angle_beta   90.05709000
+_cell_angle_gamma   87.49484000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   96.58562857
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.91176388  0.52379743  0.95006353  1
+  C  C1  1  0.91574392  0.48119889  0.72682605  1
+  C  C2  1  0.40123547  0.60388447  0.25911800  1
+  C  C3  1  1.41020074  0.54230665  0.05206597  1
+  C  C4  1  -0.03757790  0.09666349  0.48670392  1
+  C  C5  1  -0.09959266  0.68789655  0.57490710  1
+  C  C6  1  -0.03891825  0.05513653  0.26338056  1
+  C  C7  1  0.45018319  0.21187838  0.54168213  1
+  C  C8  1  0.46452716  -0.01623355  0.95262715  1
+  C  C9  1  0.42999505  0.36703177  0.67085454  1
+  C  C10  1  0.96812253  0.94211906  0.85714934  1
+  C  C11  1  0.89696758  0.64420794  0.35555350  1
+  C  C12  1  0.96803039  0.89084793  0.64013658  1
+  C  C13  1  0.46070942  0.04411934  0.15960812  1
+",-154.15301357142857
+4117,C-136227-7658-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48051000
+_cell_length_b   3.68910000
+_cell_length_c   4.21835000
+_cell_angle_alpha   104.80038000
+_cell_angle_beta   90.00178000
+_cell_angle_gamma   109.65161000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99009432
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.65817243  0.76642515  0.96555719  1
+  C  C1  1  0.08014453  0.61001808  0.09673951  1
+  C  C2  1  0.53817188  0.52393808  0.59276333  1
+  C  C3  1  0.11679843  0.68111738  0.46187621  1
+  C  C4  1  -0.14067718  0.16467400  0.89044691  1
+  C  C5  1  0.33960921  1.12638151  0.66820484  1
+",-154.30849266666667
+5604,C-136255-5449-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42991000
+_cell_length_b   3.38317000
+_cell_length_c   5.81268000
+_cell_angle_alpha   83.98003000
+_cell_angle_beta   88.87484000
+_cell_angle_gamma   66.83227000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.67687478
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.77541275  0.60231249  0.71107779  1
+  C  C1  1  1.10878555  0.93554819  0.37771561  1
+  C  C2  1  0.55193325  0.04852657  0.26635505  1
+  C  C3  1  0.88505465  0.38200333  0.93307626  1
+  C  C4  1  0.44180798  0.26920271  0.04449973  1
+  C  C5  1  0.21871993  0.71502249  0.59961795  1
+",-154.44000333333335
+9404,C-13665-1988-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50195000
+_cell_length_b   2.47034000
+_cell_length_c   7.78838000
+_cell_angle_alpha   89.99846000
+_cell_angle_beta   89.63699000
+_cell_angle_gamma   90.04280000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.13640492
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71055107  0.86876968  0.65091865  1
+  C  C1  1  0.71094791  0.86878797  1.02173830  1
+  C  C2  1  0.21537273  0.36862809  0.42179745  1
+  C  C3  1  0.70923269  0.36881492  0.93319724  1
+  C  C4  1  0.70872132  0.36878352  0.75288163  1
+  C  C5  1  0.71701494  0.36859289  0.30425544  1
+  C  C6  1  0.21385987  0.86868774  0.53314194  1
+  C  C7  1  0.71642276  -0.13140493  0.20226965  1
+",-154.2398375
+8353,C-96690-1826-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50937000
+_cell_length_b   4.39498000
+_cell_length_c   7.66569000
+_cell_angle_alpha   83.69176000
+_cell_angle_beta   75.60214000
+_cell_angle_gamma   76.84357000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   79.61012941
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.29627223  0.40892139  0.29071574  1
+  C  C1  1  1.10703285  0.94122935  0.26012111  1
+  C  C2  1  0.75067308  0.80948353  0.86169911  1
+  C  C3  1  0.16809476  0.49212391  0.45653320  1
+  C  C4  1  0.50142963  0.16255503  0.90257524  1
+  C  C5  1  0.36246775  0.72783837  0.75354667  1
+  C  C6  1  0.54595550  0.36360464  0.72526241  1
+  C  C7  1  0.20175629  0.65501175  0.15288156  1
+  C  C8  1  1.00079535  0.83982839  0.46629856  1
+  C  C9  1  0.76831726  0.60505144  0.03583100  1
+  C  C10  1  1.17493519  0.28115043  0.61729350  1
+  C  C11  1  0.59933203  0.12409735  0.20730132  1
+  C  C12  1  0.86565799  0.25008776  1.00802581  1
+  C  C13  1  0.38469580  0.93186057  0.57202867  1
+",-154.21083714285714
+6485,C-142746-5299-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.05261000
+_cell_length_b   2.42946000
+_cell_length_c   8.90986000
+_cell_angle_alpha   112.73045000
+_cell_angle_beta   102.98628000
+_cell_angle_gamma   70.22628000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.01432986
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79497130  0.29919033  0.74952978  1
+  C  C1  1  0.88067917  0.88152883  0.83275181  1
+  C  C2  1  0.29140704  0.80117206  0.25008112  1
+  C  C3  1  0.63191712  1.13154097  0.58280997  1
+  C  C4  1  1.03998684  0.05129056  -0.00003627  1
+  C  C5  1  0.12464232  0.63408513  0.08314851  1
+  C  C6  1  0.37765197  0.38317881  0.33309324  1
+  C  C7  1  0.54658324  0.54892272  0.49961315  1
+",-154.44298375
+5208,C-13897-9657-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47515000
+_cell_length_b   4.24856000
+_cell_length_c   3.72233000
+_cell_angle_alpha   64.03555000
+_cell_angle_beta   90.03707000
+_cell_angle_gamma   90.02015000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.19245546
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.25382547  0.81522461  0.93258989  1
+  C  C1  1  0.75386981  0.31449488  0.38735501  1
+  C  C2  1  0.25390297  0.53737731  0.36751738  1
+  C  C3  1  0.75370731  0.31433402  0.97902772  1
+  C  C4  1  0.25391159  0.53686449  0.77607829  1
+  C  C5  1  0.75379584  0.03649990  0.82183171  1
+",-154.28546516666668
+7136,C-189738-7344-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43941000
+_cell_length_b   6.40969000
+_cell_length_c   8.64321000
+_cell_angle_alpha   132.10126000
+_cell_angle_beta   89.98964000
+_cell_angle_gamma   100.97332000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   96.91990628
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.94868441  0.53186217  0.73453873  1
+  C  C1  1  0.74313652  0.15206998  0.73870026  1
+  C  C2  1  0.39434413  0.45724390  0.06833116  1
+  C  C3  1  0.79707270  0.24262669  0.50815524  1
+  C  C4  1  0.95654394  0.57994738  0.17436191  1
+  C  C5  1  0.07402625  0.81039539  0.40831557  1
+  C  C6  1  0.63419373  -0.09409623  0.05938904  1
+  C  C7  1  0.97105036  0.60265792  0.43579241  1
+  C  C8  1  0.28493442  0.23449975  0.84553559  1
+  C  C9  1  0.41771210  0.49533278  0.43281563  1
+  C  C10  1  0.51564704  0.66505580  0.83738532  1
+  C  C11  1  0.29314143  0.23477177  0.40301030  1
+  C  C12  1  0.66910966  0.99839442  0.50921714  1
+  C  C13  1  0.18379629  0.00485210  0.16844250  1
+",-154.28025357142857
+8037,C-193932-9509-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49146000
+_cell_length_b   3.59376000
+_cell_length_c   4.35359000
+_cell_angle_alpha   95.70407000
+_cell_angle_beta   106.61224000
+_cell_angle_gamma   69.66744000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.02632744
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36431101  0.62202338  0.14412178  1
+  C  C1  1  0.55234880  0.62199730  0.52022341  1
+  C  C2  1  0.44654941  0.25132477  0.93828055  1
+  C  C3  1  0.92264159  -0.11935020  0.52020952  1
+  C  C4  1  0.84040319  0.25134841  0.72605076  1
+  C  C5  1  0.73460380  0.88067588  0.14410789  1
+",-154.19817483333333
+8435,C-80150-2770-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43281000
+_cell_length_b   3.11451000
+_cell_length_c   8.38313000
+_cell_angle_alpha   93.76126000
+_cell_angle_beta   89.99964000
+_cell_angle_gamma   113.35992000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.16350018
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76376408  0.28344846  0.26914630  1
+  C  C1  1  0.76182448  0.27993939  0.60297382  1
+  C  C2  1  0.27141678  0.29794754  0.35284027  1
+  C  C3  1  0.23069918  0.22503780  0.85131103  1
+  C  C4  1  0.73855723  0.23963081  0.76818921  1
+  C  C5  1  0.27086971  0.29719540  0.51993935  1
+  C  C6  1  0.23123195  0.22663260  0.01793578  1
+  C  C7  1  0.73880669  0.24073772  0.10168473  1
+",-154.4615475
+7896,C-136387-2750-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48240000
+_cell_length_b   4.66929000
+_cell_length_c   12.51338000
+_cell_angle_alpha   88.71628000
+_cell_angle_beta   107.30959000
+_cell_angle_gamma   122.12324000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C20
+_cell_volume   115.60862469
+_cell_formula_units_Z   20
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.19031245  0.36885546  0.87446967  1
+  C  C1  1  0.23989563  0.98259297  0.16625346  1
+  C  C2  1  -0.10265497  0.79595659  0.72777736  1
+  C  C3  1  0.60657638  0.22547604  0.91453812  1
+  C  C4  1  0.97337021  1.21577117  0.16658597  1
+  C  C5  1  -0.06897275  0.30357210  0.74459799  1
+  C  C6  1  0.16015046  0.86185884  0.85915062  1
+  C  C7  1  0.63125422  0.07509086  0.36553567  1
+  C  C8  1  1.16271884  0.76514152  0.25985542  1
+  C  C9  1  0.17856915  0.12716921  0.69368967  1
+  C  C10  1  -0.02250754  0.92319577  1.03117578  1
+  C  C11  1  0.60379576  0.73093678  0.90917776  1
+  C  C12  1  0.70434360  0.14691999  0.03325690  1
+  C  C13  1  -0.21649747  0.42094314  0.56764723  1
+  C  C14  1  1.38157294  0.32550422  0.36536701  1
+  C  C15  1  0.59236496  -0.12493069  0.47133166  1
+  C  C16  1  0.14978050  0.60528704  0.68960567  1
+  C  C17  1  0.42538795  0.52755966  0.25994585  1
+  C  C18  1  -0.15095489  0.63257934  0.47085217  1
+  C  C19  1  0.04973827  0.18515337  0.56901634  1
+",-154.211338
+3513,C-102881-6389-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51363000
+_cell_length_b   4.57742000
+_cell_length_c   6.39218000
+_cell_angle_alpha   97.97624000
+_cell_angle_beta   99.61874000
+_cell_angle_gamma   78.04640000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   70.52684084
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.02831538  0.47756811  0.62732769  1
+  C  C1  1  0.47842992  0.15446974  0.18704533  1
+  C  C2  1  0.06364657  1.05834401  0.29550572  1
+  C  C3  1  1.12443225  0.15123392  0.53719160  1
+  C  C4  1  0.23743472  0.48005307  0.12475831  1
+  C  C5  1  0.61010454  0.10328343  -0.03517506  1
+  C  C6  1  0.63955916  0.89539678  0.80374627  1
+  C  C7  1  0.21714687  0.71264797  0.31580749  1
+  C  C8  1  0.70408109  0.98638187  0.59769410  1
+  C  C9  1  0.57443299  0.56942606  0.76884354  1
+  C  C10  1  0.79592703  0.69156481  0.45420332  1
+  C  C11  1  0.68376778  0.43122052  0.97992869  1
+",-154.08629083333332
+1871,C-189720-7233-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47229000
+_cell_length_b   3.23221000
+_cell_length_c   6.17439000
+_cell_angle_alpha   57.04575000
+_cell_angle_beta   78.43900000
+_cell_angle_gamma   67.52828000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   38.25543597
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.90993222  0.39620734  0.33634659  1
+  C  C1  1  0.40014939  0.00405383  0.74556160  1
+  C  C2  1  0.72378336  -0.01416008  0.11680272  1
+  C  C3  1  0.40922158  1.24424134  0.48929424  1
+  C  C4  1  0.89965972  0.85171766  0.89853849  1
+  C  C5  1  1.08588643  0.26185961  0.11798247  1
+",-154.2517395
+9998,C-41298-1814-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.51672000
+_cell_length_b   3.51709000
+_cell_length_c   3.31837000
+_cell_angle_alpha   90.00491000
+_cell_angle_beta   90.00005000
+_cell_angle_gamma   119.97962000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.55214939
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.92752482  0.29102119  0.21160615  1
+  C  C1  1  0.39133887  0.52282359  0.37790804  1
+  C  C2  1  0.62343045  -0.01362998  0.54362330  1
+  C  C3  1  0.39149399  0.21810811  0.71147068  1
+  C  C4  1  0.69576859  0.52264652  0.04353518  1
+  C  C5  1  0.92744077  0.98624018  0.87789906  1
+",-154.41064933333334
+6535,C-157672-8945-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.82696000
+_cell_length_b   4.25980000
+_cell_length_c   5.34739000
+_cell_angle_alpha   77.77210000
+_cell_angle_beta   83.16413000
+_cell_angle_gamma   65.95081000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   77.74825479
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.15047491  0.66511018  0.25314669  1
+  C  C1  1  0.92208641  1.02223952  0.71636595  1
+  C  C2  1  0.77273813  0.31720867  0.25613431  1
+  C  C3  1  0.61833239  0.17243772  0.49650404  1
+  C  C4  1  0.00546199  0.33303975  0.75975914  1
+  C  C5  1  0.47969489  0.92029166  0.40571156  1
+  C  C6  1  0.30922001  0.18320291  0.97911373  1
+  C  C7  1  0.44671583  0.43559915  1.06905170  1
+  C  C8  1  0.77611679  0.69053491  0.22149580  1
+  C  C9  1  0.32036089  0.74782883  0.63601454  1
+  C  C10  1  0.60700570  0.60761865  0.83917494  1
+  C  C11  1  0.67666346  0.88230070  -0.06753762  1
+  C  C12  1  0.15420842  0.03822821  0.21843266  1
+  C  C13  1  0.25013918  0.47339353  0.54293249  1
+",-154.23741285714286
+1660,C-136204-3885-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47770000
+_cell_length_b   2.47800000
+_cell_length_c   6.77758000
+_cell_angle_alpha   89.96990000
+_cell_angle_beta   111.41293000
+_cell_angle_gamma   120.03092000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.67146349
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.78845253  0.60033066  0.08685935  1
+  C  C1  1  0.56547810  -0.01130891  0.17021631  1
+  C  C2  1  0.67174333  0.54249256  0.50092787  1
+  C  C3  1  1.00962199  0.71172684  0.75184240  1
+  C  C4  1  0.45522526  0.43442009  0.83596508  1
+  C  C5  1  0.89313070  0.15301826  0.41744278  1
+",-154.53436833333333
+221,C-157701-8688-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43278000
+_cell_length_b   3.78330000
+_cell_length_c   4.91638000
+_cell_angle_alpha   85.69225000
+_cell_angle_beta   103.88323000
+_cell_angle_gamma   90.81803000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.80372301
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.08409233  0.96279690  0.77930134  1
+  C  C1  1  0.58257047  0.29616866  0.11262271  1
+  C  C2  1  1.02866048  0.18354650  0.00308833  1
+  C  C3  1  0.24925103  0.62935808  0.44591111  1
+  C  C4  1  0.69533363  0.51677569  0.33636096  1
+  C  C5  1  0.36198213  0.85011647  0.66970914  1
+",-154.47211383333334
+8945,C-9606-4988-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50381000
+_cell_length_b   4.80590000
+_cell_length_c   6.30016000
+_cell_angle_alpha   101.67339000
+_cell_angle_beta   78.38660000
+_cell_angle_gamma   105.19620000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   70.75901691
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.19999912  0.94904019  0.30314266  1
+  C  C1  1  0.38100000  0.54743284  0.53721681  1
+  C  C2  1  0.36744202  0.86169894  0.88049632  1
+  C  C3  1  0.64943675  0.38594249  0.83490931  1
+  C  C4  1  0.46701254  0.16769487  -0.01948191  1
+  C  C5  1  1.10101164  1.00595818  0.56065509  1
+  C  C6  1  0.38271265  0.21798537  0.20191581  1
+  C  C7  1  0.65044029  0.76385243  0.21228740  1
+  C  C8  1  -0.24764183  0.70790561  -0.04473876  1
+  C  C9  1  1.20077734  0.32750533  0.68066300  1
+  C  C10  1  0.48426293  0.85274174  0.63711575  1
+  C  C11  1  0.46383726  0.49655980  0.31582122  1
+",-154.27129583333334
+5379,C-9603-8567-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.75191000
+_cell_length_b   3.42343000
+_cell_length_c   6.13399000
+_cell_angle_alpha   116.76189000
+_cell_angle_beta   110.69416000
+_cell_angle_gamma   103.47038000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.10929691
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.99122701  0.79478078  0.49424945  1
+  C  C1  1  0.35752326  0.25554141  0.72907381  1
+  C  C2  1  0.62872749  0.79492464  0.49391643  1
+  C  C3  1  0.89144791  0.33659546  0.26132269  1
+  C  C4  1  0.72852429  0.25304574  0.72681191  1
+  C  C5  1  0.42774923  1.03745816  0.11256988  1
+  C  C6  1  0.19217415  0.55193094  0.87571021  1
+  C  C7  1  0.26231515  0.33390177  0.25936971  1
+",-154.07567125
+7551,C-102757-2964-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44609000
+_cell_length_b   6.09683000
+_cell_length_c   8.16860000
+_cell_angle_alpha   93.45580000
+_cell_angle_beta   91.39944000
+_cell_angle_gamma   101.63891000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   119.01634315
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46844366  0.20281138  0.92311547  1
+  C  C1  1  0.02410331  0.72557440  0.18134777  1
+  C  C2  1  0.55796207  0.77198133  0.73844081  1
+  C  C3  1  0.38378604  0.15708298  0.74713222  1
+  C  C4  1  0.87200451  0.45531437  0.57143496  1
+  C  C5  1  1.13675402  0.90490528  0.69621914  1
+  C  C6  1  1.02499351  0.71632210  0.00290126  1
+  C  C7  1  0.98764987  0.22171501  1.00448886  1
+  C  C8  1  1.03850876  0.25741194  0.17558425  1
+  C  C9  1  0.52756478  0.73248217  0.26745260  1
+  C  C10  1  0.92952351  0.24286087  0.66426311  1
+  C  C11  1  0.52497004  0.71970867  0.91650332  1
+  C  C12  1  0.55863727  0.27725770  0.25730557  1
+  C  C13  1  -0.37539251  0.26901115  0.43277214  1
+  C  C14  1  0.52494363  0.77780002  0.45105070  1
+  C  C15  1  0.44617951  0.59609312  0.58344339  1
+  C  C16  1  0.07759968  0.90862551  0.50783261  1
+  C  C17  1  0.06381094  0.15083331  0.49175852  1
+",-154.16737944444446
+5121,C-73615-2489-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42976000
+_cell_length_b   4.68358000
+_cell_length_c   5.66762000
+_cell_angle_alpha   108.26089000
+_cell_angle_beta   101.09371000
+_cell_angle_gamma   103.75079000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.94897218
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.22434964  0.16408191  0.98243527  1
+  C  C1  1  0.72120306  0.74445823  0.39656609  1
+  C  C2  1  0.72456862  0.91397850  0.23257313  1
+  C  C3  1  0.72383137  0.41346403  0.73171021  1
+  C  C4  1  0.22392206  0.66320722  0.48171795  1
+  C  C5  1  0.22161201  0.49519758  0.64704705  1
+  C  C6  1  0.72240230  0.24619614  -0.10191260  1
+  C  C7  1  0.22197435  0.99542839  1.14757490  1
+",-154.44281625
+3530,C-134216-4713-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.03498000
+_cell_length_b   2.43067000
+_cell_length_c   8.74425000
+_cell_angle_alpha   106.19809000
+_cell_angle_beta   69.98093000
+_cell_angle_gamma   93.16328000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.14493676
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.67863639  0.08782871  1.03259308  1
+  C  C1  1  0.68717573  0.00400897  0.44816775  1
+  C  C2  1  0.67916219  0.58826142  0.53268690  1
+  C  C3  1  0.69218329  0.83719101  0.28100950  1
+  C  C4  1  0.66478896  0.75504527  0.70069867  1
+  C  C5  1  0.66056476  0.33914963  0.78485799  1
+  C  C6  1  0.69180549  0.25333319  0.19736188  1
+  C  C7  1  0.67201498  0.50433310  0.94973553  1
+",-154.44681125
+1362,C-130526-2423-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48126000
+_cell_length_b   3.74201000
+_cell_length_c   5.36218000
+_cell_angle_alpha   134.18654000
+_cell_angle_beta   89.95073000
+_cell_angle_gamma   90.00598000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.70117753
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.56373168  0.44798938  0.15982088  1
+  C  C1  1  1.06366595  0.21856210  0.15960922  1
+  C  C2  1  0.56357731  0.42034168  0.86436660  1
+  C  C3  1  0.56375364  0.01011993  0.45502648  1
+  C  C4  1  0.06362820  0.65671853  0.86419624  1
+  C  C5  1  0.06377892  0.24680309  0.45459218  1
+",-154.15588616666668
+7667,C-141045-9787-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43623000
+_cell_length_b   5.23817000
+_cell_length_c   6.06877000
+_cell_angle_alpha   100.95503000
+_cell_angle_beta   119.48772000
+_cell_angle_gamma   95.76404000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   64.45771324
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.09021870  0.58219722  0.49679225  1
+  C  C1  1  0.79476076  0.86826659  0.13782240  1
+  C  C2  1  0.62730576  1.01431782  0.92905823  1
+  C  C3  1  0.28927306  0.37749607  0.64663256  1
+  C  C4  1  0.41848536  -0.16556239  0.25603699  1
+  C  C5  1  0.65432325  0.38459817  0.23352403  1
+  C  C6  1  -0.08380681  1.00041824  0.75790150  1
+  C  C7  1  0.64687515  0.75610646  0.51244635  1
+  C  C8  1  0.98797915  0.27788464  0.12789134  1
+  C  C9  1  0.81622132  0.25992369  0.68096235  1
+",-154.13277
+5593,C-134216-4713-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45388000
+_cell_length_b   5.61736000
+_cell_length_c   5.61378000
+_cell_angle_alpha   93.16155000
+_cell_angle_beta   64.01457000
+_cell_angle_gamma   64.07371000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   59.57437988
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.02717263  0.53171535  0.90649088  1
+  C  C1  1  0.26369180  0.24143475  0.46105029  1
+  C  C2  1  0.26389785  0.42632279  0.27531155  1
+  C  C3  1  1.02641995  0.87249238  0.56572230  1
+  C  C4  1  0.89964181  0.43626440  0.12995392  1
+  C  C5  1  0.66159068  0.72727775  0.57583952  1
+  C  C6  1  -0.10074193  0.09616065  0.47097789  1
+  C  C7  1  0.66265791  0.54183072  0.76110036  1
+",-154.1549425
+7776,C-134208-315-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47080000
+_cell_length_b   4.78546000
+_cell_length_c   7.27035000
+_cell_angle_alpha   104.06870000
+_cell_angle_beta   100.45130000
+_cell_angle_gamma   119.19444000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   68.07251798
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.67463709  0.81235261  0.40222640  1
+  C  C1  1  0.10515158  0.20865262  0.09292025  1
+  C  C2  1  0.27108875  0.95390652  0.34155749  1
+  C  C3  1  0.62959645  0.28818010  -0.00222244  1
+  C  C4  1  0.16614650  0.65053344  0.00637592  1
+  C  C5  1  0.29605624  0.21559436  0.77431662  1
+  C  C6  1  -0.17443350  0.84145512  0.62619470  1
+  C  C7  1  0.30000624  0.42565191  0.31410286  1
+  C  C8  1  0.91221298  0.85468739  0.10273999  1
+  C  C9  1  0.99642998  0.44404406  0.77813107  1
+  C  C10  1  1.11968925  0.62131652  0.62856581  1
+  C  C11  1  0.74934694  0.34000357  0.40870523  1
+",-154.17687083333334
+2236,C-107752-5318-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48743000
+_cell_length_b   3.87789000
+_cell_length_c   7.12612000
+_cell_angle_alpha   86.01934000
+_cell_angle_beta   100.04420000
+_cell_angle_gamma   89.99319000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.51637389
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.52126452  0.33791923  0.19751111  1
+  C  C1  1  0.84804528  0.62166533  0.85520275  1
+  C  C2  1  0.23438203  0.30280779  0.63676680  1
+  C  C3  1  0.43080780  0.10114096  1.01783990  1
+  C  C4  1  0.93150280  0.85875646  1.01911998  1
+  C  C5  1  0.70546393  0.13674060  0.57763680  1
+  C  C6  1  0.60268531  0.05650492  0.36283650  1
+  C  C7  1  0.34637899  0.38287560  0.85216821  1
+  C  C8  1  1.02068561  0.58065151  0.19616839  1
+  C  C9  1  0.10127754  0.81854263  0.35975286  1
+  C  C10  1  1.19855712  0.65644913  0.56170852  1
+  C  C11  1  -0.25621383  0.78347195  0.65368989  1
+",-154.32447916666666
+1248,C-145329-3191-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45220000
+_cell_length_b   4.51084000
+_cell_length_c   7.05632000
+_cell_angle_alpha   81.00646000
+_cell_angle_beta   110.35649000
+_cell_angle_gamma   105.76447000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   70.26068006
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.94793004  0.32003078  0.34735829  1
+  C  C1  1  0.29995503  0.30692609  0.70797690  1
+  C  C2  1  1.03354176  0.10994568  0.53864111  1
+  C  C3  1  0.15810843  0.67694613  0.38127807  1
+  C  C4  1  0.16860741  0.63576685  0.91028803  1
+  C  C5  1  0.28973584  0.23556995  0.23131864  1
+  C  C6  1  0.46554797  0.18897169  0.93128459  1
+  C  C7  1  1.06868684  0.88732369  0.18585264  1
+  C  C8  1  0.12290310  0.33714790  0.01417725  1
+  C  C9  1  -0.17218438  0.76185681  0.50915187  1
+  C  C10  1  0.90653711  0.53805124  0.69945486  1
+  C  C11  1  0.42289663  0.87923960  0.04303734  1
+",-154.12022333333334
+9088,C-184058-8674-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48140000
+_cell_length_b   3.68973000
+_cell_length_c   4.89494000
+_cell_angle_alpha   67.05427000
+_cell_angle_beta   59.53727000
+_cell_angle_gamma   70.34339000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.02588021
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.84589554  0.48767982  0.21139969  1
+  C  C1  1  0.15854149  1.00471755  0.63998405  1
+  C  C2  1  0.82873390  0.93277787  0.00517828  1
+  C  C3  1  0.14244403  0.45003792  0.43362345  1
+  C  C4  1  0.11966482  0.08990268  0.13601752  1
+  C  C5  1  -0.13195289  0.84822336  0.50866441  1
+",-154.31216933333334
+6732,C-152591-5216-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.37845000
+_cell_length_b   3.42014000
+_cell_length_c   4.23965000
+_cell_angle_alpha   77.23388000
+_cell_angle_beta   77.76896000
+_cell_angle_gamma   64.91018000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.88026263
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.80463724  -0.13863028  0.71213259  1
+  C  C1  1  0.53396919  0.81892752  1.01873239  1
+  C  C2  1  0.59091239  0.26162098  0.52152245  1
+  C  C3  1  1.19072803  0.47648203  0.71228972  1
+  C  C4  1  0.74871521  0.41883431  0.20921144  1
+  C  C5  1  0.14950345  0.20441985  1.01891051  1
+",-154.1021795
+9280,C-184040-7075-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46312000
+_cell_length_b   3.39408000
+_cell_length_c   5.28790000
+_cell_angle_alpha   86.51638000
+_cell_angle_beta   89.96682000
+_cell_angle_gamma   68.72421000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.10696717
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.22166311  1.09687785  0.85656826  1
+  C  C1  1  0.67293964  0.19726577  0.45462610  1
+  C  C2  1  0.25902574  0.02729777  0.13164990  1
+  C  C3  1  1.07890774  0.38525704  0.32808667  1
+  C  C4  1  -0.29467450  1.13032892  0.72967546  1
+  C  C5  1  0.85345167  0.83884975  0.25728502  1
+",-154.16437416666668
+5937,C-76004-9092-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.70161000
+_cell_length_b   4.94093000
+_cell_length_c   4.20289000
+_cell_angle_alpha   98.58947000
+_cell_angle_beta   68.58177000
+_cell_angle_gamma   57.05474000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   53.76724448
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.99221982  0.37264753  0.48112123  1
+  C  C1  1  0.08932934  0.79151428  0.92149162  1
+  C  C2  1  0.79159380  1.13020025  0.89241916  1
+  C  C3  1  0.51174307  0.45461561  0.55313869  1
+  C  C4  1  0.60854478  0.12749980  0.62106835  1
+  C  C5  1  0.03041301  0.79022100  0.25301300  1
+  C  C6  1  0.32851057  0.45161671  0.28207530  1
+  C  C7  1  0.12796580  0.20918262  0.69369046  1
+",-154.08826
+3357,C-184068-6075-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47977000
+_cell_length_b   3.68669000
+_cell_length_c   4.88874000
+_cell_angle_alpha   93.00683000
+_cell_angle_beta   120.40573000
+_cell_angle_gamma   109.59399000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.93033550
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.43319651  0.69648363  1.22795140  1
+  C  C1  1  0.31041892  0.29930019  0.30374815  1
+  C  C2  1  0.05192754  0.33896694  0.52592430  1
+  C  C3  1  0.48135363  0.78482820  0.73227262  1
+  C  C4  1  -0.07121073  -0.05871722  0.60167565  1
+  C  C5  1  0.88162703  0.85382887  0.09731647  1
+",-154.30983066666667
+9200,C-157672-8945-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.67278000
+_cell_length_b   5.47210000
+_cell_length_c   4.81535000
+_cell_angle_alpha   48.18517000
+_cell_angle_beta   94.61146000
+_cell_angle_gamma   118.44742000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.02280265
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.83596179  0.13319278  0.76449649  1
+  C  C1  1  0.77933037  0.07593574  0.32323944  1
+  C  C2  1  0.43409177  0.72990071  -0.02273210  1
+  C  C3  1  1.04878788  0.34610334  0.36020697  1
+  C  C4  1  0.39365070  0.69245891  0.70637245  1
+  C  C5  1  -0.00797011  0.28910712  0.91875266  1
+",-154.09796183333333
+5598,C-137379-9907-58,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.35885000
+_cell_length_b   3.41104000
+_cell_length_c   11.35136000
+_cell_angle_alpha   85.72926000
+_cell_angle_beta   85.75670000
+_cell_angle_gamma   90.48115000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C22
+_cell_volume   129.32519971
+_cell_formula_units_Z   22
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87387961  0.75858007  1.08142332  1
+  C  C1  1  1.03050528  0.10270323  0.75024354  1
+  C  C2  1  0.60996857  0.33779059  0.47117366  1
+  C  C3  1  0.69401971  0.77112180  0.75000077  1
+  C  C4  1  -0.32115793  0.89510294  0.19678972  1
+  C  C5  1  0.56027935  0.60976969  1.00648602  1
+  C  C6  1  0.74748558  0.79896151  0.61515229  1
+  C  C7  1  0.95255178  0.46794072  0.81313852  1
+  C  C8  1  0.14198756  0.68106917  0.34497213  1
+  C  C9  1  1.05933841  0.10827886  1.00665406  1
+  C  C10  1  0.42649962  0.97581214  0.54070773  1
+  C  C11  1  0.34349547  0.22783565  0.19669212  1
+  C  C12  1  -0.00964354  1.04101088  0.27618063  1
+  C  C13  1  0.20608485  0.42112760  0.08120040  1
+  C  C14  1  0.29893790  0.81586585  0.81418797  1
+  C  C15  1  -0.19509812  0.36769503  0.34487941  1
+  C  C16  1  0.49234834  0.54318180  0.26821492  1
+  C  C17  1  0.41090350  -0.03918579  0.93228185  1
+  C  C18  1  0.74672346  0.29801213  0.93182600  1
+  C  C19  1  1.06950915  0.11469804  0.61524428  1
+  C  C20  1  0.92220575  0.47244364  0.54924360  1
+  C  C21  1  0.27510031  0.64749635  0.47141947  1
+",-154.31875636363637
+2873,C-145323-1843-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.28408000
+_cell_length_b   3.28390000
+_cell_length_c   4.30252000
+_cell_angle_alpha   89.99885000
+_cell_angle_beta   89.99823000
+_cell_angle_gamma   81.50396000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.89171540
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53638610  0.57405136  0.64869268  1
+  C  C1  1  0.39909120  0.71138721  0.32813901  1
+  C  C2  1  0.30578954  0.34272205  0.14863533  1
+  C  C3  1  0.89920881  0.21157997  0.64865997  1
+  C  C4  1  0.66785142  -0.02001155  0.14865736  1
+  C  C5  1  0.16807637  0.48020894  0.82813130  1
+  C  C6  1  1.03625669  0.07382735  0.32810643  1
+  C  C7  1  0.80603496  0.84292077  0.82814281  1
+",-154.325115
+516,C-53797-7447-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48835000
+_cell_length_b   2.48747000
+_cell_length_c   6.57806000
+_cell_angle_alpha   79.03300000
+_cell_angle_beta   112.25540000
+_cell_angle_gamma   120.03913000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.62157615
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.59963456  0.10573840  0.24436557  1
+  C  C1  1  1.01622210  0.77234542  0.32759186  1
+  C  C2  1  0.26630122  0.77240507  0.57769890  1
+  C  C3  1  0.34955543  1.10567876  0.99425853  1
+  C  C4  1  0.93296789  0.43907174  0.91103224  1
+  C  C5  1  0.68288876  0.43901209  0.66092520  1
+",-154.54243566666665
+1113,C-184064-8186-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.55030000
+_cell_length_b   2.45986000
+_cell_length_c   6.29866000
+_cell_angle_alpha   101.07056000
+_cell_angle_beta   103.24784000
+_cell_angle_gamma   90.94754000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   37.67073912
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.10077575  0.30437676  0.85759936  1
+  C  C1  1  0.92750252  0.62514451  0.49650197  1
+  C  C2  1  0.70023869  0.38512247  1.01752683  1
+  C  C3  1  0.76825887  0.95187010  0.14875421  1
+  C  C4  1  0.03273417  0.73837437  0.72650726  1
+  C  C5  1  -0.12628389  0.06560529  0.37877477  1
+",-154.18200016666665
+8865,C-102905-3681-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42937000
+_cell_length_b   5.70596000
+_cell_length_c   6.41366000
+_cell_angle_alpha   83.79141000
+_cell_angle_beta   79.21036000
+_cell_angle_gamma   100.99255000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   84.77208388
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.54915202  0.90653079  0.54324298  1
+  C  C1  1  0.77371332  0.90827881  0.09870214  1
+  C  C2  1  0.94075752  0.40884730  0.26523490  1
+  C  C3  1  0.27399301  0.40935138  0.59857361  1
+  C  C4  1  0.21640729  -0.09311500  0.20951344  1
+  C  C5  1  0.88207327  0.90647397  0.87667349  1
+  C  C6  1  0.71632032  0.40744646  0.70944072  1
+  C  C7  1  0.43990459  0.90832348  0.76528441  1
+  C  C8  1  0.38259151  0.40654127  0.37668760  1
+  C  C9  1  0.60760422  0.40967548  0.93141306  1
+  C  C10  1  0.10739030  0.90868023  0.43151207  1
+  C  C11  1  1.04909244  0.40694634  0.04323568  1
+",-154.42552583333332
+7957,C-130532-5775-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.72806000
+_cell_length_b   3.72775000
+_cell_length_c   3.72671000
+_cell_angle_alpha   109.46063000
+_cell_angle_beta   70.52303000
+_cell_angle_gamma   70.50613000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.86005271
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.43686302  0.05970467  0.45443577  1
+  C  C1  1  -0.06268693  0.80941116  0.20367292  1
+  C  C2  1  0.18726712  0.30959019  0.95386532  1
+  C  C3  1  0.18732415  0.80947072  0.45378751  1
+  C  C4  1  0.93662696  0.06002753  0.95448484  1
+  C  C5  1  0.43717269  0.30953353  0.20378444  1
+",-154.08246116666666
+661,C-13647-2599-58,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.14117000
+_cell_length_b   4.56073000
+_cell_length_c   4.70047000
+_cell_angle_alpha   92.27664000
+_cell_angle_beta   106.54507000
+_cell_angle_gamma   62.99298000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.19444396
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.84322510  -0.10030888  0.46441570  1
+  C  C1  1  0.17507816  0.56608004  0.46523414  1
+  C  C2  1  0.34481617  0.89951874  -0.03596069  1
+  C  C3  1  0.59302372  0.39960371  0.71443419  1
+  C  C4  1  0.67667206  0.56585887  0.96502600  1
+  C  C5  1  -0.07518520  0.06591852  0.71544173  1
+  C  C6  1  0.09484690  0.39959307  0.21408573  1
+  C  C7  1  0.42669659  0.06602353  0.21484850  1
+",-154.4439225
+8544,C-134164-924-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.37554000
+_cell_length_b   4.07906000
+_cell_length_c   3.79134000
+_cell_angle_alpha   108.57915000
+_cell_angle_beta   107.03174000
+_cell_angle_gamma   100.24964000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.14346022
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.67899148  0.55520753  0.36467151  1
+  C  C1  1  0.79314189  0.20729259  0.14686460  1
+  C  C2  1  0.45601912  0.84413838  -0.09281709  1
+  C  C3  1  0.57012089  0.49619857  0.68929821  1
+  C  C4  1  0.11250272  0.20935672  0.54226779  1
+  C  C5  1  0.13626471  0.84183976  0.51142281  1
+  C  C6  1  0.94030520  0.36677922  0.87889954  1
+  C  C7  1  0.30797659  0.68416853  0.17448843  1
+",-154.22365375
+3307,C-80182-7828-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.30764000
+_cell_length_b   4.21832000
+_cell_length_c   5.24449000
+_cell_angle_alpha   113.88516000
+_cell_angle_beta   115.74334000
+_cell_angle_gamma   49.86809000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.55747387
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.33864300  0.44639931  1.01966017  1
+  C  C1  1  -0.11683109  1.12400444  0.19326483  1
+  C  C2  1  0.17798484  -0.09672993  0.73501146  1
+  C  C3  1  0.04359568  0.34156013  0.47741992  1
+  C  C4  1  0.88321176  0.76040662  0.19294842  1
+  C  C5  1  0.33860446  0.81007787  1.01987044  1
+  C  C6  1  1.04263833  0.66744717  0.47737521  1
+  C  C7  1  0.17724862  0.22912529  0.73497705  1
+",-154.21592125
+439,C-90835-6350-66,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47746000
+_cell_length_b   4.84858000
+_cell_length_c   5.40066000
+_cell_angle_alpha   124.38662000
+_cell_angle_beta   117.11164000
+_cell_angle_gamma   59.76537000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   44.89867029
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40629563  0.16022119  0.38613099  1
+  C  C1  1  -0.26045291  0.49366510  0.05293051  1
+  C  C2  1  0.66215690  0.91644878  0.89791706  1
+  C  C3  1  0.11072448  0.12415963  1.05296705  1
+  C  C4  1  0.77736596  0.79077395  0.38625282  1
+  C  C5  1  1.03247603  0.54645788  0.89791989  1
+  C  C6  1  0.85431670  0.36809183  0.54127158  1
+  C  C7  1  0.48391132  0.73806384  0.54118931  1
+",-154.42066
+784,C-107727-1562-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43137000
+_cell_length_b   4.20280000
+_cell_length_c   5.63987000
+_cell_angle_alpha   86.55377000
+_cell_angle_beta   95.95430000
+_cell_angle_gamma   89.81192000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.21415142
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.10306506  0.40185645  0.86154326  1
+  C  C1  1  0.19208793  0.72332139  0.35543340  1
+  C  C2  1  0.69209594  0.22333231  0.35538834  1
+  C  C3  1  0.60354900  0.56905348  0.86128176  1
+  C  C4  1  0.19261837  0.39057286  0.35508635  1
+  C  C5  1  0.10361418  0.06906969  0.86128027  1
+  C  C6  1  0.69261317  0.89057037  0.35513126  1
+  C  C7  1  0.60313204  0.90183695  0.86155545  1
+",-154.44667625
+1285,C-134187-5202-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.26533000
+_cell_length_b   3.42619000
+_cell_length_c   4.54480000
+_cell_angle_alpha   71.35883000
+_cell_angle_beta   89.97969000
+_cell_angle_gamma   89.96647000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.17817005
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.74383100  0.82886155  0.78652979  1
+  C  C1  1  0.11528298  0.77417967  -0.01675943  1
+  C  C2  1  0.46456085  0.46839471  0.95238733  1
+  C  C3  1  0.61531495  0.32888388  0.28673775  1
+  C  C4  1  -0.03554249  0.63544855  0.31725858  1
+  C  C5  1  0.24362248  0.27408832  0.48334151  1
+  C  C6  1  0.89675725  -0.03129920  0.45244850  1
+  C  C7  1  0.39649658  0.13515442  0.81725587  1
+",-154.1894025
+1959,C-177230-2077-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48714000
+_cell_length_b   7.23199000
+_cell_length_c   5.85578000
+_cell_angle_alpha   102.77711000
+_cell_angle_beta   76.28023000
+_cell_angle_gamma   94.05799000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   99.77009310
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20586686  0.72997426  0.05809823  1
+  C  C1  1  0.56640982  0.02723592  0.18659565  1
+  C  C2  1  0.20753800  0.16235711  0.84626860  1
+  C  C3  1  1.10719799  0.13646893  0.13763763  1
+  C  C4  1  0.42714842  0.70225810  0.66734366  1
+  C  C5  1  0.27739702  0.94621869  0.41202775  1
+  C  C6  1  0.56837546  0.64115489  0.40008797  1
+  C  C7  1  0.78159709  0.45197143  0.82309167  1
+  C  C8  1  0.73244150  0.83976248  1.01417036  1
+  C  C9  1  0.29602987  0.56316091  0.83833262  1
+  C  C10  1  0.58896373  0.43037609  0.31335446  1
+  C  C11  1  0.74261141  0.26806406  0.82283195  1
+  C  C12  1  0.09083416  0.33711575  0.27209801  1
+  C  C13  1  0.14703196  -0.01057174  0.65259163  1
+  C  C14  1  -0.09115567  0.82212122  0.74909608  1
+  C  C15  1  0.13363078  0.73203671  0.31542524  1
+",-154.119735
+7400,C-130534-5496-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43316000
+_cell_length_b   7.58333000
+_cell_length_c   7.19626000
+_cell_angle_alpha   120.55868000
+_cell_angle_beta   84.75127000
+_cell_angle_gamma   65.87574000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   96.49034848
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.72739424  0.19558332  0.00806236  1
+  C  C1  1  0.78398831  0.52271116  0.35901650  1
+  C  C2  1  0.37558272  0.89786556  0.46831237  1
+  C  C3  1  0.78352015  0.52575158  0.77030854  1
+  C  C4  1  0.42826536  0.04673240  -0.03447461  1
+  C  C5  1  0.56250460  0.31061668  -0.11200981  1
+  C  C6  1  -0.13287862  0.98587885  0.23281479  1
+  C  C7  1  -0.13687913  0.93005363  0.39346762  1
+  C  C8  1  0.45691906  0.77295691  0.57953182  1
+  C  C9  1  0.43879564  0.41573102  0.25356893  1
+  C  C10  1  0.87678222  0.80601231  0.71868006  1
+  C  C11  1  0.17512078  0.60910268  0.74773719  1
+  C  C12  1  0.38042299  1.00207461  0.14639070  1
+  C  C13  1  0.97831659  0.37919629  0.84759804  1
+",-154.25025
+2752,C-193928-6141-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45267000
+_cell_length_b   4.53659000
+_cell_length_c   5.89732000
+_cell_angle_alpha   52.31837000
+_cell_angle_beta   77.81632000
+_cell_angle_gamma   105.32451000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.71206767
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.84952881  0.78370722  0.72817087  1
+  C  C1  1  0.40200945  1.07579303  0.90860886  1
+  C  C2  1  0.50982835  0.91425707  0.53807667  1
+  C  C3  1  0.78603270  0.15203504  0.22156994  1
+  C  C4  1  -0.11286881  -0.01210107  0.85299576  1
+  C  C5  1  0.44589941  0.28222971  0.03154459  1
+",-154.20707283333334
+9216,C-130526-2423-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48779000
+_cell_length_b   2.48824000
+_cell_length_c   6.57715000
+_cell_angle_alpha   79.11043000
+_cell_angle_beta   100.90885000
+_cell_angle_gamma   59.97397000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.63023984
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.08158281  0.63028764  0.27916900  1
+  C  C1  1  0.33201891  1.04645697  0.19629896  1
+  C  C2  1  0.33174065  0.38044377  0.52910220  1
+  C  C3  1  0.33180701  0.71358365  0.86255352  1
+  C  C4  1  0.08201517  0.29662080  0.94616236  1
+  C  C5  1  1.08158436  -0.03606213  0.61228436  1
+",-154.5450085
+5488,C-126151-6380-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48130000
+_cell_length_b   4.83930000
+_cell_length_c   3.68957000
+_cell_angle_alpha   68.52724000
+_cell_angle_beta   70.32647000
+_cell_angle_gamma   104.81530000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.00398071
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.57275000  0.78270189  0.14032814  1
+  C  C1  1  0.86378957  0.65193836  0.42785943  1
+  C  C2  1  0.61249353  0.27836076  0.55684425  1
+  C  C3  1  0.90353310  0.14759722  0.84437554  1
+  C  C4  1  0.58916586  0.57602588  0.90121463  1
+  C  C5  1  0.88711724  0.35427324  0.08348905  1
+",-154.31174216666668
+9257,C-170350-1491-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47829000
+_cell_length_b   4.19032000
+_cell_length_c   8.34244000
+_cell_angle_alpha   90.28103000
+_cell_angle_beta   107.30461000
+_cell_angle_gamma   90.00020000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   82.71235128
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.57121031  1.01349413  0.25802926  1
+  C  C1  1  0.34207697  0.85600498  0.52767886  1
+  C  C2  1  0.61969820  0.35423373  0.30562020  1
+  C  C3  1  0.07820085  0.16580335  0.76261768  1
+  C  C4  1  0.39239074  0.87572011  1.07915943  1
+  C  C5  1  0.89509147  0.03496879  0.58125911  1
+  C  C6  1  0.57510785  0.38456944  0.75979457  1
+  C  C7  1  0.14528222  0.85506450  0.33229172  1
+  C  C8  1  0.81046735  0.35658406  0.49806864  1
+  C  C9  1  0.38595877  0.50923595  0.57329161  1
+  C  C10  1  0.19961572  0.88540917  0.88007701  1
+  C  C11  1  1.06174924  0.52288344  0.24835860  1
+  C  C12  1  0.88886339  0.66615813  0.07561239  1
+  C  C13  1  0.69733942  0.66638044  0.87785570  1
+",-154.2434157142857
+2970,C-72716-3406-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42798000
+_cell_length_b   6.32463000
+_cell_length_c   4.87995000
+_cell_angle_alpha   41.90708000
+_cell_angle_beta   60.09215000
+_cell_angle_gamma   67.34634000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.37381692
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.37979583  0.70395417  0.80994256  1
+  C  C1  1  0.44563359  0.27103101  0.67572926  1
+  C  C2  1  0.02908022  0.76438478  0.09907885  1
+  C  C3  1  0.38513070  0.62060332  0.38656978  1
+  C  C4  1  0.03640444  0.68118135  0.67551176  1
+  C  C5  1  0.96752813  0.11396418  0.81004268  1
+",-154.31521633333332
+1004,C-136208-4716-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51399000
+_cell_length_b   4.81130000
+_cell_length_c   4.18655000
+_cell_angle_alpha   125.11557000
+_cell_angle_beta   72.58128000
+_cell_angle_gamma   121.33062000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.38196879
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.34551404  0.77771376  0.57220036  1
+  C  C1  1  0.71360506  0.14631094  0.57219133  1
+  C  C2  1  0.86354381  0.49092029  0.96053977  1
+  C  C3  1  0.34627034  0.16580763  0.34852655  1
+  C  C4  1  0.19610065  0.82145778  -0.03954110  1
+  C  C5  1  0.71317520  0.53439579  0.34848999  1
+",-154.232507
+130,C-76006-9814-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.32642000
+_cell_length_b   3.36944000
+_cell_length_c   6.49887000
+_cell_angle_alpha   61.01153000
+_cell_angle_beta   80.93013000
+_cell_angle_gamma   68.14955000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   59.11424427
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.67073805  0.90283507  0.80134286  1
+  C  C1  1  0.67221131  0.44193062  0.26365338  1
+  C  C2  1  0.35957261  0.60649714  0.41291254  1
+  C  C3  1  0.04567886  1.06886083  0.26368761  1
+  C  C4  1  0.35703499  0.36517628  0.65228997  1
+  C  C5  1  0.54050739  0.80393320  0.03274611  1
+  C  C6  1  1.04429289  0.52988410  0.80143458  1
+  C  C7  1  0.17623189  0.16784717  0.03245824  1
+",-154.10060625
+7498,C-189728-4378-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46951000
+_cell_length_b   3.23596000
+_cell_length_c   5.18000000
+_cell_angle_alpha   92.03094000
+_cell_angle_beta   90.01302000
+_cell_angle_gamma   112.49183000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   38.21759824
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.14697133  0.93147550  1.03574697  1
+  C  C1  1  0.83779705  0.30868679  0.40986105  1
+  C  C2  1  0.16415019  -0.03816736  0.78022398  1
+  C  C3  1  0.66480199  0.96277428  0.62728921  1
+  C  C4  1  0.64696283  0.93123604  0.18863405  1
+  C  C5  1  0.47582490  0.58569405  0.40801034  1
+",-154.25328133333332
+1066,C-145340-6787-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42978000
+_cell_length_b   5.68691000
+_cell_length_c   8.03174000
+_cell_angle_alpha   52.47154000
+_cell_angle_beta   93.94913000
+_cell_angle_gamma   83.38322000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   86.05519963
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.85943069  0.54596918  0.09589831  1
+  C  C1  1  -0.03017955  0.32203331  0.31780484  1
+  C  C2  1  0.12548513  0.36849544  0.76954356  1
+  C  C3  1  0.52649637  0.20991284  0.42891529  1
+  C  C4  1  0.79167997  0.03816290  0.10340422  1
+  C  C5  1  0.30309440  0.65740286  -0.01517104  1
+  C  C6  1  0.63715958  0.98763903  0.65101988  1
+  C  C7  1  0.01499236  0.59033197  0.54733062  1
+  C  C8  1  0.34788656  -0.07354792  0.21445235  1
+  C  C9  1  0.68105315  0.25957194  0.88116959  1
+  C  C10  1  0.45878642  0.70214755  0.43634357  1
+  C  C11  1  1.19313491  0.87849969  0.76257500  1
+",-154.44788
+7721,C-40128-4097-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43177000
+_cell_length_b   4.65327000
+_cell_length_c   3.99167000
+_cell_angle_alpha   84.27592000
+_cell_angle_beta   89.55365000
+_cell_angle_gamma   105.76977000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.22292233
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.11534504  0.77725030  0.84815118  1
+  C  C1  1  0.78273862  0.11192704  0.17960535  1
+  C  C2  1  0.44848948  0.44373917  0.51528893  1
+  C  C3  1  0.66968242  0.88781212  0.96106808  1
+  C  C4  1  1.00312199  0.55483381  0.62707739  1
+  C  C5  1  0.33731574  0.22284196  0.29174948  1
+",-154.46268516666666
+7520,C-47633-513-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51973000
+_cell_length_b   4.72209000
+_cell_length_c   6.37742000
+_cell_angle_alpha   70.95665000
+_cell_angle_beta   97.84838000
+_cell_angle_gamma   92.37277000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   71.05593373
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87145933  0.25959661  0.03849240  1
+  C  C1  1  0.41899642  0.79717025  0.14986656  1
+  C  C2  1  0.46977667  0.47824630  0.30270974  1
+  C  C3  1  0.88698815  0.93119870  0.02171572  1
+  C  C4  1  1.00759219  0.80765653  0.45960634  1
+  C  C5  1  -0.02876723  -0.02316122  0.78721104  1
+  C  C6  1  1.02413767  0.47850754  0.44401603  1
+  C  C7  1  -0.07813512  0.76162501  0.69506366  1
+  C  C8  1  0.42522517  0.26028071  0.17869674  1
+  C  C9  1  0.47575478  0.94106640  0.33116958  1
+  C  C10  1  0.75543529  0.43541295  0.79117132  1
+  C  C11  1  0.14025966  0.30287511  0.69173817  1
+",-154.0965
+10027,C-107771-927-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.68791000
+_cell_length_b   4.89475000
+_cell_length_c   4.96144000
+_cell_angle_alpha   120.45558000
+_cell_angle_beta   109.63982000
+_cell_angle_gamma   92.90754000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   69.96417935
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.92873751  0.83541943  0.73922526  1
+  C  C1  1  0.44403035  0.40654428  0.15329324  1
+  C  C2  1  0.08607249  0.70455285  0.46340780  1
+  C  C3  1  0.99831550  0.20027184  -0.06079814  1
+  C  C4  1  0.44399633  0.40656113  0.65335934  1
+  C  C5  1  0.48332149  0.62888617  1.02450938  1
+  C  C6  1  0.08608092  0.70480276  -0.03640574  1
+  C  C7  1  0.48342066  0.62876894  0.52443038  1
+  C  C8  1  -0.07143884  0.83545685  0.23929585  1
+  C  C9  1  0.84209896  0.33126183  0.21593483  1
+  C  C10  1  0.84213162  0.33142062  -0.28391090  1
+  C  C11  1  -0.00180770  0.20030990  0.43928130  1
+",-154.31072416666666
+2736,C-150723-6210-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45505000
+_cell_length_b   4.41026000
+_cell_length_c   10.67330000
+_cell_angle_alpha   92.54738000
+_cell_angle_beta   90.68876000
+_cell_angle_gamma   97.14553000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C20
+_cell_volume   114.53537549
+_cell_formula_units_Z   20
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.13092584  0.91887516  0.13841375  1
+  C  C1  1  0.67462484  0.07633419  0.08979881  1
+  C  C2  1  -0.19093800  0.38009537  0.15667678  1
+  C  C3  1  0.46422578  0.64040054  -0.02393797  1
+  C  C4  1  0.78718459  0.06045158  0.72413650  1
+  C  C5  1  0.28266069  0.19226670  0.52612563  1
+  C  C6  1  0.64906876  0.91285525  0.34417421  1
+  C  C7  1  0.29325573  0.21049926  0.66849903  1
+  C  C8  1  0.17745941  0.01876017  0.27534980  1
+  C  C9  1  0.81046696  0.69594488  0.54428513  1
+  C  C10  1  0.31140804  0.52261546  0.48768363  1
+  C  C11  1  0.81457958  0.71461982  0.69086847  1
+  C  C12  1  -0.24202614  1.01212492  0.48353166  1
+  C  C13  1  0.96415235  0.61772884  0.06518462  1
+  C  C14  1  0.63286947  0.98106645  0.95656317  1
+  C  C15  1  0.31054265  0.53683002  0.73163393  1
+  C  C16  1  0.30235159  0.36667674  0.24541934  1
+  C  C17  1  0.33596618  0.41464653  0.86420663  1
+  C  C18  1  0.78042941  0.19691727  0.85909806  1
+  C  C19  1  0.41981047  0.57745514  0.35340851  1
+",-154.103406
+9930,C-141031-4766-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48202000
+_cell_length_b   3.73909000
+_cell_length_c   3.84484000
+_cell_angle_alpha   90.07402000
+_cell_angle_beta   89.97708000
+_cell_angle_gamma   89.96167000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.68198223
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.90774881  0.99182795  0.95024266  1
+  C  C1  1  -0.09169819  0.72564648  0.24482369  1
+  C  C2  1  0.40878915  0.48759040  0.65508163  1
+  C  C3  1  0.40877034  0.48814477  0.24457523  1
+  C  C4  1  0.40729662  0.22099196  -0.05022232  1
+  C  C5  1  0.90831957  0.72503114  0.65563771  1
+",-154.14891083333333
+7392,C-130499-1826-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48679000
+_cell_length_b   4.30175000
+_cell_length_c   4.30190000
+_cell_angle_alpha   131.75138000
+_cell_angle_beta   106.69568000
+_cell_angle_gamma   73.29219000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.58607202
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46506746  0.82029773  0.49158134  1
+  C  C1  1  0.29814112  0.73689825  1.07485329  1
+  C  C2  1  -0.03502419  0.07021693  0.74153189  1
+  C  C3  1  1.13142214  1.15361417  0.15817619  1
+  C  C4  1  0.63133048  0.40353338  0.40812673  1
+  C  C5  1  0.79825682  0.48693285  0.82485479  1
+",-154.54604783333335
+2803,C-92126-8113-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.60962000
+_cell_length_b   4.62565000
+_cell_length_c   3.67768000
+_cell_angle_alpha   113.41648000
+_cell_angle_beta   89.90145000
+_cell_angle_gamma   75.49133000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.18141522
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.25175404  0.56350771  0.32100325  1
+  C  C1  1  0.07840877  0.88653014  0.35791759  1
+  C  C2  1  0.25165563  0.56338591  0.69585454  1
+  C  C3  1  0.36882572  0.33104465  0.89281198  1
+  C  C4  1  0.07875780  -0.11384887  0.98263623  1
+  C  C5  1  0.96155514  0.11865896  0.78711061  1
+",-154.08856516666663
+2732,C-145340-6787-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.31902000
+_cell_length_b   3.31912000
+_cell_length_c   4.88603000
+_cell_angle_alpha   107.29761000
+_cell_angle_beta   107.29954000
+_cell_angle_gamma   97.20347000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.69772535
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.39267721  0.89201043  0.69496675  1
+  C  C1  1  0.74466429  0.24398456  0.69434284  1
+  C  C2  1  0.56817530  0.06727726  0.04642063  1
+  C  C3  1  0.91966939  0.41890611  0.04570820  1
+  C  C4  1  0.27867338  0.23107938  0.21199151  1
+  C  C5  1  0.58029809  0.53305465  0.52853331  1
+  C  C6  1  -0.06267328  -0.10925221  0.52866570  1
+  C  C7  1  0.92090033  0.87417582  0.21187137  1
+",-154.16395125
+1748,C-13933-5578-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43292000
+_cell_length_b   4.11191000
+_cell_length_c   4.49340000
+_cell_angle_alpha   96.31511000
+_cell_angle_beta   102.88504000
+_cell_angle_gamma   87.02145000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.53646982
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.34523338  0.78015111  1.01692043  1
+  C  C1  1  0.23331424  1.00254593  0.79543855  1
+  C  C2  1  -0.10053118  0.66795320  1.12765623  1
+  C  C3  1  0.67904615  0.11519520  0.68472096  1
+  C  C4  1  0.01142523  0.44492379  0.34869154  1
+  C  C5  1  0.56567358  0.33241747  0.45950280  1
+",-154.46000616666666
+3723,C-134158-3120-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.71780000
+_cell_length_b   4.80245000
+_cell_length_c   4.46479000
+_cell_angle_alpha   73.61664000
+_cell_angle_beta   77.79363000
+_cell_angle_gamma   70.10260000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   71.32320292
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.54225026  -0.05371229  0.72436295  1
+  C  C1  1  1.09846413  0.47338604  0.75447667  1
+  C  C2  1  0.52048739  0.45799669  0.72157403  1
+  C  C3  1  0.76460028  0.17564755  0.61163313  1
+  C  C4  1  0.81936074  0.74956149  0.22406377  1
+  C  C5  1  0.04184265  0.97849108  0.11130399  1
+  C  C6  1  0.84337349  0.24411765  0.25866719  1
+  C  C7  1  0.74339621  0.68044851  0.57705813  1
+  C  C8  1  0.10856514  0.13288943  0.76063530  1
+  C  C9  1  0.48689882  0.45150114  0.08147719  1
+  C  C10  1  0.47576392  0.79209754  0.07502677  1
+  C  C11  1  0.06603147  0.46690708  1.11405638  1
+",-154.14935166666666
+5365,C-76032-8953-54,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.95940000
+_cell_length_b   4.05722000
+_cell_length_c   6.72051000
+_cell_angle_alpha   117.38922000
+_cell_angle_beta   74.68392000
+_cell_angle_gamma   111.96501000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   88.34178260
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.19613842  0.42695398  -0.05720375  1
+  C  C1  1  0.89469436  0.45064122  0.10616202  1
+  C  C2  1  0.31023981  0.54447436  0.44371282  1
+  C  C3  1  0.58075916  0.18273311  0.63053720  1
+  C  C4  1  -0.06346122  0.83400802  0.27663291  1
+  C  C5  1  0.26211317  0.16349923  0.27918890  1
+  C  C6  1  0.52213225  0.74005268  0.93891990  1
+  C  C7  1  0.63454946  0.85858210  0.43979175  1
+  C  C8  1  0.07984956  0.71846073  0.64446667  1
+  C  C9  1  0.57129999  0.12131027  0.10366473  1
+  C  C10  1  0.75144345  0.56630973  0.73840934  1
+  C  C11  1  0.24854449  0.10248116  0.75224991  1
+",-154.2120175
+6339,C-130518-7047-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48142000
+_cell_length_b   4.21821000
+_cell_length_c   3.68910000
+_cell_angle_alpha   104.76211000
+_cell_angle_beta   70.37339000
+_cell_angle_gamma   90.02356000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.01627845
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.84397481  0.40076518  0.57306378  1
+  C  C1  1  0.52582832  0.69788124  0.21295449  1
+  C  C2  1  0.10386842  0.82915665  0.05669430  1
+  C  C3  1  0.64376892  0.32516191  0.97087398  1
+  C  C4  1  1.06520970  0.19442726  0.12822401  1
+  C  C5  1  0.32364103  0.62293627  0.61143124  1
+",-154.3112723333333
+9649,C-9586-1605-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45296000
+_cell_length_b   6.57240000
+_cell_length_c   7.00769000
+_cell_angle_alpha   87.67176000
+_cell_angle_beta   90.11364000
+_cell_angle_gamma   79.22316000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   110.88733563
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.39753228  1.07291870  0.57312411  1
+  C  C1  1  0.82993055  0.20848604  0.54750218  1
+  C  C2  1  0.08436192  0.70474793  0.22095740  1
+  C  C3  1  0.70272882  0.47710114  0.01403805  1
+  C  C4  1  0.77811188  0.32334088  0.73873185  1
+  C  C5  1  0.30215256  0.26879925  0.24267859  1
+  C  C6  1  0.47848755  0.90998031  0.43806018  1
+  C  C7  1  0.66622935  0.55001059  0.79779180  1
+  C  C8  1  1.01820906  0.83783644  0.37266807  1
+  C  C9  1  0.62130138  0.63685501  0.15227063  1
+  C  C10  1  0.00265426  0.87842613  0.81358580  1
+  C  C11  1  0.44013285  0.00250974  0.78995329  1
+  C  C12  1  0.32478909  0.23000287  0.84562985  1
+  C  C13  1  1.10459748  0.67437206  0.77691744  1
+  C  C14  1  0.79658450  0.27338681  0.34094326  1
+  C  C15  1  0.27157147  0.33987701  1.03754708  1
+",-154.18267375
+546,C-13946-920-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.31174000
+_cell_length_b   4.83802000
+_cell_length_c   5.09618000
+_cell_angle_alpha   84.99724000
+_cell_angle_beta   65.62048000
+_cell_angle_gamma   96.65489000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   73.04284123
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.31664961  0.73671911  0.77881226  1
+  C  C1  1  0.82914957  0.25708854  0.77424470  1
+  C  C2  1  0.31760275  0.25759405  0.28277286  1
+  C  C3  1  0.16563761  0.49643497  0.68239414  1
+  C  C4  1  0.46682670  0.49864747  0.37891442  1
+  C  C5  1  0.18311901  0.86302863  1.03023290  1
+  C  C6  1  0.69868685  0.87306489  0.53304363  1
+  C  C7  1  0.80433100  0.73788601  0.28735592  1
+  C  C8  1  0.44921631  0.13281717  1.02978462  1
+  C  C9  1  -0.06230669  0.11982547  0.52985515  1
+",-154.203595
+9979,C-92144-1112-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.41133000
+_cell_length_b   3.58618000
+_cell_length_c   9.12071000
+_cell_angle_alpha   108.16272000
+_cell_angle_beta   89.73714000
+_cell_angle_gamma   110.08327000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   69.91905481
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20141295  0.78505379  0.68721622  1
+  C  C1  1  0.77736184  0.93279308  0.09450868  1
+  C  C2  1  0.97326102  0.33976944  0.58910094  1
+  C  C3  1  0.28634132  0.95447712  0.17186579  1
+  C  C4  1  0.25392655  -0.11977617  0.85445094  1
+  C  C5  1  0.18889299  0.76915427  0.43019572  1
+  C  C6  1  0.76214499  -0.10149265  0.93292005  1
+  C  C7  1  0.33652833  0.06552546  0.34174273  1
+  C  C8  1  0.33897390  0.06544056  0.59267642  1
+  C  C9  1  0.96782991  0.33133469  0.41553311  1
+",-154.105448
+730,C-41273-2006-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47502000
+_cell_length_b   4.92726000
+_cell_length_c   5.94498000
+_cell_angle_alpha   101.83419000
+_cell_angle_beta   102.03253000
+_cell_angle_gamma   120.18817000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.02340238
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.22540754  -0.06940211  0.61576549  1
+  C  C1  1  0.71734068  0.57356579  0.21861950  1
+  C  C2  1  0.30442034  0.19578136  0.14749554  1
+  C  C3  1  0.04419064  0.23680067  0.54414823  1
+  C  C4  1  0.90594583  0.92912215  0.88165680  1
+  C  C5  1  1.00572773  0.71804118  0.50398233  1
+  C  C6  1  -0.20117792  0.45106849  0.62463063  1
+  C  C7  1  0.19075142  0.71350125  0.88143702  1
+  C  C8  1  0.75963471  0.09509959  0.25905542  1
+  C  C9  1  0.31056701  0.70715472  0.13790452  1
+",-154.398425
+3575,C-96678-2884-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48716000
+_cell_length_b   4.49817000
+_cell_length_c   7.71375000
+_cell_angle_alpha   70.44142000
+_cell_angle_beta   99.26744000
+_cell_angle_gamma   106.04924000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   77.92609641
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.61145213  0.19946672  0.55788965  1
+  C  C1  1  0.43531147  0.44525668  0.96080940  1
+  C  C2  1  0.87446012  0.76224315  0.52148424  1
+  C  C3  1  0.74008179  0.90868400  0.11139331  1
+  C  C4  1  1.04849408  0.38193183  0.25223277  1
+  C  C5  1  0.29942769  0.35278694  0.78356472  1
+  C  C6  1  0.21942443  0.75749233  0.22109354  1
+  C  C7  1  0.52621114  0.23085568  0.35646737  1
+  C  C8  1  -0.21705217  0.44100126  0.66051059  1
+  C  C9  1  0.35744153  0.85040937  0.39848126  1
+  C  C10  1  0.91328359  0.29355970  1.07039574  1
+  C  C11  1  1.04601571  0.00312018  0.62466526  1
+  C  C12  1  0.60753966  0.82049548  0.93022324  1
+  C  C13  1  0.13062202  -0.02803794  0.82608450  1
+",-154.4070842857143
+2865,C-76014-6220-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43186000
+_cell_length_b   3.20326000
+_cell_length_c   8.11152000
+_cell_angle_alpha   89.58748000
+_cell_angle_beta   81.18915000
+_cell_angle_gamma   68.42362000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.98363991
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.59629233  0.75796521  0.32215996  1
+  C  C1  1  -0.06749462  0.42002046  0.98895614  1
+  C  C2  1  1.09642562  0.25765066  0.82226517  1
+  C  C3  1  0.43146251  0.92219736  0.48871285  1
+  C  C4  1  0.68165412  1.17169159  0.73881050  1
+  C  C5  1  0.34713256  0.50641547  0.07234658  1
+  C  C6  1  0.84574656  0.00920950  0.57206872  1
+  C  C7  1  0.18218923  0.67052345  0.23886697  1
+",-154.45758125
+3652,C-28230-7089-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47408000
+_cell_length_b   5.46105000
+_cell_length_c   4.90670000
+_cell_angle_alpha   90.01317000
+_cell_angle_beta   120.29567000
+_cell_angle_gamma   89.99990000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.24115197
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.31625301  0.86412326  0.44344306  1
+  C  C1  1  0.65599976  0.94780512  0.78311449  1
+  C  C2  1  0.65642526  0.25444420  0.78357530  1
+  C  C3  1  0.65941870  0.23604105  0.28666721  1
+  C  C4  1  -0.34099143  0.96867956  0.28629758  1
+  C  C5  1  0.46017900  0.60213064  0.08674775  1
+  C  C6  1  1.32810886  0.86190971  0.95511829  1
+  C  C7  1  0.32830818  0.34187993  0.95534847  1
+  C  C8  1  0.31698381  0.34027361  0.44415174  1
+  C  C9  1  0.18145074  0.60228112  0.30805051  1
+",-154.35747899999998
+6599,C-92148-9593-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.17534000
+_cell_length_b   4.83259000
+_cell_length_c   3.61438000
+_cell_angle_alpha   68.05140000
+_cell_angle_beta   76.97836000
+_cell_angle_gamma   62.47615000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   45.52734430
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.50135834  0.30515953  0.43587030  1
+  C  C1  1  0.50183092  0.30396968  0.81757660  1
+  C  C2  1  0.51403654  -0.00936106  0.47157601  1
+  C  C3  1  0.51130434  0.80169102  0.87481434  1
+  C  C4  1  0.51366273  -0.00783726  0.08948301  1
+  C  C5  1  0.50364453  0.49441459  0.03258483  1
+",-154.15347583333332
+5244,C-142827-3466-55,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46793000
+_cell_length_b   6.71207000
+_cell_length_c   7.96850000
+_cell_angle_alpha   72.54114000
+_cell_angle_beta   86.08995000
+_cell_angle_gamma   87.83492000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C22
+_cell_volume   125.60287715
+_cell_formula_units_Z   22
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40843711  0.54039268  0.49450765  1
+  C  C1  1  0.37303760  0.26796204  0.84235431  1
+  C  C2  1  0.42509123  0.40880643  0.08752911  1
+  C  C3  1  -0.13193767  0.92799010  0.89857470  1
+  C  C4  1  1.04533903  0.00430340  0.36166693  1
+  C  C5  1  0.91889654  0.55347760  0.04427366  1
+  C  C6  1  0.48845822  0.92719913  0.48502510  1
+  C  C7  1  -0.10945406  0.66261390  0.19263710  1
+  C  C8  1  0.39712421  0.57230268  0.29988036  1
+  C  C9  1  0.81820871  0.89695296  0.10605767  1
+  C  C10  1  -0.10540442  0.71388744  0.87762236  1
+  C  C11  1  0.35803512  0.22355742  1.03511714  1
+  C  C12  1  0.26701378  1.00443001  0.15784278  1
+  C  C13  1  0.42048642  0.70424307  0.59530001  1
+  C  C14  1  0.43310721  1.08097355  0.61072552  1
+  C  C15  1  0.90787956  0.41276628  0.56904731  1
+  C  C16  1  0.38347327  0.04717313  0.81023522  1
+  C  C17  1  0.95322222  0.23216429  0.35374025  1
+  C  C18  1  0.43981270  0.35040110  0.27993344  1
+  C  C19  1  0.88123866  0.39629148  0.75929029  1
+  C  C20  1  0.89462101  0.64289288  0.71892094  1
+  C  C21  1  0.93144856  0.20693876  0.54267745  1
+",-154.1970990909091
+3633,C-9622-7780-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.53244000
+_cell_length_b   3.76534000
+_cell_length_c   6.28847000
+_cell_angle_alpha   126.64758000
+_cell_angle_beta   90.51065000
+_cell_angle_gamma   89.76377000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.10822864
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63613226  0.13574685  0.68602083  1
+  C  C1  1  0.64293445  0.86784250  0.22392046  1
+  C  C2  1  0.14198644  0.21315808  1.06453842  1
+  C  C3  1  0.64017483  0.62959867  0.50123583  1
+  C  C4  1  0.64385627  0.47916697  0.22415874  1
+  C  C5  1  0.63867700  0.27241870  0.50059761  1
+  C  C6  1  0.14070366  0.81437237  1.06402893  1
+  C  C7  1  0.13895739  0.30572794  0.85564679  1
+",-154.11278625
+4741,C-148258-4740-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.20838000
+_cell_length_b   3.95644000
+_cell_length_c   4.76457000
+_cell_angle_alpha   85.40325000
+_cell_angle_beta   128.22638000
+_cell_angle_gamma   108.75771000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.25235073
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.04857872  0.70000319  0.34903572  1
+  C  C1  1  0.88258606  0.19866304  0.85028996  1
+  C  C2  1  0.79847564  -0.05006219  0.59904905  1
+  C  C3  1  0.13251546  -0.05139434  0.60026717  1
+  C  C4  1  0.38261671  0.69864461  0.35022471  1
+  C  C5  1  0.29857409  0.45001614  1.09895642  1
+  C  C6  1  0.54845394  0.19996655  0.84895405  1
+  C  C7  1  0.63268108  0.44869870  0.10024342  1
+",-154.469975
+8079,C-130512-5016-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43768000
+_cell_length_b   4.23789000
+_cell_length_c   8.14593000
+_cell_angle_alpha   127.16340000
+_cell_angle_beta   98.64663000
+_cell_angle_gamma   89.90405000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   65.87449917
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.91029202  0.42446651  0.47227225  1
+  C  C1  1  1.25126913  0.53549113  1.15016365  1
+  C  C2  1  0.75979233  0.70689259  0.16189001  1
+  C  C3  1  0.56906501  0.70127317  0.79756551  1
+  C  C4  1  0.78802878  1.11884391  0.22628873  1
+  C  C5  1  0.23973907  0.16399562  0.13186704  1
+  C  C6  1  0.45774309  0.37909398  0.56655383  1
+  C  C7  1  0.12259488  -0.15789104  0.90079890  1
+  C  C8  1  0.45346235  0.00801108  0.54867703  1
+  C  C9  1  0.94559495  0.83702976  0.53734794  1
+",-154.275143
+5574,C-152607-7999-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42631000
+_cell_length_b   4.17526000
+_cell_length_c   8.50673000
+_cell_angle_alpha   86.99663000
+_cell_angle_beta   124.61030000
+_cell_angle_gamma   89.83858000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   70.77372252
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.67539306  0.76057012  0.95782342  1
+  C  C1  1  0.71431542  0.40290768  0.47789339  1
+  C  C2  1  0.77432024  0.77036703  0.25790874  1
+  C  C3  1  0.32853064  0.25745850  0.53488936  1
+  C  C4  1  0.60848483  -0.00580743  0.67354324  1
+  C  C5  1  0.36509849  0.89681719  0.05328441  1
+  C  C6  1  0.26739257  0.88539828  0.75297754  1
+  C  C7  1  0.29181704  0.24991779  0.01686938  1
+  C  C8  1  0.43413919  0.66377437  0.33790209  1
+  C  C9  1  0.74742702  0.40774657  0.99432592  1
+",-154.272417
+7396,C-149237-396-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49822000
+_cell_length_b   5.14250000
+_cell_length_c   10.60600000
+_cell_angle_alpha   80.38817000
+_cell_angle_beta   93.65338000
+_cell_angle_gamma   59.83695000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C20
+_cell_volume   114.39846729
+_cell_formula_units_Z   20
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.06850404  0.86051659  0.34538648  1
+  C  C1  1  1.19513605  1.04175552  0.13512521  1
+  C  C2  1  0.39486726  0.30088018  0.95678133  1
+  C  C3  1  0.02445967  0.71586753  0.75636307  1
+  C  C4  1  0.36014109  0.94748407  0.41391387  1
+  C  C5  1  0.82638209  0.17191266  0.76465515  1
+  C  C6  1  -0.00758442  0.37727114  0.55201230  1
+  C  C7  1  0.35794512  0.84005445  0.04397540  1
+  C  C8  1  0.38872271  0.43041532  0.82076101  1
+  C  C9  1  0.71989918  -0.05617609  0.96246833  1
+  C  C10  1  0.59473349  0.74902047  0.55170631  1
+  C  C11  1  0.69531715  0.53071794  0.12307688  1
+  C  C12  1  0.30206754  0.49203853  0.34225427  1
+  C  C13  1  0.00977500  0.84497568  0.61779679  1
+  C  C14  1  0.69043848  1.21009811  0.61835313  1
+  C  C15  1  -0.12148702  0.33039962  0.03266243  1
+  C  C16  1  0.98975615  0.32916523  0.41239553  1
+  C  C17  1  0.69203662  0.06535507  0.21179922  1
+  C  C18  1  0.32175288  0.42994695  0.20626121  1
+  C  C19  1  0.60113900  -0.03389016  0.81731068  1
+",-154.190153
+1211,C-113072-9570-57,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48378000
+_cell_length_b   3.82449000
+_cell_length_c   6.93053000
+_cell_angle_alpha   123.48920000
+_cell_angle_beta   100.24602000
+_cell_angle_gamma   108.97441000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.28843733
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87327015  0.89817564  0.21579138  1
+  C  C1  1  0.15543879  0.56911389  0.10945693  1
+  C  C2  1  0.91442162  0.36425231  0.83014995  1
+  C  C3  1  0.20302806  0.10517609  0.66514544  1
+  C  C4  1  0.17376983  0.82571764  0.88811284  1
+  C  C5  1  -0.06739181  0.62080564  0.60880657  1
+  C  C6  1  0.88494802  0.08468659  0.05310209  1
+  C  C7  1  0.21464245  0.29170698  0.50248919  1
+",-154.220245
+3029,C-184084-4554-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47295000
+_cell_length_b   3.23836000
+_cell_length_c   6.00570000
+_cell_angle_alpha   59.34553000
+_cell_angle_beta   78.05282000
+_cell_angle_gamma   67.46719000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   38.21188203
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71164875  0.59608012  0.89218999  1
+  C  C1  1  0.38623781  0.87674752  0.26321807  1
+  C  C2  1  0.69962790  0.87976992  0.63651965  1
+  C  C3  1  1.02562085  0.59732460  0.26533259  1
+  C  C4  1  0.21196003  0.44160183  1.04543582  1
+  C  C5  1  0.19984366  0.03299710  0.48341967  1
+",-154.24406966666666
+3732,C-189703-1540-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.51661000
+_cell_length_b   3.51759000
+_cell_length_c   3.31776000
+_cell_angle_alpha   89.99868000
+_cell_angle_beta   90.00206000
+_cell_angle_gamma   119.99996000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.54227297
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.60612216  0.31609935  0.34275243  1
+  C  C1  1  0.14257218  0.08450695  0.51001898  1
+  C  C2  1  0.14231649  0.38907434  0.84277987  1
+  C  C3  1  0.60601794  0.62111902  1.00990484  1
+  C  C4  1  -0.16176643  0.08476223  0.17524751  1
+  C  C5  1  0.91070906  0.62093741  0.67531568  1
+",-154.4099195
+1214,C-136210-9760-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48285000
+_cell_length_b   3.74782000
+_cell_length_c   3.84070000
+_cell_angle_alpha   89.98239000
+_cell_angle_beta   89.99775000
+_cell_angle_gamma   90.00998000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.73876700
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.82256793  0.52381831  0.05187601  1
+  C  C1  1  0.32242959  0.28788679  0.05202424  1
+  C  C2  1  0.82282497  0.79143808  0.34630088  1
+  C  C3  1  0.82251000  0.52367283  0.64086373  1
+  C  C4  1  0.32240213  0.28766942  0.64100959  1
+  C  C5  1  0.32281838  1.02007496  0.34641945  1
+",-154.1559365
+5669,C-141063-6212-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46190000
+_cell_length_b   4.23617000
+_cell_length_c   8.90347000
+_cell_angle_alpha   79.63882000
+_cell_angle_beta   90.00562000
+_cell_angle_gamma   90.01036000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   91.34039924
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.92935460  0.62023745  0.75159052  1
+  C  C1  1  -0.07969189  0.09536752  0.54468615  1
+  C  C2  1  0.91843443  0.82895670  0.44947814  1
+  C  C3  1  0.41852710  0.61003739  0.25942051  1
+  C  C4  1  0.41826602  0.24632888  0.30287348  1
+  C  C5  1  0.91816083  1.05569093  0.29071771  1
+  C  C6  1  0.92641288  0.97998109  0.71859200  1
+  C  C7  1  0.41837791  0.63880373  0.43461588  1
+  C  C8  1  0.42940528  0.46051743  0.76394974  1
+  C  C9  1  -0.08099960  0.78929953  0.19538132  1
+  C  C10  1  -0.07795561  -0.08902450  0.03060729  1
+  C  C11  1  0.41948453  0.27511604  0.47895156  1
+  C  C12  1  0.42652806  0.10208437  0.78956328  1
+  C  C13  1  0.42279506  0.97388524  0.95718862  1
+",-154.24639071428572
+3126,C-193922-5339-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45999000
+_cell_length_b   3.40414000
+_cell_length_c   5.31872000
+_cell_angle_alpha   96.22840000
+_cell_angle_beta   90.01221000
+_cell_angle_gamma   111.30440000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.21334083
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79516587  0.36414617  0.90665184  1
+  C  C1  1  0.42484382  0.62370183  0.30982930  1
+  C  C2  1  0.65263949  0.08182184  0.37739896  1
+  C  C3  1  0.25211271  0.27879698  0.50370782  1
+  C  C4  1  0.82550616  0.42656420  0.18246128  1
+  C  C5  1  0.28474745  0.34247738  0.77973079  1
+",-154.15632116666666
+3810,C-113056-5626-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45866000
+_cell_length_b   4.56498000
+_cell_length_c   6.96801000
+_cell_angle_alpha   82.16228000
+_cell_angle_beta   74.04618000
+_cell_angle_gamma   108.37590000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   69.19622956
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.78661793  0.77456727  0.78611587  1
+  C  C1  1  0.01332558  0.14955884  0.73695968  1
+  C  C2  1  -0.45695818  0.75156880  0.45929701  1
+  C  C3  1  0.58320809  0.53474133  0.31420907  1
+  C  C4  1  0.88495281  0.65904998  0.59323744  1
+  C  C5  1  0.71669970  0.04862089  0.31405981  1
+  C  C6  1  0.91538168  0.26649333  0.93359398  1
+  C  C7  1  -0.10783374  0.33216107  0.37965727  1
+  C  C8  1  0.10637637  0.62924050  0.91304078  1
+  C  C9  1  0.66433493  -0.00848397  0.11252599  1
+  C  C10  1  0.68755219  0.29575661  0.61688919  1
+  C  C11  1  0.99885864  0.76211434  0.10552501  1
+",-154.0908375
+9974,C-170882-2973-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51418000
+_cell_length_b   4.58824000
+_cell_length_c   6.66484000
+_cell_angle_alpha   69.90309000
+_cell_angle_beta   75.00102000
+_cell_angle_gamma   75.39403000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   68.60363162
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.41679535  0.31323103  0.95604283  1
+  C  C1  1  1.30559719  0.00322749  0.08526369  1
+  C  C2  1  0.45917891  0.77367900  0.00377295  1
+  C  C3  1  0.63638710  0.46239486  0.48001923  1
+  C  C4  1  0.12807832  0.31409663  0.61022010  1
+  C  C5  1  -0.05359811  0.41891369  0.81572204  1
+  C  C6  1  0.34863627  0.46372165  0.13401187  1
+  C  C7  1  0.81898613  0.35764077  0.27416062  1
+  C  C8  1  0.48611109  0.84114814  0.43688012  1
+  C  C9  1  0.00719825  -0.00584236  0.31283223  1
+  C  C10  1  0.75848706  0.78186898  0.77615434  1
+  C  C11  1  0.27909544  0.93592362  0.65202418  1
+",-154.1661333333333
+6637,C-53840-4050-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45068000
+_cell_length_b   4.62614000
+_cell_length_c   4.54054000
+_cell_angle_alpha   94.10602000
+_cell_angle_beta   74.36659000
+_cell_angle_gamma   122.01314000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.87358440
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.19476622  0.78420273  0.63398164  1
+  C  C1  1  0.83463824  0.10643706  0.99703795  1
+  C  C2  1  0.33811430  0.17603847  0.13011290  1
+  C  C3  1  -0.14631307  -0.02818477  0.69055363  1
+  C  C4  1  0.97685613  0.49742629  0.49366324  1
+  C  C5  1  0.31867378  0.31016193  0.43662103  1
+",-154.25597633333334
+5936,C-101107-3285-59,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52209000
+_cell_length_b   7.16695000
+_cell_length_c   6.53317000
+_cell_angle_alpha   85.61593000
+_cell_angle_beta   82.60493000
+_cell_angle_gamma   61.60533000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   103.00451488
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.18762362  0.80081909  0.46399629  1
+  C  C1  1  0.62029237  0.89955251  0.35843338  1
+  C  C2  1  0.83992203  0.20280705  0.82010349  1
+  C  C3  1  0.92424643  0.47014292  0.09687761  1
+  C  C4  1  0.67825362  0.20546777  0.48063160  1
+  C  C5  1  -0.12205751  0.81112637  0.14280713  1
+  C  C6  1  0.56162961  0.43068242  0.76689814  1
+  C  C7  1  0.50290680  0.42452623  0.54283347  1
+  C  C8  1  0.29762956  0.14317951  0.35935117  1
+  C  C9  1  0.31908498  0.88418357  0.02928325  1
+  C  C10  1  0.94155519  0.13046268  0.03036735  1
+  C  C11  1  0.57626183  0.77785294  0.81591584  1
+  C  C12  1  0.34024447  0.58186592  0.41122047  1
+  C  C13  1  0.03357431  0.85251525  0.69507772  1
+  C  C14  1  0.90208657  0.53205636  0.86023552  1
+  C  C15  1  0.26396769  0.22408082  0.13512977  1
+  C  C16  1  0.25812644  0.57207033  0.18856481  1
+  C  C17  1  0.78758219  0.08747667  0.68105260  1
+",-154.19864277777776
+7213,C-90800-1393-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47419000
+_cell_length_b   4.80367000
+_cell_length_c   4.80480000
+_cell_angle_alpha   61.94080000
+_cell_angle_beta   75.05895000
+_cell_angle_gamma   104.89248000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.63568006
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.18052595  0.63361876  0.29930924  1
+  C  C1  1  0.51348192  0.21662606  0.21626354  1
+  C  C2  1  0.51339038  0.71666994  0.71629134  1
+  C  C3  1  0.17998060  0.82031935  0.48660449  1
+  C  C4  1  0.51408044  0.90399718  0.90297547  1
+  C  C5  1  0.18059811  0.13365963  0.79929175  1
+  C  C6  1  0.51407578  0.40395964  0.40294195  1
+  C  C7  1  0.18010281  0.32034004  -0.01342578  1
+",-154.5230925
+3983,C-172914-2327-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.51285000
+_cell_length_b   4.19724000
+_cell_length_c   5.33372000
+_cell_angle_alpha   108.76880000
+_cell_angle_beta   117.33861000
+_cell_angle_gamma   100.78376000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   60.67494008
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63475341  0.00922431  0.62595868  1
+  C  C1  1  0.14579080  0.79046270  -0.08210941  1
+  C  C2  1  0.07284393  0.40869631  0.16307273  1
+  C  C3  1  0.83767625  0.51055812  0.55022255  1
+  C  C4  1  0.56691422  0.69402897  0.36965855  1
+  C  C5  1  0.49352130  0.31205590  0.61459186  1
+  C  C6  1  1.00460741  0.09343318  0.90673850  1
+  C  C7  1  0.64334677  0.84092230  0.15772522  1
+  C  C8  1  0.99598417  0.26163130  0.37488830  1
+  C  C9  1  0.80180832  0.59199799  -0.01766028  1
+",-154.139588
+6878,C-170908-5383-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48733000
+_cell_length_b   4.69569000
+_cell_length_c   5.29233000
+_cell_angle_alpha   47.49041000
+_cell_angle_beta   90.00243000
+_cell_angle_gamma   90.00427000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.56632520
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40885936  0.04496878  0.12167367  1
+  C  C1  1  0.40932734  0.28693423  0.46223394  1
+  C  C2  1  0.40908981  0.39997764  0.11371220  1
+  C  C3  1  -0.09106970  0.55539568  0.65551518  1
+  C  C4  1  0.90932829  0.05650923  0.68743260  1
+  C  C5  1  0.90880944  0.13168047  0.92040788  1
+  C  C6  1  -0.09096920  0.63047969  0.88865719  1
+  C  C7  1  0.40889046  0.64187229  0.45419466  1
+",-154.35843125
+2498,C-56485-2380-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52300000
+_cell_length_b   4.45535000
+_cell_length_c   5.45119000
+_cell_angle_alpha   50.30562000
+_cell_angle_beta   99.88805000
+_cell_angle_gamma   97.58220000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.42911648
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.15330384  0.74650777  0.80890304  1
+  C  C1  1  0.51315215  0.54253225  0.32123936  1
+  C  C2  1  0.85009994  0.15161152  0.91131971  1
+  C  C3  1  0.02532362  0.31240438  0.09020381  1
+  C  C4  1  0.56404854  0.23305603  0.29040729  1
+  C  C5  1  0.32556170  0.90751449  -0.01204486  1
+  C  C6  1  0.66269479  0.51626919  0.57786021  1
+  C  C7  1  0.61475462  0.82637307  0.60879924  1
+",-154.09670375
+5219,C-101121-514-62,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50130000
+_cell_length_b   7.29426000
+_cell_length_c   8.36104000
+_cell_angle_alpha   96.09340000
+_cell_angle_beta   107.39054000
+_cell_angle_gamma   99.85409000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C24
+_cell_volume   141.40600723
+_cell_formula_units_Z   24
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.89869390  0.65487324  0.93640523  1
+  C  C1  1  1.02926705  0.58076285  0.10094741  1
+  C  C2  1  -0.38858405  0.82318661  0.56013254  1
+  C  C3  1  0.71849095  0.84995610  0.15888399  1
+  C  C4  1  0.17988024  0.77081242  0.65509023  1
+  C  C5  1  0.87855090  0.21219730  0.13536617  1
+  C  C6  1  0.66551800  0.51681111  0.76938220  1
+  C  C7  1  0.27402538  0.30426833  0.48149448  1
+  C  C8  1  1.23496898  0.76350938  0.21801936  1
+  C  C9  1  0.36899726  0.69183797  0.38405141  1
+  C  C10  1  0.58128296  0.30696142  0.79133799  1
+  C  C11  1  -0.21997087  0.04682378  0.61821175  1
+  C  C12  1  -0.03636141  1.03035640  0.81175830  1
+  C  C13  1  0.53477305  0.48897705  0.15182176  1
+  C  C14  1  0.48638664  0.78241435  0.96089639  1
+  C  C15  1  0.33617694  0.17142483  0.61217981  1
+  C  C16  1  0.35201875  0.28678394  0.07087091  1
+  C  C17  1  0.85163182  0.43183705  0.49510665  1
+  C  C18  1  0.05034547  0.19646955  0.31599142  1
+  C  C19  1  0.86818399  0.04397979  0.20969947  1
+  C  C20  1  0.42299284  0.91253565  0.82984153  1
+  C  C21  1  0.13678814  0.24419387  0.87885264  1
+  C  C22  1  1.08970023  0.56019133  0.67069082  1
+  C  C23  1  -0.22035916  0.56113927  0.35940260  1
+",-154.22158875
+5777,C-57120-3338-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46412000
+_cell_length_b   5.61488000
+_cell_length_c   6.76744000
+_cell_angle_alpha   91.87963000
+_cell_angle_beta   82.66266000
+_cell_angle_gamma   97.02290000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   92.15502514
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71568610  0.62759644  0.91293438  1
+  C  C1  1  0.16067430  0.50952771  0.00676342  1
+  C  C2  1  0.24667311  0.25817334  0.06688969  1
+  C  C3  1  0.59068123  0.77747699  0.23369407  1
+  C  C4  1  0.59076567  0.92322576  0.42344280  1
+  C  C5  1  0.25393626  1.02522386  0.96356025  1
+  C  C6  1  0.16284426  0.07970581  0.42664316  1
+  C  C7  1  0.04170655  0.62580660  0.22241305  1
+  C  C8  1  0.29062503  0.27457484  0.28219401  1
+  C  C9  1  0.22448453  0.23742537  0.61688651  1
+  C  C10  1  0.37925708  0.80258924  0.63088638  1
+  C  C11  1  0.69830572  0.87855772  0.02202949  1
+  C  C12  1  0.29382779  1.03586175  0.74810195  1
+  C  C13  1  0.77408775  0.40281782  0.58174756  1
+  C  C14  1  -0.15638379  0.41896300  0.35247410  1
+  C  C15  1  0.80342750  0.64987875  0.68615318  1
+",-154.077915
+8809,C-40102-7970-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47543000
+_cell_length_b   3.72279000
+_cell_length_c   4.24867000
+_cell_angle_alpha   64.01331000
+_cell_angle_beta   89.98737000
+_cell_angle_gamma   89.95450000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.19503701
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.50350833  0.30637208  0.32173479  1
+  C  C1  1  0.50323864  0.74138836  1.04376953  1
+  C  C2  1  0.50290160  0.89825686  0.32156855  1
+  C  C3  1  1.00344581  0.28685977  0.54452903  1
+  C  C4  1  0.00322754  0.69486748  0.54462582  1
+  C  C5  1  1.00325887  0.85208734  0.82239287  1
+",-154.28658616666667
+7886,C-137399-7235-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47956000
+_cell_length_b   6.91585000
+_cell_length_c   6.73020000
+_cell_angle_alpha   101.72383000
+_cell_angle_beta   111.61293000
+_cell_angle_gamma   90.03826000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   104.69660628
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.61904604  0.82618793  0.71413476  1
+  C  C1  1  -0.13805797  0.58374411  0.45760914  1
+  C  C2  1  0.41794507  0.06396122  0.01602349  1
+  C  C3  1  0.45315580  0.69688396  0.04982593  1
+  C  C4  1  0.88480080  0.57259054  0.98205273  1
+  C  C5  1  0.34544740  0.87633015  0.44183878  1
+  C  C6  1  0.50175404  0.61448792  0.59754404  1
+  C  C7  1  0.26643769  0.86651623  0.86144773  1
+  C  C8  1  0.75760867  0.37010951  0.35426577  1
+  C  C9  1  0.64005615  0.46946535  0.73790111  1
+  C  C10  1  0.73720264  0.76200335  0.33460920  1
+  C  C11  1  0.30919484  0.08245035  0.40871227  1
+  C  C12  1  0.32377051  0.26309260  0.92178344  1
+  C  C13  1  1.13363368  0.31968724  0.23086175  1
+  C  C14  1  0.06262479  1.09877910  0.16163895  1
+  C  C15  1  0.93091192  0.37028691  0.02761571  1
+  C  C16  1  0.89089143  0.20615201  0.49029472  1
+  C  C17  1  1.11379892  0.33300462  0.71140927  1
+",-154.1761827777778
+8538,C-170908-5383-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49919000
+_cell_length_b   4.26059000
+_cell_length_c   5.15198000
+_cell_angle_alpha   61.00097000
+_cell_angle_beta   89.86721000
+_cell_angle_gamma   89.99839000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.98052700
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.33744307  0.01413346  0.59482877  1
+  C  C1  1  0.83736854  0.80353944  0.62133959  1
+  C  C2  1  0.33556749  0.58785074  0.08712280  1
+  C  C3  1  0.83601347  0.50869536  0.96147973  1
+  C  C4  1  -0.16302231  0.50213716  0.54119295  1
+  C  C5  1  0.83568906  0.20719162  0.88097071  1
+  C  C6  1  0.33549336  0.99695613  0.90680593  1
+  C  C7  1  0.33742671  0.42306489  0.41571462  1
+",-154.2349775
+6174,C-34631-1494-53,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50848000
+_cell_length_b   3.41731000
+_cell_length_c   6.35741000
+_cell_angle_alpha   97.96410000
+_cell_angle_beta   90.00822000
+_cell_angle_gamma   111.56014000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   50.11825259
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.50757672  0.01424377  0.32416026  1
+  C  C1  1  0.61245390  0.22319621  0.92748189  1
+  C  C2  1  0.34334324  0.68575234  0.48791949  1
+  C  C3  1  0.84413582  0.68735128  0.98775941  1
+  C  C4  1  0.44803673  0.89476418  0.09192530  1
+  C  C5  1  1.00813966  1.01539297  0.82410736  1
+  C  C6  1  0.94747039  -0.10644121  0.59198878  1
+  C  C7  1  0.11166893  0.22155066  0.42765432  1
+",-154.12461875
+9947,C-57137-3912-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42896000
+_cell_length_b   4.15630000
+_cell_length_c   6.21083000
+_cell_angle_alpha   72.45216000
+_cell_angle_beta   78.78253000
+_cell_angle_gamma   89.93005000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.53079499
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.21946586  0.08696189  0.78445953  1
+  C  C1  1  1.02395241  0.29547352  0.17849062  1
+  C  C2  1  -0.11906257  0.62362701  0.46386899  1
+  C  C3  1  0.67028963  1.13288772  0.88371722  1
+  C  C4  1  0.36740002  0.76632311  0.49244968  1
+  C  C5  1  0.57287382  0.25061376  0.07901875  1
+  C  C6  1  0.90046403  0.29142125  0.42317819  1
+  C  C7  1  0.34420969  0.09443394  0.53859512  1
+",-154.24644
+2364,C-130540-5836-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.79550000
+_cell_length_b   4.32512000
+_cell_length_c   5.87344000
+_cell_angle_alpha   53.98316000
+_cell_angle_beta   54.65257000
+_cell_angle_gamma   56.40810000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.34055150
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.36530746  0.17054666  0.36044383  1
+  C  C1  1  0.29092167  0.82558182  1.05072401  1
+  C  C2  1  0.01538881  0.78808714  0.36046205  1
+  C  C3  1  0.67266220  0.44331191  0.05057870  1
+  C  C4  1  1.07618253  0.22971487  0.86062273  1
+  C  C5  1  0.23114635  0.38404709  0.55047449  1
+",-154.12712183333335
+8061,C-176635-5996-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46200000
+_cell_length_b   6.13055000
+_cell_length_c   6.63125000
+_cell_angle_alpha   115.23306000
+_cell_angle_beta   79.28260000
+_cell_angle_gamma   101.58422000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   88.12306028
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.13093586  1.11942814  0.69341410  1
+  C  C1  1  0.26810483  0.20997852  0.51109452  1
+  C  C2  1  0.93626731  0.37878741  0.34147755  1
+  C  C3  1  0.46561653  0.73023018  0.62729621  1
+  C  C4  1  0.79863809  0.12839844  0.36603793  1
+  C  C5  1  0.36988800  0.78515799  0.87303125  1
+  C  C6  1  0.14199845  0.75434120  0.29542453  1
+  C  C7  1  0.59522632  0.38303247  0.02860013  1
+  C  C8  1  0.07155233  0.47024743  0.16052257  1
+  C  C9  1  0.05161179  0.83411461  0.55899430  1
+  C  C10  1  0.61015264  0.20756523  0.82501111  1
+  C  C11  1  0.82265597  0.80148664  0.98103896  1
+  C  C12  1  0.40280257  0.45923303  0.48599007  1
+  C  C13  1  0.72752761  0.85733892  0.22697637  1
+",-154.20805142857142
+3374,C-40140-2962-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48065000
+_cell_length_b   5.03939000
+_cell_length_c   5.04076000
+_cell_angle_alpha   65.65293000
+_cell_angle_beta   89.98686000
+_cell_angle_gamma   89.99052000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.41016372
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76752184  -0.06023297  0.34796459  1
+  C  C1  1  0.26761074  0.33014340  0.01379136  1
+  C  C2  1  0.76821825  0.05851650  0.75941879  1
+  C  C3  1  0.26797785  0.52185599  0.46394321  1
+  C  C4  1  0.76730744  0.79798079  0.67444275  1
+  C  C5  1  -0.23251511  0.26595121  0.20671037  1
+  C  C6  1  0.26741957  0.60530384  0.73816326  1
+  C  C7  1  0.76810202  0.35051143  0.46681699  1
+  C  C8  1  0.26769255  0.83783235  0.24675831  1
+  C  C9  1  0.26817254  1.05590465  0.93071217  1
+",-154.33966600000002
+2260,C-193930-7354-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.67864000
+_cell_length_b   4.32591000
+_cell_length_c   4.80187000
+_cell_angle_alpha   110.23289000
+_cell_angle_beta   87.00398000
+_cell_angle_gamma   123.06429000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.09040570
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.12576278  0.43789075  0.55690530  1
+  C  C1  1  0.74336212  0.05498030  0.55655009  1
+  C  C2  1  0.33741377  0.65088210  0.36443145  1
+  C  C3  1  0.39362590  0.70759701  0.86359239  1
+  C  C4  1  0.77543981  0.09044691  0.86369010  1
+  C  C5  1  1.18100062  0.49470243  0.05602378  1
+",-154.08188316666667
+3780,C-107760-8155-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.53149000
+_cell_length_b   4.80116000
+_cell_length_c   4.15929000
+_cell_angle_alpha   89.98522000
+_cell_angle_beta   90.21181000
+_cell_angle_gamma   74.02886000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.60070309
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.41848262  -0.08382542  0.87278110  1
+  C  C1  1  0.00419173  0.75269761  0.00313671  1
+  C  C2  1  0.27153929  0.20562610  1.02149245  1
+  C  C3  1  1.14958284  0.46280957  0.52147512  1
+  C  C4  1  0.27168201  0.20551870  0.35432110  1
+  C  C5  1  0.14899908  0.46312584  0.85414639  1
+  C  C6  1  1.00377368  0.75251736  0.37268268  1
+  C  C7  1  0.41815605  0.91589954  0.50307854  1
+",-154.263
+5950,C-170333-3244-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51487000
+_cell_length_b   4.23118000
+_cell_length_c   6.14243000
+_cell_angle_alpha   90.02993000
+_cell_angle_beta   114.41280000
+_cell_angle_gamma   90.00272000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   59.51695451
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.08981602  0.08396889  0.75411582  1
+  C  C1  1  -0.14530309  0.23747918  0.51663112  1
+  C  C2  1  0.97127935  0.08124540  0.13148034  1
+  C  C3  1  0.63012365  1.07931714  0.28843933  1
+  C  C4  1  0.97107838  0.71678930  0.13143990  1
+  C  C5  1  0.08973183  0.71385947  0.75407853  1
+  C  C6  1  0.72390527  0.58127853  0.88607517  1
+  C  C7  1  0.85461928  0.55954350  0.51652670  1
+  C  C8  1  0.72402972  0.21672153  0.88618809  1
+  C  C9  1  0.62988810  0.71815645  0.28837240  1
+",-154.136592
+4709,C-134173-4385-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48729000
+_cell_length_b   2.48740000
+_cell_length_c   8.24344000
+_cell_angle_alpha   81.30914000
+_cell_angle_beta   89.98547000
+_cell_angle_gamma   59.97544000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.48088697
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.69318862  -0.02844229  0.76313741  1
+  C  C1  1  0.50522242  0.34724372  0.20067471  1
+  C  C2  1  0.75549423  0.84745554  0.95065731  1
+  C  C3  1  0.25521050  0.84709713  0.45085059  1
+  C  C4  1  0.19291450  -0.02861374  0.26311671  1
+  C  C5  1  0.44316310  0.47167627  1.01302092  1
+  C  C6  1  -0.05706957  0.47131862  0.51323609  1
+  C  C7  1  1.00548410  1.34725855  0.70082866  1
+",-154.5406225
+1288,C-40126-7915-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46146000
+_cell_length_b   3.39656000
+_cell_length_c   6.06423000
+_cell_angle_alpha   109.99007000
+_cell_angle_beta   101.68499000
+_cell_angle_gamma   111.30111000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.18408719
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36976520  0.83817022  0.30471921  1
+  C  C1  1  0.46559027  0.35393369  0.98232237  1
+  C  C2  1  0.22289492  1.14378646  0.70682353  1
+  C  C3  1  0.83923151  0.90339935  0.17842372  1
+  C  C4  1  0.61184681  0.04696227  0.58021676  1
+  C  C5  1  -0.00355532  0.28971631  0.10903881  1
+",-154.16265516666667
+4418,C-130534-5496-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43944000
+_cell_length_b   4.22629000
+_cell_length_c   6.52853000
+_cell_angle_alpha   90.01494000
+_cell_angle_beta   79.24906000
+_cell_angle_gamma   89.98962000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   66.12628011
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.67109927  0.34260006  0.24405679  1
+  C  C1  1  -0.00125163  0.38423093  0.57892890  1
+  C  C2  1  0.68442212  0.99139024  0.22957451  1
+  C  C3  1  -0.11618574  0.33780241  0.80901686  1
+  C  C4  1  0.33809772  0.49085359  0.90228184  1
+  C  C5  1  0.21773263  0.49447603  0.14981050  1
+  C  C6  1  1.19075215  0.83451634  0.21505395  1
+  C  C7  1  0.55015678  0.38617996  0.47510487  1
+  C  C8  1  0.87605869  -0.01322228  0.82374749  1
+  C  C9  1  0.37145290  0.82952882  0.83514620  1
+",-154.255122
+4437,C-142757-9743-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43115000
+_cell_length_b   4.65586000
+_cell_length_c   5.81552000
+_cell_angle_alpha   114.04433000
+_cell_angle_beta   90.19185000
+_cell_angle_gamma   104.93033000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.64587149
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.95258485  0.30035966  0.11543291  1
+  C  C1  1  0.11901487  0.63358641  0.28149606  1
+  C  C2  1  0.36904581  0.13378971  1.03095373  1
+  C  C3  1  0.45257477  0.30028300  0.61558569  1
+  C  C4  1  0.70257417  0.80057199  0.36462406  1
+  C  C5  1  0.86904391  0.13370540  0.53107043  1
+  C  C6  1  0.61902244  0.63345683  0.78192361  1
+  C  C7  1  0.20256248  0.80046139  0.86507301  1
+",-154.45451875
+8138,C-126181-8319-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48185000
+_cell_length_b   3.68980000
+_cell_length_c   4.84124000
+_cell_angle_alpha   57.44446000
+_cell_angle_beta   75.06571000
+_cell_angle_gamma   70.30740000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.01882245
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.30683545  0.28796723  0.93374466  1
+  C  C1  1  0.85491165  0.70353838  0.42954913  1
+  C  C2  1  0.72851930  0.57544811  0.80294164  1
+  C  C3  1  0.53179017  0.04849399  0.72704753  1
+  C  C4  1  0.27656275  0.99100240  0.29875542  1
+  C  C5  1  1.05161508  0.23067889  0.50546342  1
+",-154.31375516666665
+8520,C-53804-8031-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45040000
+_cell_length_b   5.96605000
+_cell_length_c   5.47797000
+_cell_angle_alpha   56.68404000
+_cell_angle_beta   63.47186000
+_cell_angle_gamma   65.90344000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.43683306
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53695555  0.52900441  0.89174584  1
+  C  C1  1  1.04955947  0.35800267  0.04869974  1
+  C  C2  1  0.72339397  0.68478162  0.54827052  1
+  C  C3  1  0.20170967  0.73436491  0.02291110  1
+  C  C4  1  -0.20324805  1.06687814  0.59482230  1
+  C  C5  1  0.06679110  0.52991252  0.35957928  1
+  C  C6  1  0.12794517  0.87826735  0.45177237  1
+  C  C7  1  0.60911439  0.92278883  0.92890710  1
+  C  C8  1  0.72207366  0.35865860  0.37442693  1
+  C  C9  1  0.27332848  0.06622475  0.12014301  1
+",-154.213998
+4122,C-170920-9068-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42990000
+_cell_length_b   4.71905000
+_cell_length_c   6.14817000
+_cell_angle_alpha   106.38349000
+_cell_angle_beta   90.05837000
+_cell_angle_gamma   120.90488000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.11555720
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.28045206  0.36224959  0.49989269  1
+  C  C1  1  0.94806068  1.02961356  0.33261601  1
+  C  C2  1  -0.05175677  0.02979384  0.83231977  1
+  C  C3  1  0.94813970  0.52969639  1.08264660  1
+  C  C4  1  0.28065596  0.36243751  0.99959005  1
+  C  C5  1  0.28060030  0.86238582  0.24971386  1
+  C  C6  1  0.28066888  0.86248309  0.74957817  1
+  C  C7  1  0.94804658  0.52959799  0.58279026  1
+",-154.4401075
+6937,C-76030-274-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47113000
+_cell_length_b   2.54101000
+_cell_length_c   8.47187000
+_cell_angle_alpha   73.28000000
+_cell_angle_beta   73.04573000
+_cell_angle_gamma   89.98193000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.52973372
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.02664515  1.20510258  0.17821050  1
+  C  C1  1  0.74564749  0.48333296  0.90898791  1
+  C  C2  1  0.46707619  0.19681725  0.68816808  1
+  C  C3  1  0.79959678  1.01999521  0.35539229  1
+  C  C4  1  0.34996362  0.58456715  0.80573096  1
+  C  C5  1  0.56506394  0.29974444  0.08629249  1
+  C  C6  1  0.07916974  0.30494730  0.57617218  1
+  C  C7  1  0.19747540  -0.08296049  0.45861890  1
+",-154.255125
+481,C-152591-5216-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43008000
+_cell_length_b   2.42987000
+_cell_length_c   8.47326000
+_cell_angle_alpha   84.99956000
+_cell_angle_beta   98.32270000
+_cell_angle_gamma   120.02618000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.85563162
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.05253113  1.02320314  0.50652595  1
+  C  C1  1  0.89175232  0.02827361  0.18163147  1
+  C  C2  1  0.38630442  0.69051244  0.50687714  1
+  C  C3  1  0.05662864  0.69503744  0.85007720  1
+  C  C4  1  0.55869318  0.36199665  0.18164440  1
+  C  C5  1  0.72328491  1.02778682  0.85054394  1
+",-154.45535833333335
+6266,C-28256-8272-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46118000
+_cell_length_b   4.22086000
+_cell_length_c   5.56647000
+_cell_angle_alpha   98.92299000
+_cell_angle_beta   90.53700000
+_cell_angle_gamma   90.68285000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.11856811
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.04118294  0.29005793  0.37852255  1
+  C  C1  1  1.12362462  -0.07360965  0.38634214  1
+  C  C2  1  0.38149855  0.29325200  0.96659747  1
+  C  C3  1  0.76013371  0.79010464  -0.01262135  1
+  C  C4  1  0.26914258  0.94388061  0.89058282  1
+  C  C5  1  0.52259198  0.39705096  0.24399567  1
+  C  C6  1  0.62971816  0.76779625  0.25281485  1
+  C  C7  1  1.15000491  0.81770729  0.62702349  1
+  C  C8  1  -0.00036262  0.49253922  0.61794959  1
+  C  C9  1  0.87064257  0.44511513  0.87044129  1
+",-154.07122099999998
+5115,C-142755-3271-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48816000
+_cell_length_b   4.30407000
+_cell_length_c   4.30482000
+_cell_angle_alpha   99.59288000
+_cell_angle_beta   73.20169000
+_cell_angle_gamma   90.01925000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.46098428
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.15738218  0.53756442  0.12293457  1
+  C  C1  1  1.15400803  0.10024711  0.49803453  1
+  C  C2  1  0.65397347  0.60024604  0.49800683  1
+  C  C3  1  0.59246384  0.28743524  0.62297239  1
+  C  C4  1  1.09244081  0.78741949  0.62287375  1
+  C  C5  1  0.40415049  0.35039097  -0.00193235  1
+  C  C6  1  0.34258326  1.03756336  0.12290687  1
+  C  C7  1  -0.09587254  0.85037523  0.99796901  1
+",-154.5429175
+3105,C-176663-4376-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.41346000
+_cell_length_b   3.57933000
+_cell_length_c   8.92088000
+_cell_angle_alpha   89.26546000
+_cell_angle_beta   74.36503000
+_cell_angle_gamma   70.16975000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   69.54819047
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.13917810  0.49390957  0.43843972  1
+  C  C1  1  0.31934578  0.65057919  0.18162685  1
+  C  C2  1  1.00373450  0.24852532  0.69852614  1
+  C  C3  1  0.90776554  0.92190800  0.45681279  1
+  C  C4  1  0.53073838  0.56839152  0.01295508  1
+  C  C5  1  1.22456673  0.14225614  0.52931859  1
+  C  C6  1  0.14578221  0.49194129  0.93501639  1
+  C  C7  1  0.39372245  0.30860030  0.27724675  1
+  C  C8  1  0.03235789  1.03095516  0.27898917  1
+  C  C9  1  0.38821103  0.32764061  0.77473714  1
+",-154.104826
+4911,C-102875-8418-57,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44122000
+_cell_length_b   7.97007000
+_cell_length_c   5.72520000
+_cell_angle_alpha   88.78524000
+_cell_angle_beta   89.92421000
+_cell_angle_gamma   98.82870000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   110.04771532
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.01784208  0.22079911  0.85144431  1
+  C  C1  1  0.53665907  0.25904763  0.98700876  1
+  C  C2  1  0.23168645  0.66629316  0.08893221  1
+  C  C3  1  0.51374565  0.21420224  0.49552432  1
+  C  C4  1  0.92673497  0.04204920  0.77149458  1
+  C  C5  1  0.60774992  0.40578948  1.13819116  1
+  C  C6  1  0.33149049  0.85255722  0.52262735  1
+  C  C7  1  0.69437062  0.58013911  0.56213616  1
+  C  C8  1  0.78672409  0.76311886  0.53159649  1
+  C  C9  1  0.69124077  0.58373973  0.11550251  1
+  C  C10  1  1.05632576  0.30374971  0.60602806  1
+  C  C11  1  0.31794616  0.83752338  0.01594529  1
+  C  C12  1  0.85644437  0.91090760  -0.04658601  1
+  C  C13  1  0.42187632  1.03137905  0.61329660  1
+  C  C14  1  0.14856187  0.49124425  0.58154915  1
+  C  C15  1  0.53539170  0.25472839  0.24874787  1
+",-154.06998625
+3645,C-92154-4888-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47928000
+_cell_length_b   3.87923000
+_cell_length_c   6.40334000
+_cell_angle_alpha   107.58801000
+_cell_angle_beta   101.16582000
+_cell_angle_gamma   89.99590000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.48267339
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40277062  0.98953273  0.18383313  1
+  C  C1  1  0.74860229  0.64240632  0.87301784  1
+  C  C2  1  -0.02676637  0.06157969  0.32481240  1
+  C  C3  1  0.06349869  -0.14708638  0.50432469  1
+  C  C4  1  0.31348775  0.19796212  1.00471818  1
+  C  C5  1  0.62978192  0.02531933  0.63586026  1
+  C  C6  1  0.62987464  0.40801798  0.63598225  1
+  C  C7  1  0.31405070  0.60148756  1.00510558  1
+  C  C8  1  0.74825830  1.02532760  0.87291819  1
+  C  C9  1  1.06336566  0.44947795  0.50417548  1
+",-154.296113
+4345,C-177284-4704-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.81522000
+_cell_length_b   3.82041000
+_cell_length_c   4.11676000
+_cell_angle_alpha   111.45977000
+_cell_angle_beta   99.19160000
+_cell_angle_gamma   86.58679000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   69.57715367
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.61276075  -0.07372706  0.20813906  1
+  C  C1  1  0.85223573  0.65041883  0.14985576  1
+  C  C2  1  0.36187189  0.78726296  0.31441550  1
+  C  C3  1  0.41155662  0.41603044  0.31322640  1
+  C  C4  1  0.76465638  0.27192377  0.85138747  1
+  C  C5  1  0.16050232  0.27639930  0.41841799  1
+  C  C6  1  0.26960557  0.05399870  0.66326459  1
+  C  C7  1  0.01183016  0.93059958  0.77482794  1
+  C  C8  1  0.08661096  0.88256404  1.12258690  1
+  C  C9  1  0.68786654  0.32044944  0.50394840  1
+  C  C10  1  0.50598562  0.14976394  -0.03539408  1
+  C  C11  1  0.92250387  0.55268407  0.47585746  1
+",-154.14292666666668
+2335,C-28230-7089-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51370000
+_cell_length_b   4.18689000
+_cell_length_c   4.18657000
+_cell_angle_alpha   109.78722000
+_cell_angle_beta   107.46476000
+_cell_angle_gamma   107.43592000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.37756946
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64461590  0.22628991  0.34883206  1
+  C  C1  1  0.79440322  0.18232673  0.69326897  1
+  C  C2  1  0.12596872  0.51333324  1.02400394  1
+  C  C3  1  0.27605013  0.46942155  0.36838331  1
+  C  C4  1  0.27651579  0.85775047  -0.01988196  1
+  C  C5  1  0.64425084  0.83781331  0.73702217  1
+",-154.23231583333333
+2007,C-176646-2657-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52015000
+_cell_length_b   4.96507000
+_cell_length_c   5.97834000
+_cell_angle_alpha   120.59370000
+_cell_angle_beta   76.33342000
+_cell_angle_gamma   108.01892000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   60.94943743
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.81105924  0.11171295  0.43172281  1
+  C  C1  1  1.19759701  0.59979661  0.81402603  1
+  C  C2  1  0.15231760  0.41985743  0.53238415  1
+  C  C3  1  0.77788903  0.82450959  0.90872891  1
+  C  C4  1  0.54431039  -0.03693526  0.60736890  1
+  C  C5  1  0.38610739  0.61324884  0.41869004  1
+  C  C6  1  0.02386383  0.41010122  -0.02640865  1
+  C  C7  1  0.50002015  0.55315339  0.14707169  1
+  C  C8  1  0.97373246  1.05244675  0.78936815  1
+  C  C9  1  -0.29955071  0.88946628  0.18115387  1
+",-154.073579
+7533,C-157687-9066-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.96593000
+_cell_length_b   4.83979000
+_cell_length_c   5.70375000
+_cell_angle_alpha   93.58388000
+_cell_angle_beta   74.06510000
+_cell_angle_gamma   134.63040000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   73.54544441
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.59448031  0.29549613  -0.02048787  1
+  C  C1  1  0.18814023  0.33313827  0.38235864  1
+  C  C2  1  0.48087607  0.97921329  0.09163441  1
+  C  C3  1  0.44717359  0.46300590  1.12778177  1
+  C  C4  1  0.59455605  0.77658393  -0.02062285  1
+  C  C5  1  0.22186450  0.84944034  0.34627605  1
+  C  C6  1  0.83534852  0.80576245  0.73626234  1
+  C  C7  1  0.07400095  0.01662358  0.49440425  1
+  C  C8  1  0.83257020  0.50537596  0.73686782  1
+  C  C9  1  1.07453218  0.53558225  0.49442224  1
+",-154.24613
+2573,C-126161-9940-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.51703000
+_cell_length_b   2.48771000
+_cell_length_c   4.30383000
+_cell_angle_alpha   106.79196000
+_cell_angle_beta   114.10827000
+_cell_angle_gamma   90.01720000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.60267513
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64487336  0.11557791  0.88114378  1
+  C  C1  1  1.06194954  0.28218469  0.21470229  1
+  C  C2  1  -0.02179331  0.44891125  0.54781045  1
+  C  C3  1  0.39528287  0.61551802  0.88136895  1
+  C  C4  1  0.31154003  0.78224458  0.21447711  1
+  C  C5  1  0.72861621  0.94885135  0.54803562  1
+",-154.5481
+8889,C-142740-3180-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45776000
+_cell_length_b   6.10370000
+_cell_length_c   4.47787000
+_cell_angle_alpha   107.20100000
+_cell_angle_beta   74.55446000
+_cell_angle_gamma   89.63047000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   61.58698763
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.43188939  0.08253292  0.60332222  1
+  C  C1  1  1.11849140  0.77756175  0.22259661  1
+  C  C2  1  0.75778864  0.43440248  -0.05730266  1
+  C  C3  1  0.90828360  0.22094223  0.64627134  1
+  C  C4  1  0.05294660  0.30947778  0.35589413  1
+  C  C5  1  0.23431597  0.57342561  -0.01469603  1
+  C  C6  1  0.61311474  0.34734163  0.23406176  1
+  C  C7  1  0.54823135  0.87941981  0.36463014  1
+",-154.0675475
+7574,C-126149-3704-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48105000
+_cell_length_b   4.21635000
+_cell_length_c   3.68927000
+_cell_angle_alpha   104.78392000
+_cell_angle_beta   109.64222000
+_cell_angle_gamma   89.97405000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98972197
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.49666415  0.05527171  0.38811185  1
+  C  C1  1  0.97730842  0.83290981  0.34963250  1
+  C  C2  1  0.71898069  0.26169427  0.83349234  1
+  C  C3  1  0.29724499  0.13059381  -0.01004619  1
+  C  C4  1  0.17808639  0.75776359  0.74764255  1
+  C  C5  1  0.75645007  0.62686431  0.90476925  1
+",-154.3089535
+3047,C-172953-2094-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.53643000
+_cell_length_b   2.47945000
+_cell_length_c   6.25032000
+_cell_angle_alpha   78.47618000
+_cell_angle_beta   113.09630000
+_cell_angle_gamma   90.03473000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.29632862
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.74844961  -0.01432570  0.41994522  1
+  C  C1  1  -0.05402913  0.64383145  0.10452329  1
+  C  C2  1  0.54512237  0.33618460  0.72331598  1
+  C  C3  1  0.59937010  0.56283164  0.26533671  1
+  C  C4  1  0.40217416  0.90635429  0.58099961  1
+  C  C5  1  0.80245740  0.21537953  -0.03859551  1
+",-154.28188500000002
+2972,C-28224-863-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45968000
+_cell_length_b   3.39787000
+_cell_length_c   5.97752000
+_cell_angle_alpha   62.28886000
+_cell_angle_beta   78.09681000
+_cell_angle_gamma   68.74596000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.17679643
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.05703272  0.41901216  0.37531289  1
+  C  C1  1  0.22941149  -0.11825290  0.56945784  1
+  C  C2  1  0.65658047  0.34874749  0.24792058  1
+  C  C3  1  0.69283970  0.56126031  0.97216259  1
+  C  C4  1  0.20359300  0.66673651  0.84535746  1
+  C  C5  1  0.82798763  0.81168492  0.44212594  1
+",-154.1503285
+8960,C-106065-6878-70,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.33091000
+_cell_length_b   3.93307000
+_cell_length_c   9.91527000
+_cell_angle_alpha   89.25933000
+_cell_angle_beta   94.36513000
+_cell_angle_gamma   104.79262000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C20
+_cell_volume   125.22456901
+_cell_formula_units_Z   20
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.07670862  0.34708637  0.06767400  1
+  C  C1  1  0.24734577  0.56265618  0.42980953  1
+  C  C2  1  0.65092286  0.88434240  0.43900745  1
+  C  C3  1  1.09349663  0.37380520  0.30360705  1
+  C  C4  1  0.58127841  0.06813247  0.56581859  1
+  C  C5  1  0.40092117  1.14464295  0.85730486  1
+  C  C6  1  0.77568079  0.05959126  0.30833730  1
+  C  C7  1  0.50200871  0.40426245  0.53417509  1
+  C  C8  1  0.33111716  0.47428797  0.66101226  1
+  C  C9  1  -0.07930487  0.66850873  0.50836165  1
+  C  C10  1  0.64379272  0.38758198  0.76662753  1
+  C  C11  1  0.87747984  0.67465632  0.84964554  1
+  C  C12  1  0.21492691  0.50805595  -0.06184047  1
+  C  C13  1  1.08146545  0.94442035  0.75825575  1
+  C  C14  1  0.77190861  1.01902965  0.06987413  1
+  C  C15  1  0.58668164  0.84281102  0.93743445  1
+  C  C16  1  0.59999266  0.86741499  0.18874469  1
+  C  C17  1  -0.09411346  0.21075456  0.68628538  1
+  C  C18  1  0.23108193  0.81041521  0.63336870  1
+  C  C19  1  0.26084916  0.53119018  0.18591301  1
+",-154.08415399999998
+9894,C-72754-2980-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43021000
+_cell_length_b   2.43058000
+_cell_length_c   8.53604000
+_cell_angle_alpha   81.76295000
+_cell_angle_beta   88.35013000
+_cell_angle_gamma   59.97294000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.14929803
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53304686  0.19949568  0.14379442  1
+  C  C1  1  0.17745691  0.11543654  0.81124320  1
+  C  C2  1  0.51086649  0.44848039  0.81119928  1
+  C  C3  1  0.86605814  0.53312967  0.14375888  1
+  C  C4  1  0.75179157  -0.11638821  0.47755135  1
+  C  C5  1  0.41913193  0.54972283  0.47814247  1
+",-154.466722
+5175,C-193920-1389-54,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.69006000
+_cell_length_b   2.48143000
+_cell_length_c   4.84617000
+_cell_angle_alpha   75.22855000
+_cell_angle_beta   57.33363000
+_cell_angle_gamma   70.33994000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.02710192
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.32200095  0.72842863  0.32420092  1
+  C  C1  1  0.56089647  0.50698789  0.53054641  1
+  C  C2  1  0.97866630  0.04667407  0.02717575  1
+  C  C3  1  -0.15129538  -0.07141990  0.39944773  1
+  C  C4  1  0.26647445  0.46826628  0.89607707  1
+  C  C5  1  0.50536998  0.24682554  0.10242256  1
+",-154.3125595
+7129,C-176644-8612-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45866000
+_cell_length_b   3.40205000
+_cell_length_c   5.95902000
+_cell_angle_alpha   71.88326000
+_cell_angle_beta   78.13412000
+_cell_angle_gamma   111.24126000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.20634097
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.26892144  0.11195984  0.82809935  1
+  C  C1  1  0.90282164  0.57708569  1.02193063  1
+  C  C2  1  0.51439807  0.32611979  0.55223074  1
+  C  C3  1  0.37493563  0.64812016  0.14961085  1
+  C  C4  1  0.13030100  0.43296529  0.42541787  1
+  C  C5  1  0.74030902  0.18322363  0.95566806  1
+",-154.15061683333332
+6623,C-184046-597-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47234000
+_cell_length_b   3.76589000
+_cell_length_c   7.26635000
+_cell_angle_alpha   84.45960000
+_cell_angle_beta   99.80308000
+_cell_angle_gamma   89.97689000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   66.34473884
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.04770643  0.24728500  1.01966180  1
+  C  C1  1  0.60693824  0.25516494  0.13453095  1
+  C  C2  1  -0.04231510  1.16314644  0.84420235  1
+  C  C3  1  0.32521760  0.47724402  0.57850352  1
+  C  C4  1  0.67623103  -0.08144274  0.27161712  1
+  C  C5  1  0.32800123  0.87649053  0.58345645  1
+  C  C6  1  0.77199735  0.00434023  0.46878434  1
+  C  C7  1  0.77029909  0.39177707  0.46569378  1
+  C  C8  1  0.40229018  0.15123485  0.73437031  1
+  C  C9  1  0.67399914  0.54691855  0.26765728  1
+",-154.070046
+7566,C-113036-345-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44217000
+_cell_length_b   4.19331000
+_cell_length_c   6.54105000
+_cell_angle_alpha   109.27958000
+_cell_angle_beta   100.73405000
+_cell_angle_gamma   90.03036000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   61.98334158
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.19440915  1.11759164  0.52901156  1
+  C  C1  1  0.51768927  0.84489632  1.17876627  1
+  C  C2  1  0.85436806  0.47906022  0.84584898  1
+  C  C3  1  0.49631129  0.17102492  0.14148287  1
+  C  C4  1  0.29966666  0.36632501  0.73940760  1
+  C  C5  1  0.97191158  0.64548979  0.08895508  1
+  C  C6  1  -0.00992025  0.32252481  0.13100206  1
+  C  C7  1  0.63947534  0.00663028  0.42251278  1
+",-154.22754375
+6846,C-40095-5757-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46682000
+_cell_length_b   3.37929000
+_cell_length_c   5.79367000
+_cell_angle_alpha   81.15173000
+_cell_angle_beta   115.21132000
+_cell_angle_gamma   111.36323000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.69360375
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.16357625  0.90136598  0.35377008  1
+  C  C1  1  0.77504622  0.52524157  0.15290221  1
+  C  C2  1  0.99926176  0.77580066  0.75278289  1
+  C  C3  1  0.39764960  0.82277092  0.62817278  1
+  C  C4  1  0.62792564  0.07933132  0.22888003  1
+  C  C5  1  0.23785633  0.70210845  1.02753851  1
+",-154.15878666666666
+3858,C-170376-6835-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.68937000
+_cell_length_b   2.47953000
+_cell_length_c   4.89505000
+_cell_angle_alpha   59.52664000
+_cell_angle_beta   92.80300000
+_cell_angle_gamma   70.37589000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.00160341
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17146543  0.87992297  0.07452802  1
+  C  C1  1  0.41353147  0.38589438  0.44714904  1
+  C  C2  1  0.77298941  0.00467339  0.14933388  1
+  C  C3  1  0.81116636  1.26259271  0.37183058  1
+  C  C4  1  0.25619054  0.83332804  0.57796100  1
+  C  C5  1  0.32778370  0.43324681  0.94298760  1
+",-154.315582
+6186,C-177264-2024-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48614000
+_cell_length_b   4.14736000
+_cell_length_c   6.67679000
+_cell_angle_alpha   78.62131000
+_cell_angle_beta   89.99278000
+_cell_angle_gamma   90.00139000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.49067927
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.05463113  0.19359405  0.21244099  1
+  C  C1  1  0.55490707  0.69332630  0.59320931  1
+  C  C2  1  0.05470288  0.76522207  0.91875932  1
+  C  C3  1  1.05484150  0.21235523  0.59564353  1
+  C  C4  1  0.55471595  0.64282968  0.36853078  1
+  C  C5  1  0.55471552  0.91657716  0.98910027  1
+  C  C6  1  0.55481377  0.33858735  0.68078380  1
+  C  C7  1  0.55467984  0.27127356  0.90090242  1
+  C  C8  1  0.05463254  0.39749511  -0.01319310  1
+  C  C9  1  1.05484806  -0.15587297  0.66497360  1
+  C  C10  1  0.05473038  0.41639878  0.36919166  1
+  C  C11  1  0.55463505  0.96715489  0.21306002  1
+",-154.3982875
+2835,C-76026-3583-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48347000
+_cell_length_b   4.72100000
+_cell_length_c   6.27236000
+_cell_angle_alpha   100.46576000
+_cell_angle_beta   101.42754000
+_cell_angle_gamma   105.24693000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.38699713
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.74472141  0.82524040  0.51570011  1
+  C  C1  1  0.90046397  0.40858734  0.24657665  1
+  C  C2  1  0.47178560  0.91484078  0.88296903  1
+  C  C3  1  0.94714215  0.98112119  0.76557346  1
+  C  C4  1  0.32567892  0.58081143  0.92566979  1
+  C  C5  1  0.14087511  0.93128062  0.20467749  1
+  C  C6  1  0.51084944  0.29621402  0.57538439  1
+  C  C7  1  0.51956015  0.48714855  0.40305148  1
+  C  C8  1  0.91008340  0.60107320  0.07478187  1
+  C  C9  1  0.67545084  0.07057990  0.13326880  1
+  C  C10  1  0.28041700  0.96606683  0.44542582  1
+  C  C11  1  0.09405241  0.31544003  0.72288591  1
+",-154.41922333333335
+5316,C-170904-2880-62,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.56202000
+_cell_length_b   4.16141000
+_cell_length_c   5.99293000
+_cell_angle_alpha   89.98500000
+_cell_angle_beta   50.17606000
+_cell_angle_gamma   89.97856000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.07185364
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.92662509  0.74566651  0.57950496  1
+  C  C1  1  0.92659366  0.07673486  0.57977040  1
+  C  C2  1  0.31119946  0.57672718  0.32408116  1
+  C  C3  1  0.49009193  0.22597019  -0.12935183  1
+  C  C4  1  0.31085266  0.24565473  0.32431391  1
+  C  C5  1  -0.50963180  0.59568951  0.87036628  1
+  C  C6  1  0.74646005  0.09565010  0.03354034  1
+  C  C7  1  0.74689375  0.72599591  1.03326137  1
+",-154.27103875
+1087,C-96665-6528-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51445000
+_cell_length_b   4.18760000
+_cell_length_c   4.18711000
+_cell_angle_alpha   109.80096000
+_cell_angle_beta   107.41989000
+_cell_angle_gamma   107.43918000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.40864554
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.62609605  0.41311346  0.46349207  1
+  C  C1  1  0.62651300  0.02481263  0.85171695  1
+  C  C2  1  0.25823815  0.04431983  0.09465096  1
+  C  C3  1  0.25809980  0.65612005  0.48305889  1
+  C  C4  1  0.77628646  0.36927286  0.80794912  1
+  C  C5  1  1.10806934  0.69989598  0.13857911  1
+",-154.23472816666666
+5435,C-184068-6075-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.96495000
+_cell_length_b   3.61320000
+_cell_length_c   4.84416000
+_cell_angle_alpha   74.80636000
+_cell_angle_beta   71.64561000
+_cell_angle_gamma   100.09478000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   45.61186120
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.10239503  0.33205106  0.38235600  1
+  C  C1  1  0.39130020  0.76991990  0.88067499  1
+  C  C2  1  0.20217351  0.98554224  0.07150779  1
+  C  C3  1  0.70635073  -0.07156119  0.57238127  1
+  C  C4  1  0.89706429  0.71297721  0.38164334  1
+  C  C5  1  0.20212969  0.36675318  0.07073210  1
+",-154.13762366666666
+3927,C-172949-8358-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.26517000
+_cell_length_b   3.28092000
+_cell_length_c   3.63424000
+_cell_angle_alpha   104.59729000
+_cell_angle_beta   104.54293000
+_cell_angle_gamma   80.79476000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.27409710
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.23080363  0.77674863  0.58685293  1
+  C  C1  1  0.17509832  0.04229210  -0.03128926  1
+  C  C2  1  0.85871722  0.35984792  -0.03161521  1
+  C  C3  1  0.59250921  0.41488948  0.58648062  1
+  C  C4  1  0.44413550  0.98877708  0.35057283  1
+  C  C5  1  0.80460321  0.62817130  0.35020218  1
+",-154.20642866666665
+14,C-136235-2385-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.79923000
+_cell_length_b   4.82358000
+_cell_length_c   5.03031000
+_cell_angle_alpha   126.83590000
+_cell_angle_beta   110.67204000
+_cell_angle_gamma   98.85442000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.38824544
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.11111070  0.64318119  0.49605617  1
+  C  C1  1  0.14507190  0.37020029  0.53224113  1
+  C  C2  1  0.49240842  0.02412836  -0.12223718  1
+  C  C3  1  0.55093530  0.58370194  0.93685326  1
+  C  C4  1  0.76488428  -0.01081483  0.15046652  1
+  C  C5  1  0.70587860  0.42953345  1.09129919  1
+",-154.13520916666667
+9313,C-176661-8591-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.27037000
+_cell_length_b   3.27391000
+_cell_length_c   3.63431000
+_cell_angle_alpha   75.41568000
+_cell_angle_beta   75.43995000
+_cell_angle_gamma   80.81259000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.25556509
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.42253808  0.34655207  -0.11513351  1
+  C  C1  1  0.47763514  1.08057363  0.26615476  1
+  C  C2  1  0.21148593  0.13453207  0.64758102  1
+  C  C3  1  1.06173607  0.70826925  0.88444204  1
+  C  C4  1  0.84940756  0.49495597  0.64750877  1
+  C  C5  1  0.79404133  0.76301020  0.26584073  1
+",-154.202811
+6314,C-130215-2506-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48750000
+_cell_length_b   6.36557000
+_cell_length_c   8.82704000
+_cell_angle_alpha   70.04477000
+_cell_angle_beta   73.76188000
+_cell_angle_gamma   80.52952000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C22
+_cell_volume   125.76727695
+_cell_formula_units_Z   22
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.35919143  0.79640121  0.46144296  1
+  C  C1  1  0.21320118  0.98728405  0.03672607  1
+  C  C2  1  0.75081896  0.84936822  0.54156459  1
+  C  C3  1  0.37399335  0.56790217  1.06385681  1
+  C  C4  1  0.48754495  0.47944729  0.66972158  1
+  C  C5  1  0.35309500  0.27050681  0.80671028  1
+  C  C6  1  0.77182964  0.23566177  0.35079160  1
+  C  C7  1  1.08957991  0.85721216  0.21280850  1
+  C  C8  1  0.65383887  0.09268628  0.53936545  1
+  C  C9  1  0.46958362  0.54832541  0.50002400  1
+  C  C10  1  0.38568336  0.17778931  0.26544312  1
+  C  C11  1  0.06459199  0.11820125  0.62206619  1
+  C  C12  1  0.82131983  0.93712875  0.95419771  1
+  C  C13  1  0.64563490  0.48609933  0.33947709  1
+  C  C14  1  0.59983189  0.68690322  0.71002866  1
+  C  C15  1  0.13737771  0.24362779  -0.00219406  1
+  C  C16  1  0.19022947  0.59993981  0.23831436  1
+  C  C17  1  0.48119942  0.92567367  0.28577576  1
+  C  C18  1  0.90312199  0.68348760  0.96900591  1
+  C  C19  1  0.51767647  0.31437585  0.07558001  1
+  C  C20  1  -0.08032858  0.13569208  0.78822170  1
+  C  C21  1  1.01810554  0.68776076  0.79662823  1
+",-154.14474727272727
+1838,C-90856-6520-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45644000
+_cell_length_b   3.66482000
+_cell_length_c   6.47116000
+_cell_angle_alpha   73.56744000
+_cell_angle_beta   79.06637000
+_cell_angle_gamma   70.40821000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.35094611
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.47732345  1.00910197  0.57212401  1
+  C  C1  1  0.11143002  0.07541387  0.23803574  1
+  C  C2  1  0.88466946  0.47469720  0.28905977  1
+  C  C3  1  0.32581267  0.44750704  0.43435679  1
+  C  C4  1  0.38013880  -0.03280173  0.80850316  1
+  C  C5  1  0.83300296  -0.04459052  0.91497818  1
+  C  C6  1  0.10276456  0.84729019  0.48484362  1
+  C  C7  1  0.73497827  -0.08644541  0.15126213  1
+",-154.2888
+1446,C-96694-8817-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47870000
+_cell_length_b   3.68916000
+_cell_length_c   4.89450000
+_cell_angle_alpha   92.88886000
+_cell_angle_beta   120.43646000
+_cell_angle_gamma   109.64421000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.97492169
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.02381537  0.12164145  0.42104222  1
+  C  C1  1  0.45297926  0.56693841  0.62746946  1
+  C  C2  1  0.57602764  0.96467056  0.55223853  1
+  C  C3  1  0.06927261  0.20703992  0.92485863  1
+  C  C4  1  0.62261522  1.05054248  1.05603047  1
+  C  C5  1  0.19380980  0.60500227  0.84960389  1
+",-154.31191983333335
+5832,C-113036-345-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42468000
+_cell_length_b   3.55777000
+_cell_length_c   7.92468000
+_cell_angle_alpha   80.20941000
+_cell_angle_beta   111.39203000
+_cell_angle_gamma   74.01210000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.32882837
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76517411  0.37771478  0.90081368  1
+  C  C1  1  0.76519898  0.37775970  0.40075332  1
+  C  C2  1  0.76509778  -0.12225928  0.15076233  1
+  C  C3  1  0.09820911  0.54355175  0.81762070  1
+  C  C4  1  0.76528123  0.87770209  0.65079375  1
+  C  C5  1  0.09815100  1.04364948  0.06762401  1
+  C  C6  1  0.09822043  0.54383233  0.31763493  1
+  C  C7  1  0.09828287  0.04369965  0.56761928  1
+",-154.39124875
+741,C-80195-4794-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43292000
+_cell_length_b   6.41278000
+_cell_length_c   5.74726000
+_cell_angle_alpha   92.98528000
+_cell_angle_beta   96.54717000
+_cell_angle_gamma   101.02142000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   87.18835371
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.10091836  0.43578882  0.33283762  1
+  C  C1  1  0.76653202  0.76865442  0.32906959  1
+  C  C2  1  0.29472990  0.47669957  0.82769199  1
+  C  C3  1  0.51724429  0.92124259  0.82749749  1
+  C  C4  1  0.54527159  0.32453866  0.33436907  1
+  C  C5  1  0.43480339  0.10276556  0.33500477  1
+  C  C6  1  0.62814685  0.14314792  -0.17026439  1
+  C  C7  1  0.18494263  0.25514502  -0.16921174  1
+  C  C8  1  0.85041048  0.58770603  0.82673812  1
+  C  C9  1  0.96035672  0.80936280  0.82553375  1
+  C  C10  1  0.21020611  0.65724753  0.32846880  1
+  C  C11  1  0.87745825  0.99055368  0.33219664  1
+",-154.4543825
+6346,C-184082-7687-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.32115000
+_cell_length_b   3.35912000
+_cell_length_c   8.69665000
+_cell_angle_alpha   81.51142000
+_cell_angle_beta   110.94574000
+_cell_angle_gamma   83.01965000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   88.00728898
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.52233016  -0.18044425  -0.09737991  1
+  C  C1  1  0.54805254  0.65381502  0.60189152  1
+  C  C2  1  0.88077294  0.40946465  0.75556361  1
+  C  C3  1  0.85215717  0.52118079  0.90236193  1
+  C  C4  1  0.90200759  1.14619266  0.28968660  1
+  C  C5  1  0.20061640  0.07805782  0.75567093  1
+  C  C6  1  0.97159736  0.52698693  0.18752670  1
+  C  C7  1  0.57868675  0.55468748  0.45199180  1
+  C  C8  1  0.89374999  0.23426124  0.45203267  1
+  C  C9  1  0.52322804  0.73770643  0.07508499  1
+  C  C10  1  0.46116499  1.03240964  0.17668273  1
+  C  C11  1  0.24503368  0.80493873  0.28962101  1
+  C  C12  1  0.19627141  0.42961836  0.07508141  1
+  C  C13  1  0.22113688  -0.01745318  0.60197940  1
+",-154.1804892857143
+332,C-189713-5516-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.41031000
+_cell_length_b   3.81654000
+_cell_length_c   4.04338000
+_cell_angle_alpha   104.33446000
+_cell_angle_beta   99.76917000
+_cell_angle_gamma   60.05111000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.11347235
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.49003388  0.11945918  0.72132879  1
+  C  C1  1  0.08618973  0.33307552  0.52903092  1
+  C  C2  1  0.92888962  0.17516339  0.22104982  1
+  C  C3  1  0.52565210  0.38895576  1.02843654  1
+  C  C4  1  0.14342657  0.77156613  1.02894947  1
+  C  C5  1  0.87168169  0.73656773  0.72123556  1
+",-154.116229
+1849,C-40112-2876-53,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43001000
+_cell_length_b   2.43001000
+_cell_length_c   8.48015000
+_cell_angle_alpha   99.13821000
+_cell_angle_beta   82.13329000
+_cell_angle_gamma   120.01718000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.71161060
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46281130  -0.32176047  0.21980540  1
+  C  C1  1  1.33977674  0.79137213  0.55317954  1
+  C  C2  1  0.67267211  0.45806981  0.55378565  1
+  C  C3  1  0.55927686  0.53524371  0.89333243  1
+  C  C4  1  0.12942938  0.01145367  0.21993855  1
+  C  C5  1  -0.10733029  0.20184504  0.89317843  1
+",-154.45524
+2279,C-130507-2037-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48112000
+_cell_length_b   3.68740000
+_cell_length_c   4.22065000
+_cell_angle_alpha   74.98803000
+_cell_angle_beta   90.01506000
+_cell_angle_gamma   109.65368000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.96311770
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20574971  0.69052107  0.40246094  1
+  C  C1  1  0.88187191  1.04667725  0.70026934  1
+  C  C2  1  1.00679229  0.29372679  0.32611478  1
+  C  C3  1  0.42848120  0.13670119  0.19558304  1
+  C  C4  1  0.68538602  0.64962235  0.62434939  1
+  C  C5  1  0.46025418  0.20333715  0.83100232  1
+",-154.31050066666668
+1572,C-145343-7716-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.05456000
+_cell_length_b   4.84944000
+_cell_length_c   4.64551000
+_cell_angle_alpha   58.88267000
+_cell_angle_beta   74.97776000
+_cell_angle_gamma   90.52130000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.04072848
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.21924266  0.16465215  0.74130468  1
+  C  C1  1  1.05312092  0.33095469  0.90858487  1
+  C  C2  1  -0.28296390  0.16486574  0.24080820  1
+  C  C3  1  0.55502548  0.33075811  0.40894003  1
+  C  C4  1  0.71704252  0.66486084  0.24081383  1
+  C  C5  1  1.05312827  0.83095112  0.90858977  1
+  C  C6  1  0.55503693  0.83075170  0.40894873  1
+  C  C7  1  0.21924212  0.66464775  0.74130708  1
+",-154.41106125
+1268,C-142771-2182-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47951000
+_cell_length_b   2.47965000
+_cell_length_c   8.30017000
+_cell_angle_alpha   98.56240000
+_cell_angle_beta   81.43147000
+_cell_angle_gamma   120.02108000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.52747435
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.31448185  -0.08483739  0.85619234  1
+  C  C1  1  0.66929154  0.56061334  0.79325526  1
+  C  C2  1  0.14651422  0.08240267  0.35915322  1
+  C  C3  1  0.50117610  0.72773575  0.29621901  1
+  C  C4  1  -0.26940072  0.49905697  0.60752325  1
+  C  C5  1  1.08513873  0.14454878  0.54501847  1
+  C  C6  1  0.56308419  0.66532954  0.10783431  1
+  C  C7  1  0.25131138  0.97733074  0.04445395  1
+",-154.5285325
+6450,C-136239-2356-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42570000
+_cell_length_b   4.21363000
+_cell_length_c   4.21520000
+_cell_angle_alpha   89.78669000
+_cell_angle_beta   90.02733000
+_cell_angle_gamma   89.98456000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.08326379
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.38335273  0.16058665  0.49100356  1
+  C  C1  1  0.38365195  0.50873770  0.55230600  1
+  C  C2  1  0.38308853  0.10043785  0.14341622  1
+  C  C3  1  0.88304957  0.07155516  0.98759391  1
+  C  C4  1  -0.11658859  1.01224583  0.64016463  1
+  C  C5  1  0.88372861  0.66419561  0.58003848  1
+",-154.31059
+4510,C-142785-5183-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.58466000
+_cell_length_b   4.82485000
+_cell_length_c   7.13160000
+_cell_angle_alpha   67.31283000
+_cell_angle_beta   71.69675000
+_cell_angle_gamma   106.25090000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   69.26139423
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.23027003  0.18040929  0.03716503  1
+  C  C1  1  0.72455551  0.02606849  0.26753600  1
+  C  C2  1  0.19334739  1.06065164  0.87691075  1
+  C  C3  1  0.91820503  0.20939329  0.72685563  1
+  C  C4  1  1.15222542  0.56144882  0.68800183  1
+  C  C5  1  0.17979189  0.88832526  0.24130567  1
+  C  C6  1  0.71215643  0.52311633  0.90374114  1
+  C  C7  1  0.05779811  0.12163061  0.53885404  1
+  C  C8  1  0.11631833  0.60696097  0.19075825  1
+  C  C9  1  0.74927044  1.23296402  0.38573693  1
+  C  C10  1  0.75849240  0.73336764  0.66978436  1
+  C  C11  1  0.80541154  0.68546973  0.03602687  1
+",-154.08975083333334
+6684,C-141049-5998-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.11432000
+_cell_length_b   4.35939000
+_cell_length_c   5.88610000
+_cell_angle_alpha   93.38006000
+_cell_angle_beta   99.80143000
+_cell_angle_gamma   111.83463000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   72.44120712
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.10411365  0.91262821  0.70709192  1
+  C  C1  1  0.29621290  0.74373164  0.28579834  1
+  C  C2  1  0.90812259  0.74065910  -0.10791256  1
+  C  C3  1  0.27555577  0.91141188  0.08848519  1
+  C  C4  1  0.57774163  0.41172709  0.89311299  1
+  C  C5  1  0.97173753  0.24603942  0.47483400  1
+  C  C6  1  0.64774044  0.91781052  0.47393222  1
+  C  C7  1  0.21942031  0.24090505  0.70825562  1
+  C  C8  1  0.96581594  0.41410110  0.28653513  1
+  C  C9  1  0.60298735  0.24200279  0.08904885  1
+",-154.128637
+6170,C-41278-5784-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48125000
+_cell_length_b   3.68929000
+_cell_length_c   4.84195000
+_cell_angle_alpha   111.54256000
+_cell_angle_beta   104.80574000
+_cell_angle_gamma   109.67007000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99579739
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.16667091  1.00756250  0.09401903  1
+  C  C1  1  0.41696621  0.13677588  0.46683187  1
+  C  C2  1  1.12614666  0.42445310  0.59760227  1
+  C  C3  1  0.45744091  0.71969144  -0.03719104  1
+  C  C4  1  0.14220746  0.66316890  0.39093896  1
+  C  C5  1  0.44128695  0.48052878  0.16917901  1
+",-154.310554
+415,C-90839-8747-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43107000
+_cell_length_b   2.60782000
+_cell_length_c   9.07777000
+_cell_angle_alpha   110.25683000
+_cell_angle_beta   100.55692000
+_cell_angle_gamma   84.59014000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   53.04805420
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.08653311  0.24961260  0.45803593  1
+  C  C1  1  0.43054752  0.30535730  0.12543762  1
+  C  C2  1  0.17236013  0.53028143  0.62408674  1
+  C  C3  1  0.71317577  0.67469790  0.70450085  1
+  C  C4  1  0.54326996  1.12079316  0.37670257  1
+  C  C5  1  0.45974165  -0.10456607  0.20322727  1
+  C  C6  1  0.34344907  0.08094983  0.95180073  1
+  C  C7  1  -0.20061591  0.95415366  0.87059479  1
+",-154.10935375
+9138,C-28242-4049-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46617000
+_cell_length_b   3.38587000
+_cell_length_c   5.25753000
+_cell_angle_alpha   91.21669000
+_cell_angle_beta   89.98944000
+_cell_angle_gamma   68.68133000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.88634494
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.48154497  0.40689928  0.63746968  1
+  C  C1  1  0.92982370  0.51908845  0.03796327  1
+  C  C2  1  0.88877396  0.59347124  0.31281212  1
+  C  C3  1  0.29722649  0.77614457  0.43727519  1
+  C  C4  1  1.07202170  0.22505799  0.51164261  1
+  C  C5  1  0.45033457  0.47720637  -0.08777406  1
+",-154.16347383333334
+6727,C-76036-7014-60,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43082000
+_cell_length_b   3.15654000
+_cell_length_c   8.87710000
+_cell_angle_alpha   112.07397000
+_cell_angle_beta   89.71632000
+_cell_angle_gamma   113.05548000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.26572424
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.02438410  0.57601672  0.78589041  1
+  C  C1  1  0.36054003  0.24713424  0.11879615  1
+  C  C2  1  0.27378920  1.07418733  0.53601747  1
+  C  C3  1  0.61020548  0.74730947  0.86891870  1
+  C  C4  1  0.10956762  0.74508871  0.36889567  1
+  C  C5  1  0.85783714  0.24257293  0.61916220  1
+  C  C6  1  0.52487208  0.57613465  0.28559899  1
+  C  C7  1  0.77667814  0.07918055  0.03549751  1
+",-154.45244125
+8295,C-152565-20-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45432000
+_cell_length_b   4.58833000
+_cell_length_c   7.75518000
+_cell_angle_alpha   70.81458000
+_cell_angle_beta   87.78984000
+_cell_angle_gamma   75.95805000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   79.93686844
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.20604958  0.13564485  0.83756913  1
+  C  C1  1  0.69214059  0.04215613  0.42149895  1
+  C  C2  1  0.30447726  0.67890831  0.67522499  1
+  C  C3  1  0.48482125  0.46096224  0.56367728  1
+  C  C4  1  0.36999659  0.82386849  0.00985331  1
+  C  C5  1  0.67804022  0.14031971  0.71405666  1
+  C  C6  1  0.18669053  0.46169078  0.85942429  1
+  C  C7  1  0.73180558  0.88805102  0.62508626  1
+  C  C8  1  0.97617030  0.50090682  0.44225449  1
+  C  C9  1  0.11771481  0.29324398  0.16249965  1
+  C  C10  1  0.82695224  0.82633969  0.30419499  1
+  C  C11  1  0.29308342  0.93242936  0.18032849  1
+  C  C12  1  1.00557057  0.59554690  0.00930702  1
+  C  C13  1  0.10776616  0.24419733  0.36015060  1
+",-154.0934407142857
+10105,C-134201-7830-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42899000
+_cell_length_b   6.21631000
+_cell_length_c   4.15404000
+_cell_angle_alpha   72.47553000
+_cell_angle_beta   89.91076000
+_cell_angle_gamma   78.77849000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.55956620
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.77232268  -0.08542927  0.10237830  1
+  C  C1  1  0.25647712  0.94500980  0.24349639  1
+  C  C2  1  0.10826022  0.23033257  0.57314023  1
+  C  C3  1  0.55725594  0.32953163  0.61845902  1
+  C  C4  1  0.45875117  0.52589871  0.73193299  1
+  C  C5  1  0.78896824  0.87077845  0.77190802  1
+  C  C6  1  1.23125352  0.98612526  0.57562662  1
+  C  C7  1  0.90852701  0.62544245  -0.22327507  1
+",-154.24637375
+7671,C-92142-9665-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48761000
+_cell_length_b   3.51554000
+_cell_length_c   4.30430000
+_cell_angle_alpha   65.90901000
+_cell_angle_beta   73.20565000
+_cell_angle_gamma   90.00141000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.59691274
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.02317964  -0.11407484  0.79677478  1
+  C  C1  1  0.68988764  0.55251147  0.46346029  1
+  C  C2  1  0.85665838  0.46930445  0.13013589  1
+  C  C3  1  0.35653170  0.21920474  0.13012130  1
+  C  C4  1  0.52330245  0.13599771  0.79679691  1
+  C  C5  1  0.19001044  0.80258403  0.46348241  1
+",-154.54578666666666
+6965,C-145389-5770-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50631000
+_cell_length_b   3.94702000
+_cell_length_c   4.78083000
+_cell_angle_alpha   86.84644000
+_cell_angle_beta   81.67479000
+_cell_angle_gamma   79.88224000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.04679892
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.27245942  0.48864024  0.89334187  1
+  C  C1  1  0.56496289  0.57512398  0.36175894  1
+  C  C2  1  0.99891607  0.06343468  0.60441173  1
+  C  C3  1  0.74723753  0.38849601  0.07829391  1
+  C  C4  1  0.08495105  0.85893748  0.86315530  1
+  C  C5  1  1.02073976  0.81669191  0.36624744  1
+  C  C6  1  0.45391079  0.30417511  0.60907725  1
+  C  C7  1  -0.06442651  0.01971429  0.10731576  1
+",-154.13096
+3211,C-136237-3205-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48155000
+_cell_length_b   3.68799000
+_cell_length_c   4.21888000
+_cell_angle_alpha   75.05782000
+_cell_angle_beta   90.08282000
+_cell_angle_gamma   109.64227000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98007892
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.85686410  0.21372361  0.14062444  1
+  C  C1  1  -0.02407947  0.45931884  0.76685927  1
+  C  C2  1  0.43528496  0.37064783  0.27122599  1
+  C  C3  1  0.65606168  0.81606372  0.06474285  1
+  C  C4  1  0.17629529  0.85683494  0.84263836  1
+  C  C5  1  0.39739994  0.30212475  0.63634378  1
+",-154.3104435
+6604,C-152585-9341-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.18545000
+_cell_length_b   4.19399000
+_cell_length_c   6.07806000
+_cell_angle_alpha   111.67066000
+_cell_angle_beta   107.02729000
+_cell_angle_gamma   80.97261000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   72.04553715
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.11649529  0.08346010  0.14009644  1
+  C  C1  1  0.39481415  0.81511750  0.38198280  1
+  C  C2  1  -0.08258363  0.63824395  0.73623576  1
+  C  C3  1  0.36006130  0.60007274  0.13982495  1
+  C  C4  1  0.60254587  0.84192597  0.62379471  1
+  C  C5  1  0.09689166  0.11493717  0.38241842  1
+  C  C6  1  1.12560002  0.32599796  0.62436608  1
+  C  C7  1  1.04589772  0.76748953  -0.00882282  1
+  C  C8  1  0.56534720  0.28534093  1.02768503  1
+  C  C9  1  0.43829570  0.15804296  0.77298852  1
+",-154.24717700000002
+3210,C-41318-6901-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48119000
+_cell_length_b   3.68751000
+_cell_length_c   4.22211000
+_cell_angle_alpha   74.96073000
+_cell_angle_beta   89.95237000
+_cell_angle_gamma   70.35677000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.97671985
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.95993572  0.79726714  0.43733973  1
+  C  C1  1  0.28407613  0.15313595  0.73516014  1
+  C  C2  1  0.48010534  0.75643823  0.65885250  1
+  C  C3  1  0.70546381  0.31011039  0.86568547  1
+  C  C4  1  0.15892959  0.40043539  0.36104510  1
+  C  C5  1  0.73717212  0.24368099  0.23043216  1
+",-154.31156733333333
+5144,C-170329-7952-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46522000
+_cell_length_b   3.37356000
+_cell_length_c   6.20582000
+_cell_angle_alpha   122.46752000
+_cell_angle_beta   78.86268000
+_cell_angle_gamma   111.15471000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.60961646
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.51701276  0.88815310  0.31532649  1
+  C  C1  1  1.14056022  0.54017900  0.71492046  1
+  C  C2  1  0.55235085  0.23810846  0.58974527  1
+  C  C3  1  0.36578573  0.06201078  0.79125208  1
+  C  C4  1  0.95412625  0.36397627  0.91647434  1
+  C  C5  1  -0.00798341  0.71470989  0.19086746  1
+",-154.15425616666667
+5866,C-102883-8617-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.48100000
+_cell_length_b   4.61561000
+_cell_length_c   3.44666000
+_cell_angle_alpha   90.08532000
+_cell_angle_beta   94.76675000
+_cell_angle_gamma   68.41298000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   51.28972020
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.83260756  0.44721237  0.67446648  1
+  C  C1  1  0.23286684  0.92704789  0.35922728  1
+  C  C2  1  0.63411469  0.27994741  -0.04033447  1
+  C  C3  1  0.17675477  0.43712994  0.01691609  1
+  C  C4  1  0.57816498  0.79105165  0.61377381  1
+  C  C5  1  0.07488479  0.76466617  0.09997832  1
+  C  C6  1  0.97680665  0.27041871  0.30177156  1
+  C  C7  1  0.73836482  0.95327177  -0.12976626  1
+",-154.12183375
+7335,C-170912-4239-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.53353000
+_cell_length_b   5.05470000
+_cell_length_c   3.76683000
+_cell_angle_alpha   89.93104000
+_cell_angle_beta   89.91889000
+_cell_angle_gamma   90.12959000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.23869991
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.32524675  0.79394615  0.42426858  1
+  C  C1  1  0.32503423  0.79369109  1.06796665  1
+  C  C2  1  0.32647534  0.60961667  0.74563863  1
+  C  C3  1  0.82558145  0.22974037  0.04553400  1
+  C  C4  1  0.82592775  0.23000031  0.44368733  1
+  C  C5  1  0.82609294  0.43913284  0.74475767  1
+  C  C6  1  1.32447015  1.07005172  0.93930785  1
+  C  C7  1  0.32462159  0.07032915  0.55089429  1
+",-154.12344625
+1756,C-72718-9015-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45819000
+_cell_length_b   4.58711000
+_cell_length_c   7.65468000
+_cell_angle_alpha   75.80016000
+_cell_angle_beta   77.87227000
+_cell_angle_gamma   76.76261000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   80.36275081
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.03613950  0.59793453  0.09004756  1
+  C  C1  1  0.54043746  0.14410607  0.68013876  1
+  C  C2  1  0.46416232  0.39265796  0.37001400  1
+  C  C3  1  0.21975187  0.25874887  0.05399255  1
+  C  C4  1  1.10355226  0.73885147  0.88454289  1
+  C  C5  1  0.70896784  0.59640471  0.81962806  1
+  C  C6  1  0.23080878  1.00420218  0.21700189  1
+  C  C7  1  -0.20787106  0.27539607  0.93388224  1
+  C  C8  1  0.01331681  0.15517326  0.37313009  1
+  C  C9  1  0.43427931  0.66265873  0.19811462  1
+  C  C10  1  0.42728200  0.46336918  0.56095667  1
+  C  C11  1  0.84276979  0.62906787  0.61173792  1
+  C  C12  1  -0.00647146  0.07332246  0.80234976  1
+  C  C13  1  0.80436449  0.95615903  0.54501899  1
+",-154.12824142857144
+1907,C-184076-5045-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48322000
+_cell_length_b   3.74177000
+_cell_length_c   3.84478000
+_cell_angle_alpha   90.06198000
+_cell_angle_beta   90.00392000
+_cell_angle_gamma   90.02350000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.72428034
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76884848  0.18872358  0.08573492  1
+  C  C1  1  0.76899272  0.92073445  0.79074883  1
+  C  C2  1  0.26907737  0.42416947  0.49657765  1
+  C  C3  1  0.76891213  0.18845392  0.49634178  1
+  C  C4  1  0.26902257  0.42450077  0.08596603  1
+  C  C5  1  0.26895753  0.69217462  0.79106179  1
+",-154.15911983333334
+5021,C-80155-5756-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48735000
+_cell_length_b   4.05963000
+_cell_length_c   4.69749000
+_cell_angle_alpha   105.94197000
+_cell_angle_beta   89.96890000
+_cell_angle_gamma   90.00118000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.60964305
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76231817  0.03139634  0.32025361  1
+  C  C1  1  0.76228376  1.03873912  0.97350123  1
+  C  C2  1  0.76226175  0.37200329  0.90346850  1
+  C  C3  1  0.26271882  0.60586228  0.55169798  1
+  C  C4  1  0.26234026  0.83757325  0.85871611  1
+  C  C5  1  0.76282974  0.37992364  0.55651416  1
+  C  C6  1  0.26229594  0.80672416  0.32572005  1
+  C  C7  1  0.26212796  0.57317923  0.01845546  1
+",-154.36350875
+9852,C-184066-1258-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42700000
+_cell_length_b   4.23148000
+_cell_length_c   6.27781000
+_cell_angle_alpha   129.09414000
+_cell_angle_beta   112.77140000
+_cell_angle_gamma   89.99089000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.37446818
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.75042241  0.82532539  0.44947860  1
+  C  C1  1  0.27029668  0.68819263  0.46978350  1
+  C  C2  1  0.68319646  0.69026659  0.88113792  1
+  C  C3  1  0.33186104  0.39927750  0.53068905  1
+  C  C4  1  0.33987016  0.82620534  0.03844958  1
+  C  C5  1  0.68987915  0.11477094  0.38869484  1
+",-154.30535633333332
+3398,C-80188-9960-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.11194000
+_cell_length_b   3.40078000
+_cell_length_c   4.78702000
+_cell_angle_alpha   77.36989000
+_cell_angle_beta   44.08588000
+_cell_angle_gamma   78.52768000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.35973376
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.09202325  0.82680423  0.59386322  1
+  C  C1  1  0.34518330  0.15411816  0.78520483  1
+  C  C2  1  0.51795356  0.01910037  0.40234269  1
+  C  C3  1  0.74505383  0.20928456  0.73064801  1
+  C  C4  1  -0.00801264  0.79851990  1.14195687  1
+  C  C5  1  -0.00074130  0.53716903  0.92169806  1
+  C  C6  1  0.57235196  0.34719588  0.11305524  1
+  C  C7  1  0.09861854  0.56773598  0.37316667  1
+",-154.32619875
+5087,C-13921-7340-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.57470000
+_cell_length_b   3.87883000
+_cell_length_c   4.24665000
+_cell_angle_alpha   87.23947000
+_cell_angle_beta   87.67449000
+_cell_angle_gamma   73.92604000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   72.29546499
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.48424713  0.13409879  0.23737911  1
+  C  C1  1  0.47184651  0.57577286  0.67904822  1
+  C  C2  1  0.99220830  0.16163584  0.25959267  1
+  C  C3  1  0.26756260  0.00847108  0.10583211  1
+  C  C4  1  0.02368580  0.38573932  0.49191064  1
+  C  C5  1  0.23809859  0.77978133  0.87595175  1
+  C  C6  1  0.79120596  0.58711896  0.69077314  1
+  C  C7  1  0.77684151  1.03047872  0.13092403  1
+  C  C8  1  0.91381040  0.78983689  0.88859886  1
+  C  C9  1  0.34871170  0.37398600  0.48052977  1
+",-154.192229
+1462,C-172945-2721-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48130000
+_cell_length_b   4.21689000
+_cell_length_c   3.68918000
+_cell_angle_alpha   75.21690000
+_cell_angle_beta   109.64488000
+_cell_angle_gamma   90.05741000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99838862
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.88092652  0.07169159  0.71408309  1
+  C  C1  1  0.08023523  0.14701338  1.11228278  1
+  C  C2  1  0.56111974  0.36918277  0.07374172  1
+  C  C3  1  0.76213580  0.44458692  0.47165998  1
+  C  C4  1  0.34061278  0.57535725  0.62888309  1
+  C  C5  1  0.30260733  0.94066200  0.55764734  1
+",-154.3101525
+3597,C-47646-615-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.36454000
+_cell_length_b   3.36457000
+_cell_length_c   6.94127000
+_cell_angle_alpha   99.57018000
+_cell_angle_beta   112.04699000
+_cell_angle_gamma   83.34803000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   71.69451527
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.85877635  1.18492747  0.09493155  1
+  C  C1  1  0.80972977  0.41419874  0.27617407  1
+  C  C2  1  0.12287708  0.30598534  0.48175798  1
+  C  C3  1  0.41324338  0.66378779  0.61259146  1
+  C  C4  1  0.49200835  0.73104067  0.27526123  1
+  C  C5  1  0.17609276  -0.13270905  0.09569112  1
+  C  C6  1  0.18555634  0.65312940  0.89216072  1
+  C  C7  1  0.48281281  0.94300519  0.47915641  1
+  C  C8  1  0.25516264  -0.06824672  0.75857316  1
+  C  C9  1  0.89598768  0.14618829  0.61269243  1
+  C  C10  1  0.77254877  0.45010988  0.75864912  1
+  C  C11  1  0.54525247  0.29124183  0.88957436  1
+",-154.198455
+9001,C-150717-6846-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49235000
+_cell_length_b   6.77607000
+_cell_length_c   6.12635000
+_cell_angle_alpha   88.04442000
+_cell_angle_beta   81.52232000
+_cell_angle_gamma   85.50854000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   101.99234185
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87598187  0.98700633  0.51142347  1
+  C  C1  1  0.47040741  0.65161190  0.55888954  1
+  C  C2  1  0.44805276  0.26783692  0.33459162  1
+  C  C3  1  -0.10029550  0.32811503  0.69021812  1
+  C  C4  1  0.80389576  0.95113555  0.28224005  1
+  C  C5  1  -0.06727107  0.55833493  0.66134097  1
+  C  C6  1  -0.23041305  0.80095341  0.95518465  1
+  C  C7  1  0.31829094  0.48509336  0.98586778  1
+  C  C8  1  0.36712605  0.89156476  0.61645867  1
+  C  C9  1  0.83471126  0.59158399  0.90023811  1
+  C  C10  1  0.91594667  0.21554969  0.48042629  1
+  C  C11  1  0.28107290  0.90961020  0.87077359  1
+  C  C12  1  -0.30893494  0.59847286  0.31432925  1
+  C  C13  1  0.35546205  0.29691207  0.83794807  1
+  C  C14  1  0.69390067  0.12508686  0.14181147  1
+  C  C15  1  0.72911400  0.78628837  0.19453543  1
+  C  C16  1  1.26277211  0.11789083  -0.01228795  1
+  C  C17  1  0.27491012  0.47861393  0.24233767  1
+",-154.16410277777777
+4579,C-170362-9529-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42762000
+_cell_length_b   4.22819000
+_cell_length_c   4.87854000
+_cell_angle_alpha   92.70827000
+_cell_angle_beta   119.86280000
+_cell_angle_gamma   89.97720000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.36249396
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.31242939  0.74379058  0.55589002  1
+  C  C1  1  0.30529846  0.66094629  1.04910667  1
+  C  C2  1  -0.10459233  0.25094070  0.63866632  1
+  C  C3  1  0.95565446  0.60081780  0.69908198  1
+  C  C4  1  -0.03794530  0.68376905  0.20597014  1
+  C  C5  1  0.37341592  0.09406568  0.61655598  1
+",-154.31009
+2808,C-136249-3748-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.54610000
+_cell_length_b   3.54692000
+_cell_length_c   5.62542000
+_cell_angle_alpha   94.50991000
+_cell_angle_beta   85.46643000
+_cell_angle_gamma   60.59445000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   60.88208879
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64054982  0.83437241  0.24841426  1
+  C  C1  1  0.76875723  0.14616429  0.37287363  1
+  C  C2  1  0.83347466  0.36728653  0.17109644  1
+  C  C3  1  -0.06183113  0.96086670  0.77432309  1
+  C  C4  1  0.58333542  0.31549749  0.97124365  1
+  C  C5  1  0.45788110  0.01748403  0.49655015  1
+  C  C6  1  0.37546740  0.75286837  0.87253305  1
+  C  C7  1  0.33463357  0.09736472  0.07134616  1
+  C  C8  1  -0.00936804  1.21041041  0.57390134  1
+  C  C9  1  0.72082358  0.71151914  0.67403313  1
+",-154.126542
+3729,C-9636-6240-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45705000
+_cell_length_b   3.66479000
+_cell_length_c   6.86673000
+_cell_angle_alpha   97.51265000
+_cell_angle_beta   110.93425000
+_cell_angle_gamma   109.59831000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.15178842
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70044695  0.28855417  1.00770034  1
+  C  C1  1  0.04459534  0.18750153  0.90226904  1
+  C  C2  1  0.72154467  0.29462101  0.52784059  1
+  C  C3  1  1.03408406  0.48687110  0.24383259  1
+  C  C4  1  0.74376849  0.73347977  0.33052979  1
+  C  C5  1  0.99717318  0.74317609  0.57869053  1
+  C  C6  1  0.02035663  0.18236048  0.38201022  1
+  C  C7  1  0.70695298  -0.01154625  0.66570680  1
+",-154.2859825
+7246,C-28256-8272-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.38181000
+_cell_length_b   4.08600000
+_cell_length_c   3.61405000
+_cell_angle_alpha   104.21085000
+_cell_angle_beta   104.08253000
+_cell_angle_gamma   99.82095000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   45.52579798
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76294670  0.55854350  0.53800924  1
+  C  C1  1  0.45935768  0.24710940  0.50293367  1
+  C  C2  1  0.45925021  0.24724116  0.88373405  1
+  C  C3  1  0.26625031  0.05615467  0.09692831  1
+  C  C4  1  -0.04398111  0.74956574  -0.05596776  1
+  C  C5  1  0.76263741  0.55831753  0.15686870  1
+",-154.14160633333333
+905,C-189724-308-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.27801000
+_cell_length_b   4.95788000
+_cell_length_c   4.28378000
+_cell_angle_alpha   106.14579000
+_cell_angle_beta   117.83319000
+_cell_angle_gamma   105.59311000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   68.15097995
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.51434196  0.61029003  0.43272986  1
+  C  C1  1  0.46825756  0.55773486  0.04750846  1
+  C  C2  1  0.75235431  0.46394249  0.67039476  1
+  C  C3  1  0.13809314  0.51806851  0.71737498  1
+  C  C4  1  0.85393182  0.61151271  0.09452705  1
+  C  C5  1  0.92078103  1.11702375  1.08025753  1
+  C  C6  1  0.68510599  0.95780760  0.68440526  1
+  C  C7  1  0.50086453  0.11647106  0.49958422  1
+  C  C8  1  0.09164224  0.46485433  0.33187670  1
+  C  C9  1  0.10535793  0.95861226  0.26525527  1
+",-154.111857
+6156,C-136258-6886-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.83285000
+_cell_length_b   4.88361000
+_cell_length_c   3.67147000
+_cell_angle_alpha   103.04614000
+_cell_angle_beta   112.05789000
+_cell_angle_gamma   109.18404000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   69.55589780
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.91282947  0.87598322  0.72600926  1
+  C  C1  1  0.39230756  0.38301328  0.27082168  1
+  C  C2  1  0.03902211  0.73309945  1.03997573  1
+  C  C3  1  0.57369490  0.22537802  0.41631333  1
+  C  C4  1  0.88317249  0.38184252  0.79114304  1
+  C  C5  1  0.54245396  0.73081124  0.47954358  1
+  C  C6  1  0.41708266  0.87328551  0.16445323  1
+  C  C7  1  0.06428079  0.22402439  0.93613927  1
+  C  C8  1  0.08517621  0.80555431  0.47823101  1
+  C  C9  1  0.37075435  0.80337237  0.72697386  1
+",-154.14470799999998
+5363,C-34629-5612-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48418000
+_cell_length_b   4.15879000
+_cell_length_c   6.95678000
+_cell_angle_alpha   89.98902000
+_cell_angle_beta   110.91204000
+_cell_angle_gamma   90.00712000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.13753555
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76768539  0.90717904  0.86831784  1
+  C  C1  1  0.55175690  0.60117957  0.15464259  1
+  C  C2  1  0.22703328  0.40691650  0.83050561  1
+  C  C3  1  0.70978679  -0.12311414  0.31069419  1
+  C  C4  1  0.20518265  0.10115814  0.30617156  1
+  C  C5  1  0.33225981  0.72888535  0.93356773  1
+  C  C6  1  0.99282395  0.40722345  0.59310630  1
+  C  C7  1  0.53153094  0.90735472  0.63043024  1
+  C  C8  1  0.93930060  0.75498228  0.53803032  1
+  C  C9  1  0.04745682  0.37696722  0.15042828  1
+  C  C10  1  0.42767013  0.22918859  0.52715095  1
+  C  C11  1  0.81987613  0.25478869  0.92352860  1
+",-154.42669
+2139,C-145343-7716-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.94281000
+_cell_length_b   4.77562000
+_cell_length_c   5.02807000
+_cell_angle_alpha   81.49401000
+_cell_angle_beta   80.02454000
+_cell_angle_gamma   86.73627000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   92.17075291
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.89888666  0.20762031  0.23303780  1
+  C  C1  1  0.73827003  0.96532695  0.30730961  1
+  C  C2  1  0.45437545  0.46237916  0.04941116  1
+  C  C3  1  0.36931495  0.99298519  0.90307163  1
+  C  C4  1  0.36882783  -0.00705151  0.40355598  1
+  C  C5  1  0.18215832  0.70972537  0.49442501  1
+  C  C6  1  0.69486259  0.46761660  0.27635594  1
+  C  C7  1  0.45472948  0.46258098  0.54854987  1
+  C  C8  1  0.89903704  0.20701109  0.73482870  1
+  C  C9  1  -0.05851649  0.70514796  0.26529398  1
+  C  C10  1  -0.05841492  0.70448901  0.76667738  1
+  C  C11  1  0.26920147  0.17872152  0.13957461  1
+  C  C12  1  0.26953822  0.17876485  0.63961681  1
+  C  C13  1  0.73859164  0.96466654  0.80960729  1
+  C  C14  1  0.69492776  0.46709933  0.77732244  1
+  C  C15  1  0.18288427  0.70958216  0.99352958  1
+",-154.12973375
+1151,C-134171-9685-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46273000
+_cell_length_b   6.31055000
+_cell_length_c   5.55409000
+_cell_angle_alpha   101.30602000
+_cell_angle_beta   116.34265000
+_cell_angle_gamma   101.24278000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   71.84192077
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.88663131  0.30233770  0.60435211  1
+  C  C1  1  -0.05501715  0.70485034  0.46146825  1
+  C  C2  1  0.80457570  0.16940409  0.08936849  1
+  C  C3  1  0.03293700  0.94686054  0.42818095  1
+  C  C4  1  0.53499503  0.43787341  0.68498310  1
+  C  C5  1  0.67367123  0.93210264  0.07686809  1
+  C  C6  1  0.58777617  0.67203205  0.62044046  1
+  C  C7  1  0.69840127  1.07371486  0.53001339  1
+  C  C8  1  0.40188094  0.28399486  0.12959000  1
+  C  C9  1  0.92495768  0.57336915  1.00800519  1
+  C  C10  1  0.55392568  0.53152879  0.15794077  1
+  C  C11  1  0.98198235  0.80111307  0.95093130  1
+",-154.24500666666668
+2091,C-53830-4868-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42878000
+_cell_length_b   2.42887000
+_cell_length_c   8.69944000
+_cell_angle_alpha   82.66104000
+_cell_angle_beta   106.44173000
+_cell_angle_gamma   119.99597000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.62259966
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.12543255  0.46265597  1.11576143  1
+  C  C1  1  0.14439939  0.86145585  0.44875269  1
+  C  C2  1  0.78860651  0.46198824  0.78337811  1
+  C  C3  1  0.81190963  0.19470115  0.44964249  1
+  C  C4  1  1.12127610  0.12900299  0.78255857  1
+  C  C5  1  0.79300922  0.79623620  0.11663631  1
+",-154.4442635
+2163,C-130532-5775-54,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48273000
+_cell_length_b   3.84321000
+_cell_length_c   3.74727000
+_cell_angle_alpha   89.97262000
+_cell_angle_beta   90.00536000
+_cell_angle_gamma   89.98864000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.75514421
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71962188  -0.02283582  0.64189753  1
+  C  C1  1  0.21952859  0.97742487  0.40610881  1
+  C  C2  1  0.21965536  0.68237494  0.13853434  1
+  C  C3  1  0.71964783  0.68214267  0.90986263  1
+  C  C4  1  0.21976581  0.38772771  0.40648760  1
+  C  C5  1  0.71983663  0.38745442  0.64219168  1
+",-154.16682799999998
+1860,C-113083-5385-56,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44578000
+_cell_length_b   6.22897000
+_cell_length_c   6.84714000
+_cell_angle_alpha   119.57970000
+_cell_angle_beta   114.69353000
+_cell_angle_gamma   93.75921000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   77.39362053
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.67087986  0.55105800  0.67948208  1
+  C  C1  1  0.22230129  0.99866100  0.23019480  1
+  C  C2  1  0.67738434  0.80562830  0.70867112  1
+  C  C3  1  0.30204147  0.75358839  0.43436249  1
+  C  C4  1  0.23356024  0.37938257  0.05765771  1
+  C  C5  1  0.52620335  0.23493718  -0.08648329  1
+  C  C6  1  0.37629433  -0.03976339  -0.13673871  1
+  C  C7  1  1.15003313  0.18258314  0.63876433  1
+  C  C8  1  0.45167199  1.02742391  0.48417101  1
+  C  C9  1  0.59474993  0.60943447  0.29028973  1
+  C  C10  1  0.15294491  0.43654293  0.66648643  1
+  C  C11  1  0.60612097  -0.01255751  0.11645779  1
+",-154.25895
+8883,C-184058-8674-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48987000
+_cell_length_b   3.93745000
+_cell_length_c   5.94857000
+_cell_angle_alpha   82.38742000
+_cell_angle_beta   77.92766000
+_cell_angle_gamma   89.98530000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.50318386
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76778645  0.36446661  0.22496743  1
+  C  C1  1  0.22100179  0.50785445  0.31683497  1
+  C  C2  1  0.47916595  0.80776334  0.79464942  1
+  C  C3  1  -0.11491100  0.27120355  -0.01502118  1
+  C  C4  1  0.24901182  0.87429629  0.26360864  1
+  C  C5  1  0.08720578  0.34836455  0.58367467  1
+  C  C6  1  0.98377045  0.57297937  0.78530867  1
+  C  C7  1  0.37971002  0.03150075  -0.00330543  1
+  C  C8  1  0.58150159  0.11012390  0.59493135  1
+  C  C9  1  0.70384236  1.01861278  0.35440857  1
+",-154.336206
+8482,C-47640-4572-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48710000
+_cell_length_b   4.06421000
+_cell_length_c   5.29578000
+_cell_angle_alpha   121.56154000
+_cell_angle_beta   90.03310000
+_cell_angle_gamma   90.02294000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.61195574
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.78974292  0.25566106  0.83489172  1
+  C  C1  1  0.78952826  0.68182376  0.05955650  1
+  C  C2  1  0.28967399  1.02567955  0.82976845  1
+  C  C3  1  0.28951522  0.67067481  0.48210702  1
+  C  C4  1  0.28954783  0.91223663  0.06467151  1
+  C  C5  1  -0.21024051  0.18117313  0.52707009  1
+  C  C6  1  0.78945919  0.75743950  0.36755059  1
+  C  C7  1  0.28971170  0.26842466  0.41278191  1
+",-154.369245
+8709,C-142815-448-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46827000
+_cell_length_b   5.92306000
+_cell_length_c   7.63140000
+_cell_angle_alpha   86.05185000
+_cell_angle_beta   82.13987000
+_cell_angle_gamma   110.17161000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   102.93117022
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.26350305  0.50989156  0.17457798  1
+  C  C1  1  0.27259443  0.73320731  0.24472691  1
+  C  C2  1  0.26338373  1.04177005  0.71085596  1
+  C  C3  1  0.69878904  0.40778978  0.46023841  1
+  C  C4  1  0.82360389  0.31221809  0.94044756  1
+  C  C5  1  0.62540310  0.05860122  0.00143471  1
+  C  C6  1  0.89819584  0.69834693  0.90322316  1
+  C  C7  1  0.67226606  0.90872258  0.65676450  1
+  C  C8  1  -0.02616316  0.06589114  0.30984946  1
+  C  C9  1  1.08535439  0.96161397  0.91793698  1
+  C  C10  1  0.08969940  0.41027512  0.75047417  1
+  C  C11  1  0.05357024  0.69142833  0.43392967  1
+  C  C12  1  0.47411671  -0.00286124  0.20230621  1
+  C  C13  1  0.69016959  0.84385248  0.47278765  1
+  C  C14  1  0.15029493  0.33191271  0.35448434  1
+  C  C15  1  0.78075325  0.49550082  0.05346639  1
+  C  C16  1  0.40099747  0.67177431  0.78751331  1
+  C  C17  1  0.53222864  0.31611222  0.65941413  1
+",-154.10709166666666
+3034,C-73645-3621-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.14881000
+_cell_length_b   3.28447000
+_cell_length_c   4.14808000
+_cell_angle_alpha   102.75883000
+_cell_angle_beta   110.74650000
+_cell_angle_gamma   102.75951000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.70322089
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.09392956  0.87161223  0.50838260  1
+  C  C1  1  0.08051506  0.21119378  0.37086833  1
+  C  C2  1  0.39068203  0.55582825  0.68078331  1
+  C  C3  1  0.56676925  0.89624417  0.54473843  1
+  C  C4  1  0.90401810  0.49325091  0.19340493  1
+  C  C5  1  0.21788986  0.87200716  0.19582217  1
+  C  C6  1  0.56879891  0.27458091  0.85863815  1
+  C  C7  1  0.25506096  0.89657428  0.85715228  1
+",-154.1563125
+4062,C-57109-5472-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.34989000
+_cell_length_b   3.40897000
+_cell_length_c   4.57967000
+_cell_angle_alpha   89.14567000
+_cell_angle_beta   111.51774000
+_cell_angle_gamma   92.08300000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.62113892
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71533460  0.86406979  0.10437238  1
+  C  C1  1  0.74885801  0.37518168  0.49941345  1
+  C  C2  1  0.07508664  0.56686912  0.78431984  1
+  C  C3  1  0.41371408  0.04223041  0.49909341  1
+  C  C4  1  0.97344328  0.20904162  0.28472676  1
+  C  C5  1  0.48578048  0.70872282  0.30968486  1
+  C  C6  1  0.05092949  0.55551586  0.10381033  1
+  C  C7  1  0.37291142  0.85478219  0.78425886  1
+",-154.19868
+1841,C-53822-9555-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47039000
+_cell_length_b   3.36407000
+_cell_length_c   5.96596000
+_cell_angle_alpha   59.79431000
+_cell_angle_beta   77.93605000
+_cell_angle_gamma   68.34183000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.80688466
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76649108  0.40767773  -0.15081010  1
+  C  C1  1  0.96247734  0.21810251  0.64171953  1
+  C  C2  1  0.33672714  0.86705275  0.24354505  1
+  C  C3  1  -0.19396958  0.05046434  0.12260801  1
+  C  C4  1  0.18308631  0.69891466  0.72457098  1
+  C  C5  1  0.37897511  0.50935002  0.51694403  1
+",-154.121674
+799,C-157713-6979-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43924000
+_cell_length_b   4.22585000
+_cell_length_c   6.52738000
+_cell_angle_alpha   90.16110000
+_cell_angle_beta   100.80363000
+_cell_angle_gamma   90.00338000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   66.09048983
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.22099451  0.29867574  0.27637537  1
+  C  C1  1  0.54554197  0.80068545  0.95045711  1
+  C  C2  1  0.26168139  0.95958022  0.34308921  1
+  C  C3  1  0.09053390  0.29742746  1.02886151  1
+  C  C4  1  1.05107295  0.95785584  -0.03763209  1
+  C  C5  1  0.76862442  -0.19732295  0.35747735  1
+  C  C6  1  0.43260297  0.40469648  0.70513494  1
+  C  C7  1  0.88064846  0.40510475  0.60132755  1
+  C  C8  1  0.54317574  0.44959889  0.93541222  1
+  C  C9  1  0.76941669  0.45132252  0.37071534  1
+",-154.254258
+5500,C-13931-57-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48148000
+_cell_length_b   3.69110000
+_cell_length_c   6.27687000
+_cell_angle_alpha   40.50458000
+_cell_angle_beta   78.58813000
+_cell_angle_gamma   70.30998000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99807691
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40270700  0.60937048  0.71890560  1
+  C  C1  1  0.94886125  0.01778037  0.22305290  1
+  C  C2  1  0.37021425  1.04395296  0.35379380  1
+  C  C3  1  0.62588784  -0.04282159  0.92533149  1
+  C  C4  1  0.14539419  0.69605222  0.14716963  1
+  C  C5  1  0.82450466  0.63496456  -0.15026022  1
+",-154.31126666666668
+1344,C-76030-274-54,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.37698000
+_cell_length_b   4.08088000
+_cell_length_c   3.79203000
+_cell_angle_alpha   108.55993000
+_cell_angle_beta   107.02304000
+_cell_angle_gamma   100.25145000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.20076883
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.69297533  0.91305424  0.38212155  1
+  C  C1  1  0.57842922  0.26099910  0.59936685  1
+  C  C2  1  0.06328978  0.78256611  0.57163632  1
+  C  C3  1  0.80156598  0.97147957  1.05693661  1
+  C  C4  1  0.23522272  0.62544302  0.23499556  1
+  C  C5  1  0.25898294  0.25874049  0.20371520  1
+  C  C6  1  0.91566179  0.62322963  0.83947112  1
+  C  C7  1  0.43060404  0.10085944  0.86703078  1
+",-154.22958125
+4863,C-152575-7588-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48186000
+_cell_length_b   3.68987000
+_cell_length_c   4.84428000
+_cell_angle_alpha   57.38939000
+_cell_angle_beta   75.10459000
+_cell_angle_gamma   70.32021000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.02620551
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.07044685  0.08274870  0.03035465  1
+  C  C1  1  0.35133208  0.37023720  0.89947678  1
+  C  C2  1  0.60781711  0.42662137  0.32781369  1
+  C  C3  1  0.80448028  -0.04626999  0.40330478  1
+  C  C4  1  0.12735795  0.60931700  0.10616705  1
+  C  C5  1  0.38294523  0.66601742  0.53429775  1
+",-154.31416633333333
+6853,C-34615-6034-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52741000
+_cell_length_b   4.29669000
+_cell_length_c   5.07875000
+_cell_angle_alpha   59.58828000
+_cell_angle_beta   83.42166000
+_cell_angle_gamma   94.87591000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.58830041
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.58924435  0.50074406  0.68121066  1
+  C  C1  1  0.78449777  0.82707777  0.70773986  1
+  C  C2  1  0.53434493  0.63040389  0.35901533  1
+  C  C3  1  0.50028524  1.03315382  0.22919594  1
+  C  C4  1  0.44201718  0.16229601  0.90747906  1
+  C  C5  1  0.96683034  0.12914376  0.34885398  1
+  C  C6  1  1.06775202  0.53370090  0.23973056  1
+  C  C7  1  0.24788697  0.83568838  -0.11880228  1
+",-154.07076375
+697,C-53832-8784-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.48584000
+_cell_length_b   3.45173000
+_cell_length_c   5.85164000
+_cell_angle_alpha   96.95024000
+_cell_angle_beta   116.94652000
+_cell_angle_gamma   91.88776000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   61.99527677
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.24619629  0.13288619  0.43975421  1
+  C  C1  1  0.28539851  0.75715231  0.28159981  1
+  C  C2  1  0.15545216  0.76987530  1.00270067  1
+  C  C3  1  0.70152220  0.33047331  0.59130842  1
+  C  C4  1  0.03098774  1.01216783  0.60069890  1
+  C  C5  1  0.67249658  0.28814824  0.00275648  1
+  C  C6  1  0.96484167  0.43696658  0.28156786  1
+  C  C7  1  0.74734118  0.63521352  0.43838825  1
+  C  C8  1  0.80986362  0.48662698  0.85611010  1
+  C  C9  1  0.32156846  0.00183734  0.88356070  1
+",-154.25906500000002
+6995,C-72754-2980-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.68348000
+_cell_length_b   4.83015000
+_cell_length_c   3.63366000
+_cell_angle_alpha   112.14258000
+_cell_angle_beta   103.01446000
+_cell_angle_gamma   120.56805000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.95459390
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.47838651  0.41905738  0.57144428  1
+  C  C1  1  0.47884774  0.22755584  0.78560103  1
+  C  C2  1  0.47680364  0.72676324  0.22548803  1
+  C  C3  1  0.47763963  0.41938786  0.19212093  1
+  C  C4  1  0.47654861  0.72745554  0.84647662  1
+  C  C5  1  0.47586036  0.91874173  0.63214071  1
+",-154.123173
+2269,C-40140-2962-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45897000
+_cell_length_b   5.43142000
+_cell_length_c   6.25634000
+_cell_angle_alpha   106.06200000
+_cell_angle_beta   88.66068000
+_cell_angle_gamma   84.93496000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   79.88260125
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.83289439  0.44183140  0.70870465  1
+  C  C1  1  0.83725812  0.69458839  0.11440494  1
+  C  C2  1  0.80082360  0.69917288  0.36560741  1
+  C  C3  1  0.34416926  0.27250157  0.36676825  1
+  C  C4  1  0.31694835  0.56564547  0.42465697  1
+  C  C5  1  0.90356888  0.40883127  0.94301845  1
+  C  C6  1  0.67838924  -0.01630143  0.77358519  1
+  C  C7  1  0.46416136  0.24281828  -0.04374857  1
+  C  C8  1  0.23088114  0.84166355  0.82149226  1
+  C  C9  1  0.29795092  0.58520203  0.67275198  1
+  C  C10  1  0.77759558  0.96774329  0.53477779  1
+  C  C11  1  0.37220296  0.12525215  0.14147974  1
+  C  C12  1  0.84950574  0.21396105  0.49510859  1
+  C  C13  1  0.30777736  0.83943360  0.06161134  1
+",-154.13121500000003
+7105,C-141068-2442-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43264000
+_cell_length_b   3.11645000
+_cell_length_c   6.41708000
+_cell_angle_alpha   71.06940000
+_cell_angle_beta   78.98299000
+_cell_angle_gamma   72.42757000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.63577431
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87773132  0.41556028  0.11236800  1
+  C  C1  1  0.21157424  0.41339467  0.44644110  1
+  C  C2  1  0.43492772  0.41256224  0.00145943  1
+  C  C3  1  0.76842330  0.41247433  0.33463459  1
+  C  C4  1  0.54521564  0.41370429  0.77948960  1
+  C  C5  1  0.10259878  0.41029829  0.66862138  1
+",-154.46119433333334
+2354,C-152569-5742-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43540000
+_cell_length_b   5.43674000
+_cell_length_c   5.78292000
+_cell_angle_alpha   68.41261000
+_cell_angle_beta   77.81470000
+_cell_angle_gamma   90.19235000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   69.31764178
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.47616632  0.81647502  0.14539297  1
+  C  C1  1  0.94142704  0.33575634  0.21164930  1
+  C  C2  1  0.77277698  0.61392163  0.55658457  1
+  C  C3  1  0.39384861  0.38891765  0.30649750  1
+  C  C4  1  0.34645668  0.60802046  0.40944138  1
+  C  C5  1  0.06722497  0.34793362  -0.04574518  1
+  C  C6  1  0.72035822  0.83269088  0.66002287  1
+  C  C7  1  0.63446034  0.40519551  0.82094684  1
+  C  C8  1  0.04322071  0.87366402  0.01214276  1
+  C  C9  1  0.17380152  0.88616466  0.75453919  1
+",-154.095918
+6271,C-113060-2504-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51032000
+_cell_length_b   4.72912000
+_cell_length_c   6.40717000
+_cell_angle_alpha   83.76187000
+_cell_angle_beta   78.62706000
+_cell_angle_gamma   74.53249000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   71.74239784
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.35959360  1.07436420  0.56159475  1
+  C  C1  1  1.30241047  0.96966304  0.77056316  1
+  C  C2  1  0.54563102  0.87684599  0.38646980  1
+  C  C3  1  0.83991536  0.47898805  0.19668222  1
+  C  C4  1  0.10020661  0.91513974  0.24107264  1
+  C  C5  1  0.03744369  0.49152233  0.78623799  1
+  C  C6  1  0.19822666  0.41417140  0.54689949  1
+  C  C7  1  0.30027605  0.64416440  0.10847064  1
+  C  C8  1  0.41500784  0.66024881  0.85911321  1
+  C  C9  1  0.69435238  0.53637213  0.43260681  1
+  C  C10  1  0.12496278  0.20015226  0.90183704  1
+  C  C11  1  0.02706574  0.18850084  0.11659806  1
+",-154.2406825
+10021,C-172953-2094-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49102000
+_cell_length_b   4.35640000
+_cell_length_c   5.36240000
+_cell_angle_alpha   138.21753000
+_cell_angle_beta   89.98795000
+_cell_angle_gamma   106.64813000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.01081364
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.39712415  0.36850043  0.40120328  1
+  C  C1  1  0.31510568  0.20450312  0.03096211  1
+  C  C2  1  0.02799296  0.62866952  0.66077502  1
+  C  C3  1  0.92228325  0.41737454  0.03147522  1
+  C  C4  1  0.84069862  0.25339774  0.66132888  1
+  C  C5  1  0.21042134  -0.00660006  0.40190197  1
+",-154.19495700000002
+4130,C-34639-131-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48833000
+_cell_length_b   4.30492000
+_cell_length_c   4.97391000
+_cell_angle_alpha   73.19706000
+_cell_angle_beta   120.03874000
+_cell_angle_gamma   106.81294000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.47846390
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.78658262  0.60098291  -0.06671678  1
+  C  C1  1  0.78675332  0.60088158  0.43331152  1
+  C  C2  1  0.91113219  0.97580742  0.37056917  1
+  C  C3  1  0.91096150  0.97590876  0.87054087  1
+  C  C4  1  0.28649448  0.10094830  0.68329204  1
+  C  C5  1  0.41109919  0.47587311  0.12055932  1
+  C  C6  1  0.28661562  0.10091722  0.18329308  1
+  C  C7  1  0.41122033  0.47584203  0.62056035  1
+",-154.54624875
+890,C-170331-6356-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48171000
+_cell_length_b   3.69019000
+_cell_length_c   4.84503000
+_cell_angle_alpha   57.33927000
+_cell_angle_beta   75.09853000
+_cell_angle_gamma   70.31606000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.01260930
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.09640187  0.67790361  0.24252813  1
+  C  C1  1  0.51815463  -0.03451892  0.11165461  1
+  C  C2  1  0.55023168  0.26043118  0.74665655  1
+  C  C3  1  -0.02817910  0.54813497  0.61564771  1
+  C  C4  1  0.29421168  0.20435746  0.31837476  1
+  C  C5  1  0.77471795  1.02146620  0.54021164  1
+",-154.312452
+3803,C-148223-6845-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.37477000
+_cell_length_b   4.07905000
+_cell_length_c   4.27385000
+_cell_angle_alpha   115.01104000
+_cell_angle_beta   121.99159000
+_cell_angle_gamma   79.73653000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.13842581
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76588939  0.73136702  0.32013878  1
+  C  C1  1  0.18172610  0.57235271  0.58837851  1
+  C  C2  1  0.74590988  0.09630102  0.95638368  1
+  C  C3  1  0.00104265  0.44178112  0.77782466  1
+  C  C4  1  0.43471508  0.38334620  0.10291728  1
+  C  C5  1  0.69027584  0.72920895  0.92484251  1
+  C  C6  1  0.25424179  0.25451378  0.29321086  1
+  C  C7  1  0.66931917  0.09410522  0.56056072  1
+",-154.22351
+2739,C-113039-2678-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45597000
+_cell_length_b   4.76813000
+_cell_length_c   8.72565000
+_cell_angle_alpha   113.88992000
+_cell_angle_beta   100.54976000
+_cell_angle_gamma   93.53712000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   90.79223495
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.50432317  0.40782674  0.15092009  1
+  C  C1  1  0.90186406  0.92999142  0.93485599  1
+  C  C2  1  0.47728161  0.15397520  0.98266182  1
+  C  C3  1  0.81780840  0.93071077  0.63761374  1
+  C  C4  1  0.22328960  0.83988675  0.51711924  1
+  C  C5  1  0.82199299  0.43693586  0.65121905  1
+  C  C6  1  0.42176770  0.71120953  0.12920394  1
+  C  C7  1  1.12654127  1.01824982  0.40820137  1
+  C  C8  1  0.16290294  0.49618328  0.41729166  1
+  C  C9  1  -0.06037579  0.26977160  0.76117861  1
+  C  C10  1  0.23473377  0.34912458  0.53832787  1
+  C  C11  1  -0.14950018  0.76619027  0.74763652  1
+  C  C12  1  0.57703792  0.35444928  0.30660054  1
+  C  C13  1  0.53948662  0.34603935  0.87477193  1
+  C  C14  1  0.54740100  1.00158334  0.29964785  1
+  C  C15  1  0.83268540  0.68956232  1.01605128  1
+",-154.179623125
+8155,C-172949-8358-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.31824000
+_cell_length_b   3.51825000
+_cell_length_c   3.51751000
+_cell_angle_alpha   59.93568000
+_cell_angle_beta   90.00271000
+_cell_angle_gamma   89.99717000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.54009761
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46849794  0.90969174  0.90729877  1
+  C  C1  1  0.80108879  0.90981938  0.21167372  1
+  C  C2  1  0.13574987  0.21382473  0.90753499  1
+  C  C3  1  0.30104032  0.44599335  0.13898645  1
+  C  C4  1  0.63580977  0.14155044  0.44353202  1
+  C  C5  1  0.96848250  0.44586426  0.44349695  1
+",-154.40953083333332
+6960,C-141033-8048-51,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48135000
+_cell_length_b   3.68776000
+_cell_length_c   4.21986000
+_cell_angle_alpha   104.95891000
+_cell_angle_beta   89.96405000
+_cell_angle_gamma   109.63639000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.97850094
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.58359845  0.17196995  0.39941461  1
+  C  C1  1  0.46094342  0.92593773  0.02544482  1
+  C  C2  1  0.03973202  0.08331262  0.89512639  1
+  C  C3  1  0.00552598  1.01544965  0.53016411  1
+  C  C4  1  -0.21575946  0.56949088  0.32364463  1
+  C  C5  1  1.26411569  0.52915187  0.10180744  1
+",-154.31075983333332
+6285,C-177256-4099-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43072000
+_cell_length_b   5.66136000
+_cell_length_c   4.20486000
+_cell_angle_alpha   85.32946000
+_cell_angle_beta   89.77983000
+_cell_angle_gamma   98.09830000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.08970841
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.68866133  0.90248978  1.06042465  1
+  C  C1  1  0.68842655  0.90357240  0.39310583  1
+  C  C2  1  0.36169283  0.39453431  0.84343784  1
+  C  C3  1  0.86171195  0.39453800  0.34338632  1
+  C  C4  1  0.86144390  0.39568055  0.67618230  1
+  C  C5  1  0.18841021  0.90357634  0.89316510  1
+  C  C6  1  0.18862686  0.90249334  0.56038327  1
+  C  C7  1  0.36141057  0.39567489  0.17616619  1
+",-154.44737125
+2028,C-56522-2971-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45609000
+_cell_length_b   3.66343000
+_cell_length_c   6.43512000
+_cell_angle_alpha   96.70985000
+_cell_angle_beta   79.01192000
+_cell_angle_gamma   70.45147000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.53264460
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20131300  1.01645423  0.21291354  1
+  C  C1  1  0.19187984  0.51505297  0.73241128  1
+  C  C2  1  -0.22568222  0.49813734  0.58583788  1
+  C  C3  1  0.76832057  0.98949380  0.10575469  1
+  C  C4  1  0.36773028  0.11067346  0.78170829  1
+  C  C5  1  0.59389149  0.90347246  0.53831534  1
+  C  C6  1  1.05409547  0.06985102  0.45057836  1
+  C  C7  1  0.90754676  0.94287593  0.86855162  1
+",-154.28062125
+5744,C-152577-7771-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52157000
+_cell_length_b   4.96837000
+_cell_length_c   5.97380000
+_cell_angle_alpha   59.49365000
+_cell_angle_beta   76.48147000
+_cell_angle_gamma   71.89766000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   61.02409820
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.03589668  0.12671708  0.48132815  1
+  C  C1  1  1.14010731  0.90374574  0.73228553  1
+  C  C2  1  0.30033509  -0.02209036  0.30591609  1
+  C  C3  1  0.45934741  0.62855457  0.49364373  1
+  C  C4  1  0.81861026  0.42540221  0.93970153  1
+  C  C5  1  0.86968425  0.06763726  0.12355668  1
+  C  C6  1  0.64478068  0.61465819  0.09902102  1
+  C  C7  1  0.69588060  0.43490964  0.38008516  1
+  C  C8  1  0.34324124  0.56761473  0.76593234  1
+  C  C9  1  0.06169646  0.83993983  0.00449847  1
+",-154.077457
+9260,C-170346-7491-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50662000
+_cell_length_b   4.87522000
+_cell_length_c   6.05545000
+_cell_angle_alpha   85.14505000
+_cell_angle_beta   113.81433000
+_cell_angle_gamma   120.56837000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.60200910
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.06688920  0.53151983  0.18092457  1
+  C  C1  1  0.30988295  0.05545798  0.30405529  1
+  C  C2  1  0.68501617  1.03235440  0.56958934  1
+  C  C3  1  0.57726160  0.32274882  0.93914681  1
+  C  C4  1  0.51763275  0.89870071  0.17179593  1
+  C  C5  1  0.57872328  0.42593843  0.31430475  1
+  C  C6  1  0.41192558  0.01354576  0.92945121  1
+  C  C7  1  0.13664233  0.88116398  0.66591599  1
+  C  C8  1  0.25537999  0.37819247  0.68640508  1
+  C  C9  1  0.82143664  0.52989782  0.59263343  1
+",-154.075777
+6615,C-142763-5042-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47416000
+_cell_length_b   4.27985000
+_cell_length_c   4.80260000
+_cell_angle_alpha   90.01147000
+_cell_angle_beta   121.00312000
+_cell_angle_gamma   89.98937000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.58972406
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.19179489  0.12561916  0.00801726  1
+  C  C1  1  0.56520645  1.12547353  0.38198441  1
+  C  C2  1  0.69144362  0.79205502  0.50795313  1
+  C  C3  1  0.56516993  0.29217971  0.88197027  1
+  C  C4  1  0.19166304  0.29205950  0.50801242  1
+  C  C5  1  0.06495240  0.62546841  0.38190375  1
+  C  C6  1  0.69161187  0.62560784  1.00793956  1
+  C  C7  1  0.06502311  0.79218202  0.88192018  1
+",-154.51891125
+2443,C-96665-6528-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.70425000
+_cell_length_b   4.18190000
+_cell_length_c   5.32150000
+_cell_angle_alpha   59.37738000
+_cell_angle_beta   64.38035000
+_cell_angle_gamma   59.42416000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.35024305
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.81229688  0.92164506  0.55444482  1
+  C  C1  1  0.60076450  0.32673474  0.36300121  1
+  C  C2  1  0.19558042  0.53940031  0.55435570  1
+  C  C3  1  0.16024274  0.26806435  0.86160834  1
+  C  C4  1  0.75626121  0.48102992  0.05289551  1
+  C  C5  1  0.54360775  0.88585842  0.86148842  1
+",-154.11446433333333
+1565,C-34631-1494-55,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.01793000
+_cell_length_b   4.20712000
+_cell_length_c   4.85108000
+_cell_angle_alpha   89.81677000
+_cell_angle_beta   74.28717000
+_cell_angle_gamma   72.20625000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.24206655
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.62003096  0.95179818  0.34822652  1
+  C  C1  1  0.62000625  -0.04819686  0.84822939  1
+  C  C2  1  0.62313612  0.11789704  0.09754621  1
+  C  C3  1  0.62338424  0.61784385  0.84752450  1
+  C  C4  1  0.62348621  0.61781600  0.34750824  1
+  C  C5  1  0.62017503  0.45176526  0.59821976  1
+  C  C6  1  0.62009158  0.45178969  0.09823043  1
+  C  C7  1  0.62328581  0.11786095  0.59752884  1
+",-154.41403
+1808,C-184084-4554-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49441000
+_cell_length_b   4.13429000
+_cell_length_c   6.39955000
+_cell_angle_alpha   108.80019000
+_cell_angle_beta   101.24951000
+_cell_angle_gamma   89.99378000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   61.13459377
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.94904609  0.67971639  0.21931471  1
+  C  C1  1  0.62641370  0.67646634  0.57441197  1
+  C  C2  1  0.39738756  1.12878207  0.11729554  1
+  C  C3  1  0.39696473  0.76424506  1.11666156  1
+  C  C4  1  0.28078297  0.51146506  0.87872596  1
+  C  C5  1  0.05657176  0.60793290  0.43608894  1
+  C  C6  1  0.70891593  1.04567821  0.73551117  1
+  C  C7  1  0.94970389  0.31594838  0.22042250  1
+  C  C8  1  0.70885908  0.46713617  0.73556979  1
+  C  C9  1  0.28093979  0.14417863  0.87884515  1
+",-154.15576
+4300,C-126169-9026-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48159000
+_cell_length_b   3.68879000
+_cell_length_c   4.21287000
+_cell_angle_alpha   104.63440000
+_cell_angle_beta   90.05419000
+_cell_angle_gamma   109.64665000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98503189
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53653037  0.60469432  0.99814978  1
+  C  C1  1  0.79326026  0.12182422  0.56962869  1
+  C  C2  1  0.56992831  0.67686028  0.36344696  1
+  C  C3  1  0.11469996  0.76129298  0.86699478  1
+  C  C4  1  0.31231732  0.15947688  0.79210408  1
+  C  C5  1  -0.00817231  0.51989292  0.49437752  1
+",-154.30813033333334
+1533,C-130546-1595-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48131000
+_cell_length_b   3.68892000
+_cell_length_c   4.21676000
+_cell_angle_alpha   104.81623000
+_cell_angle_beta   89.95061000
+_cell_angle_gamma   109.63069000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99174114
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.90937941  0.44281197  0.65721261  1
+  C  C1  1  0.42925872  0.48166318  -0.12023851  1
+  C  C2  1  0.68865533  0.99748688  0.45101127  1
+  C  C3  1  0.22855082  0.08378321  0.95513222  1
+  C  C4  1  0.11050952  0.84116434  0.58214624  1
+  C  C5  1  0.65000921  0.92655923  0.08593087  1
+",-154.3092815
+7591,C-136221-5891-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42612000
+_cell_length_b   4.22758000
+_cell_length_c   4.22739000
+_cell_angle_alpha   92.21309000
+_cell_angle_beta   90.02257000
+_cell_angle_gamma   90.01990000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.32637095
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.45896628  0.78185995  0.78477341  1
+  C  C1  1  0.45898802  0.43287383  0.72481945  1
+  C  C2  1  0.45892482  0.84339739  0.13433587  1
+  C  C3  1  0.95890165  0.27587977  0.70025530  1
+  C  C4  1  -0.04104610  0.92695677  0.64030325  1
+  C  C5  1  0.95901482  0.86585309  0.29101282  1
+",-154.3154865
+31,C-184080-2077-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44237000
+_cell_length_b   4.61722000
+_cell_length_c   6.37646000
+_cell_angle_alpha   95.25967000
+_cell_angle_beta   88.66276000
+_cell_angle_gamma   105.37640000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   69.04118214
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.03853963  0.57647491  0.48133088  1
+  C  C1  1  0.43025582  0.49702044  0.35955151  1
+  C  C2  1  0.02737293  0.73441277  0.66685517  1
+  C  C3  1  0.28906577  1.28958021  0.88952152  1
+  C  C4  1  0.71773663  0.14312543  0.85567180  1
+  C  C5  1  0.45403757  0.60859371  -0.03325464  1
+  C  C6  1  0.53611684  0.70186431  0.17949549  1
+  C  C7  1  0.70127953  1.02122806  0.25840031  1
+  C  C8  1  0.55864123  -0.18594360  0.78840827  1
+  C  C9  1  0.27237871  0.16777296  0.29320899  1
+",-154.07629400000002
+9261,C-102887-506-57,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48499000
+_cell_length_b   4.08638000
+_cell_length_c   4.67862000
+_cell_angle_alpha   83.32660000
+_cell_angle_beta   105.41707000
+_cell_angle_gamma   90.00192000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.46606275
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46885211  0.64231894  0.34438525  1
+  C  C1  1  -0.03198289  0.41747537  0.34224862  1
+  C  C2  1  0.79780412  0.34876985  0.00089326  1
+  C  C3  1  1.08491825  0.11126854  0.57301695  1
+  C  C4  1  0.31008321  0.82327800  0.02946585  1
+  C  C5  1  0.73848577  0.70471237  0.88572867  1
+  C  C6  1  0.25513286  0.17877062  0.91461092  1
+  C  C7  1  0.58361727  -0.11541747  0.57098857  1
+",-154.36713375
+7898,C-96692-7228-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.24058000
+_cell_length_b   3.62787000
+_cell_length_c   3.27836000
+_cell_angle_alpha   75.52429000
+_cell_angle_beta   130.49933000
+_cell_angle_gamma   90.11374000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.24267638
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.90851014  0.13834052  0.58702335  1
+  C  C1  1  0.85364975  0.75651828  0.79962600  1
+  C  C2  1  0.12129310  0.37476010  1.01318591  1
+  C  C3  1  0.26977823  1.13874191  0.58711700  1
+  C  C4  1  0.48256119  0.37516150  1.01327957  1
+  C  C5  1  0.53742158  0.75698374  0.80067691  1
+",-154.20191016666666
+9764,C-113068-6749-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50430000
+_cell_length_b   3.29781000
+_cell_length_c   7.49617000
+_cell_angle_alpha   60.18975000
+_cell_angle_beta   71.56505000
+_cell_angle_gamma   67.81949000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.10084783
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.20089031  1.04057213  0.49618935  1
+  C  C1  1  0.08502202  0.57912290  0.95782284  1
+  C  C2  1  0.90074118  0.52516285  0.65393118  1
+  C  C3  1  0.82794442  0.76378518  0.13089258  1
+  C  C4  1  0.64248633  0.71063681  0.82696930  1
+  C  C5  1  0.93200534  0.24729011  0.28888909  1
+  C  C6  1  0.54048562  0.24119933  0.65388382  1
+  C  C7  1  0.18965189  0.04718299  0.13089713  1
+",-154.11227
+4185,C-142785-5183-57,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.35354000
+_cell_length_b   2.45421000
+_cell_length_c   8.09082000
+_cell_angle_alpha   107.63219000
+_cell_angle_beta   66.42404000
+_cell_angle_gamma   111.42196000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   55.84730536
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.05605739  0.06080045  0.30467641  1
+  C  C1  1  -0.05439347  0.93986873  0.73718585  1
+  C  C2  1  0.54534299  0.51985972  1.01764623  1
+  C  C3  1  0.67563168  -0.00549901  0.92749209  1
+  C  C4  1  0.56538465  0.87184721  0.36036559  1
+  C  C5  1  0.31461492  0.33677295  0.45047198  1
+  C  C6  1  0.30683836  0.59640872  0.21420708  1
+  C  C7  1  0.07580616  0.41430303  0.64680367  1
+",-154.20223375
+2743,C-90800-1393-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.43674000
+_cell_length_b   4.86819000
+_cell_length_c   6.39358000
+_cell_angle_alpha   103.38271000
+_cell_angle_beta   100.54459000
+_cell_angle_gamma   117.14373000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   87.30612180
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.73818352  0.07499900  -0.04400615  1
+  C  C1  1  0.20265779  0.70846682  0.12896302  1
+  C  C2  1  0.60191937  0.77385553  0.79302328  1
+  C  C3  1  0.67154971  0.33692190  0.29140914  1
+  C  C4  1  0.53844581  0.39206127  0.48169012  1
+  C  C5  1  -0.26315363  0.72082115  0.60303913  1
+  C  C6  1  0.98829074  0.66095913  0.29517921  1
+  C  C7  1  0.28326183  0.44922491  0.78816715  1
+  C  C8  1  0.53234865  0.03515949  0.12751954  1
+  C  C9  1  0.01468423  0.89096081  0.49501983  1
+  C  C10  1  0.25605317  0.22065767  0.58709780  1
+  C  C11  1  0.06772491  0.40151302  -0.04596767  1
+",-154.22128916666665
+5332,C-189740-9333-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.95144000
+_cell_length_b   5.56998000
+_cell_length_c   4.20455000
+_cell_angle_alpha   53.78375000
+_cell_angle_beta   72.35971000
+_cell_angle_gamma   82.91170000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   70.96314027
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.23235614  0.78378224  0.88085700  1
+  C  C1  1  0.22992148  0.78209859  0.54962473  1
+  C  C2  1  0.63230878  0.38363433  0.08100935  1
+  C  C3  1  0.43186185  0.58325610  0.48137186  1
+  C  C4  1  1.03200282  0.98330816  0.28129309  1
+  C  C5  1  0.62983871  0.38215325  0.74959587  1
+  C  C6  1  -0.16788225  0.18348244  0.68113853  1
+  C  C7  1  0.82970974  0.18171194  0.34995231  1
+  C  C8  1  0.02951032  0.98185080  0.94992849  1
+  C  C9  1  0.42938422  0.58162604  0.15010176  1
+",-154.436549
+2154,C-170896-9077-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44018000
+_cell_length_b   4.18638000
+_cell_length_c   6.73932000
+_cell_angle_alpha   68.39361000
+_cell_angle_beta   79.69205000
+_cell_angle_gamma   90.03120000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   62.80886241
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.45832940  0.46392135  0.20904224  1
+  C  C1  1  0.98534942  -0.00886499  0.15892707  1
+  C  C2  1  0.10770929  1.15842498  0.91852244  1
+  C  C3  1  0.32300881  0.62034073  0.48938595  1
+  C  C4  1  0.66196241  0.26878489  0.81173398  1
+  C  C5  1  0.76910899  0.51080204  0.59642449  1
+  C  C6  1  -0.03558098  0.31305079  0.19860190  1
+  C  C7  1  0.44138006  0.78548870  0.24890113  1
+",-154.2447525
+3291,C-41264-888-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.51411000
+_cell_length_b   3.51938000
+_cell_length_c   3.31794000
+_cell_angle_alpha   90.00361000
+_cell_angle_beta   89.98684000
+_cell_angle_gamma   59.98703000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.53234565
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.24473803  0.71471572  0.95544517  1
+  C  C1  1  0.17126970  0.25124959  0.45546527  1
+  C  C2  1  -0.06023401  1.01951789  0.28761147  1
+  C  C3  1  0.47561724  -0.05294128  0.78757026  1
+  C  C4  1  0.47596811  0.25132682  0.12098587  1
+  C  C5  1  0.93966523  0.71475697  0.62095526  1
+",-154.40917716666667
+9398,C-194844-3110-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45796000
+_cell_length_b   7.51849000
+_cell_length_c   8.49900000
+_cell_angle_alpha   124.08789000
+_cell_angle_beta   73.16896000
+_cell_angle_gamma   90.08011000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   121.91274603
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40416959  0.52321765  0.44907819  1
+  C  C1  1  0.82798759  0.62366687  0.02967487  1
+  C  C2  1  0.60042584  0.60663064  0.75897780  1
+  C  C3  1  1.04487751  0.68457252  0.31192485  1
+  C  C4  1  0.49548595  0.27101926  0.86198087  1
+  C  C5  1  0.39627466  0.06351765  -0.04605888  1
+  C  C6  1  0.56924041  0.25104791  0.28140210  1
+  C  C7  1  0.43738325  0.70270563  0.41937195  1
+  C  C8  1  1.33358352  0.07182878  0.51812764  1
+  C  C9  1  0.79284982  0.11332508  0.05777783  1
+  C  C10  1  0.88336694  0.11773081  0.46766650  1
+  C  C11  1  0.23822840  0.94882298  0.61572875  1
+  C  C12  1  0.20922478  0.68233564  0.14841783  1
+  C  C13  1  0.60548051  0.02693883  0.74905117  1
+  C  C14  1  -0.03463352  0.24590618  0.38531031  1
+  C  C15  1  -0.19036953  0.50756300  0.54366587  1
+  C  C16  1  -0.05080464  0.37621090  0.90906802  1
+  C  C17  1  1.00721043  0.63192617  0.85241414  1
+",-154.08876222222224
+5977,C-126167-1633-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42997000
+_cell_length_b   2.42992000
+_cell_length_c   8.71276000
+_cell_angle_alpha   97.26385000
+_cell_angle_beta   82.08672000
+_cell_angle_gamma   59.97677000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.95906585
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.59521717  0.86699124  0.21793017  1
+  C  C1  1  0.22194585  0.89045706  -0.11481375  1
+  C  C2  1  0.53212398  0.60111222  0.55502957  1
+  C  C3  1  0.26099091  0.53466263  0.21868822  1
+  C  C4  1  0.88787587  0.55780886  0.88604888  1
+  C  C5  1  0.86658982  -0.06664231  0.55419471  1
+",-154.45483716666666
+5911,C-193946-2107-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48099000
+_cell_length_b   3.68826000
+_cell_length_c   4.21885000
+_cell_angle_alpha   75.15628000
+_cell_angle_beta   89.94482000
+_cell_angle_gamma   70.37027000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99384910
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.10903159  0.39166958  -0.00691629  1
+  C  C1  1  0.53085631  0.54794677  0.12424991  1
+  C  C2  1  0.64971809  0.30492779  0.49723947  1
+  C  C3  1  0.07120992  0.46214452  0.62804974  1
+  C  C4  1  0.33065691  0.94624196  0.19926960  1
+  C  C5  1  0.85051788  0.90708598  0.42181897  1
+",-154.3098305
+8146,C-56512-1663-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42898000
+_cell_length_b   3.69331000
+_cell_length_c   6.68480000
+_cell_angle_alpha   73.04855000
+_cell_angle_beta   85.67149000
+_cell_angle_gamma   86.06612000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.13172590
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70293975  0.26087451  0.11218579  1
+  C  C1  1  0.20295123  0.76088917  0.36219620  1
+  C  C2  1  0.70314239  0.92794684  0.27899657  1
+  C  C3  1  0.20311960  0.42793362  1.02900596  1
+  C  C4  1  0.20312604  0.42796287  0.52901866  1
+  C  C5  1  0.70293938  0.26089435  0.61220623  1
+  C  C6  1  0.20294214  0.76087009  0.86220616  1
+  C  C7  1  0.70313137  -0.07205575  0.77902014  1
+",-154.43619125
+5072,C-13906-5787-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.30660000
+_cell_length_b   3.64111000
+_cell_length_c   4.18498000
+_cell_angle_alpha   62.16608000
+_cell_angle_beta   100.90483000
+_cell_angle_gamma   92.30980000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.68493367
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.10500319  0.89858100  0.25572850  1
+  C  C1  1  -0.08696910  0.68502088  1.06272131  1
+  C  C2  1  0.41214982  0.62480317  0.56319364  1
+  C  C3  1  1.10480037  0.27904229  0.25559113  1
+  C  C4  1  0.41235264  0.24434188  0.56333101  1
+  C  C5  1  0.60412211  0.83836328  0.75620082  1
+",-154.13597483333334
+9209,C-34633-9015-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46873000
+_cell_length_b   3.78439000
+_cell_length_c   5.68828000
+_cell_angle_alpha   90.04793000
+_cell_angle_beta   115.96659000
+_cell_angle_gamma   90.00802000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.77864584
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.74522827  0.72857872  0.71517143  1
+  C  C1  1  0.61705284  0.92263321  0.08247400  1
+  C  C2  1  0.40740690  0.22226444  0.87526080  1
+  C  C3  1  0.47332183  0.60798321  0.44026500  1
+  C  C4  1  0.40670746  0.62309672  0.87486458  1
+  C  C5  1  0.29203393  0.92200501  0.25509976  1
+  C  C6  1  0.74585602  0.11613588  0.71550730  1
+  C  C7  1  0.47391514  0.23536461  0.44069283  1
+",-154.11033875
+207,C-102915-7408-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45634000
+_cell_length_b   4.41480000
+_cell_length_c   6.42764000
+_cell_angle_alpha   83.85572000
+_cell_angle_beta   101.01863000
+_cell_angle_gamma   74.09968000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   64.85551909
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.37151532  0.99123933  0.17785701  1
+  C  C1  1  0.44069712  0.49335031  0.30241094  1
+  C  C2  1  0.36586669  0.06301106  0.72437849  1
+  C  C3  1  0.92084057  1.06811989  0.83845303  1
+  C  C4  1  1.03143710  0.06019585  1.05155766  1
+  C  C5  1  0.65324049  0.14357452  0.38486597  1
+  C  C6  1  -0.15268677  0.64140505  0.26134601  1
+  C  C7  1  0.25164662  1.07310330  0.51107419  1
+",-154.1527775
+3333,C-177252-751-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48441000
+_cell_length_b   3.82435000
+_cell_length_c   5.98329000
+_cell_angle_alpha   59.63502000
+_cell_angle_beta   77.97026000
+_cell_angle_gamma   71.01684000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.31531363
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.75970097  0.45071845  0.83249623  1
+  C  C1  1  0.21152434  0.37992599  0.99754829  1
+  C  C2  1  0.58246245  0.96339435  0.66976393  1
+  C  C3  1  -0.02898406  1.07944568  0.77594909  1
+  C  C4  1  0.46123024  0.65559750  0.21977121  1
+  C  C5  1  0.63490238  0.14302397  0.38310804  1
+  C  C6  1  0.24664245  0.02641363  0.27704454  1
+  C  C7  1  0.00916972  0.72615882  0.05487467  1
+",-154.222055
+7192,C-13661-7792-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43742000
+_cell_length_b   4.86162000
+_cell_length_c   9.13301000
+_cell_angle_alpha   70.87911000
+_cell_angle_beta   89.93240000
+_cell_angle_gamma   59.83966000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   86.62433733
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.02447365  0.23204069  0.25182807  1
+  C  C1  1  0.40604169  0.80115919  0.06876913  1
+  C  C2  1  0.64413242  0.06411453  0.26541329  1
+  C  C3  1  0.60472206  0.10238430  -0.17368946  1
+  C  C4  1  1.01855249  0.18851708  0.74609669  1
+  C  C5  1  0.88626500  0.82120105  0.54985439  1
+  C  C6  1  0.18509942  0.52218392  0.50073363  1
+  C  C7  1  1.02567779  0.68180317  0.31409880  1
+  C  C8  1  0.61580863  0.59177873  0.24071558  1
+  C  C9  1  0.80670449  0.90014250  -0.00992812  1
+  C  C10  1  0.89525236  0.31194463  0.57072828  1
+  C  C11  1  1.23845270  -0.03090879  0.56082150  1
+",-154.24648249999998
+1041,C-13677-4233-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45657000
+_cell_length_b   3.66278000
+_cell_length_c   6.47614000
+_cell_angle_alpha   99.52326000
+_cell_angle_beta   100.93974000
+_cell_angle_gamma   109.59041000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.22162595
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.35133867  0.80674152  0.15181746  1
+  C  C1  1  0.81687463  0.72038886  0.57344487  1
+  C  C2  1  0.52929456  0.27952588  0.43545592  1
+  C  C3  1  0.94076725  0.24894648  0.29005220  1
+  C  C4  1  1.11270355  0.64678499  0.23868805  1
+  C  C5  1  0.51110018  0.76566018  0.91562188  1
+  C  C6  1  -0.04587926  0.75791384  0.80961783  1
+  C  C7  1  0.35431237  0.88076005  0.48640959  1
+",-154.2867025
+9164,C-56489-4783-59,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43159000
+_cell_length_b   5.70980000
+_cell_length_c   4.20398000
+_cell_angle_alpha   78.31596000
+_cell_angle_beta   90.03114000
+_cell_angle_gamma   88.22674000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.12943149
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.31879676  0.80224404  0.93357951  1
+  C  C1  1  0.87952076  0.30972611  0.93207692  1
+  C  C2  1  -0.12035738  0.30760600  0.26588918  1
+  C  C3  1  0.81879676  0.80224404  0.43357951  1
+  C  C4  1  0.31891861  0.80012394  0.26739176  1
+  C  C5  1  0.81891861  0.80012394  0.76739176  1
+  C  C6  1  0.37952076  0.30972611  0.43207692  1
+  C  C7  1  0.37964262  0.30760600  0.76588918  1
+",-154.447435
+9943,C-148258-4740-53,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45374000
+_cell_length_b   4.59121000
+_cell_length_c   7.14098000
+_cell_angle_alpha   98.03863000
+_cell_angle_beta   107.26293000
+_cell_angle_gamma   111.65535000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   68.52585029
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.19301486  0.99586857  0.36883223  1
+  C  C1  1  -0.03522375  0.42841804  0.97179577  1
+  C  C2  1  0.96199931  0.62045668  0.32790866  1
+  C  C3  1  0.12907126  0.71959501  0.89457820  1
+  C  C4  1  1.00611132  1.04113184  0.67878731  1
+  C  C5  1  0.12696523  0.52526053  0.53762431  1
+  C  C6  1  1.08531530  0.10553446  0.18721326  1
+  C  C7  1  0.20249094  0.21580159  0.88993746  1
+  C  C8  1  0.84211701  0.68448267  0.65942004  1
+  C  C9  1  0.89629152  1.14974846  0.49696569  1
+  C  C10  1  0.24822771  0.46230864  0.20630597  1
+  C  C11  1  -0.10799340  -0.06774496  -0.02351079  1
+",-154.07222916666666
+3668,C-73669-4812-64,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.73027000
+_cell_length_b   4.93323000
+_cell_length_c   5.73137000
+_cell_angle_alpha   87.88767000
+_cell_angle_beta   129.05703000
+_cell_angle_gamma   113.50883000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   71.61407981
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.02938936  0.49765775  0.14568423  1
+  C  C1  1  0.72862786  0.00996028  0.60946361  1
+  C  C2  1  0.03317944  0.02594864  0.28570859  1
+  C  C3  1  0.38157067  0.05196087  0.64592776  1
+  C  C4  1  0.48843227  0.98805628  1.11219547  1
+  C  C5  1  0.58787230  0.38828342  0.79122304  1
+  C  C6  1  0.81594349  0.53285084  0.64810047  1
+  C  C7  1  0.10584830  0.87880031  0.75763249  1
+  C  C8  1  0.04323766  0.35045001  0.61756241  1
+  C  C9  1  0.26061096  0.84355524  0.25526638  1
+  C  C10  1  0.69460855  0.32445755  0.25754109  1
+  C  C11  1  0.34744707  0.36632421  0.29394577  1
+",-154.17714
+3976,C-141022-7340-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48817000
+_cell_length_b   3.51689000
+_cell_length_c   4.30467000
+_cell_angle_alpha   65.90519000
+_cell_angle_beta   106.76560000
+_cell_angle_gamma   89.99352000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.62407358
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.27151666  0.94124624  0.70111297  1
+  C  C1  1  1.10490734  0.35815169  0.36767563  1
+  C  C2  1  -0.06181667  0.27457957  0.03444630  1
+  C  C3  1  0.43824067  1.02481836  1.03434230  1
+  C  C4  1  0.60484999  0.60791291  0.36777963  1
+  C  C5  1  0.77157401  0.69148503  0.70100897  1
+",-154.54878483333331
+3606,C-170882-2973-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.37527000
+_cell_length_b   3.79057000
+_cell_length_c   4.07857000
+_cell_angle_alpha   108.53435000
+_cell_angle_beta   100.25445000
+_cell_angle_gamma   107.04491000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.13583749
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.84628359  0.44956622  0.13309769  1
+  C  C1  1  0.21328321  0.74432667  0.45161498  1
+  C  C2  1  0.47608340  0.26030576  0.26407227  1
+  C  C3  1  1.01834593  0.11330151  0.97640627  1
+  C  C4  1  0.04186732  0.08107104  0.60938509  1
+  C  C5  1  0.36136191  0.47706569  0.61170454  1
+  C  C6  1  0.69856102  0.71776088  -0.02583620  1
+  C  C7  1  0.58415151  0.93447573  0.32198976  1
+",-154.22449875
+10087,C-57169-8585-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.76134000
+_cell_length_b   4.30369000
+_cell_length_c   4.39793000
+_cell_angle_alpha   76.65120000
+_cell_angle_beta   64.12492000
+_cell_angle_gamma   64.43180000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.70279528
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79192017  0.02307487  0.83084404  1
+  C  C1  1  0.25677604  -0.12858726  0.68088035  1
+  C  C2  1  0.71743466  0.41022920  0.22102671  1
+  C  C3  1  0.99119004  0.64238632  0.45073347  1
+  C  C4  1  0.55434837  0.26141058  0.06933667  1
+  C  C5  1  0.35477993  0.64071683  0.45065818  1
+  C  C6  1  0.08904490  0.41167230  0.22083105  1
+  C  C7  1  0.62859559  -0.12713115  0.68064772  1
+",-154.07953875
+2101,C-145325-7931-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43203000
+_cell_length_b   3.24694000
+_cell_length_c   8.70142000
+_cell_angle_alpha   68.52573000
+_cell_angle_beta   89.34670000
+_cell_angle_gamma   67.08914000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.20486222
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71692961  0.11251181  0.25389909  1
+  C  C1  1  0.80102160  0.94408509  0.83676556  1
+  C  C2  1  0.30100204  0.94438873  0.33716514  1
+  C  C3  1  0.46701982  0.61231848  0.50366717  1
+  C  C4  1  0.55106797  0.44416659  0.08692451  1
+  C  C5  1  0.05093139  0.44427842  0.58699748  1
+  C  C6  1  0.96688324  0.61243031  0.00374014  1
+  C  C7  1  0.21694917  0.11220817  0.75349951  1
+",-154.467775
+4473,C-90863-258-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43238000
+_cell_length_b   3.24654000
+_cell_length_c   13.18455000
+_cell_angle_alpha   121.33545000
+_cell_angle_beta   97.56533000
+_cell_angle_gamma   93.05463000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   87.23904219
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.00085124  0.35612257  0.89161226  1
+  C  C1  1  0.44342685  0.13482858  0.83565268  1
+  C  C2  1  0.33192905  0.69065447  0.72475557  1
+  C  C3  1  0.44261607  0.13672644  0.33524355  1
+  C  C4  1  0.66454971  0.02442440  0.55788337  1
+  C  C5  1  0.66588620  1.02368138  0.05807640  1
+  C  C6  1  0.33212790  0.69182460  0.22453458  1
+  C  C7  1  0.77651249  0.46946260  0.16857767  1
+  C  C8  1  0.77607116  0.46888798  0.66868268  1
+  C  C9  1  1.10891706  0.80211939  0.50207946  1
+  C  C10  1  0.99810151  0.35790004  0.39116728  1
+  C  C11  1  0.11029743  0.80077434  0.00241530  1
+",-154.45393583333333
+7603,C-157683-5975-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43057000
+_cell_length_b   3.14333000
+_cell_length_c   6.69127000
+_cell_angle_alpha   91.94257000
+_cell_angle_beta   112.80622000
+_cell_angle_gamma   109.85935000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.50687917
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.27089220  -0.03870901  0.29900024  1
+  C  C1  1  0.27191660  0.62949860  0.96554002  1
+  C  C2  1  0.27030657  0.29071014  0.63333133  1
+  C  C3  1  0.60311092  0.17734393  0.52201555  1
+  C  C4  1  0.60472849  0.84887546  0.18804624  1
+  C  C5  1  0.60506132  0.51458388  0.85531862  1
+",-154.46530816666666
+1112,C-157711-6174-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43198000
+_cell_length_b   4.45682000
+_cell_length_c   5.84612000
+_cell_angle_alpha   125.53454000
+_cell_angle_beta   81.10804000
+_cell_angle_gamma   120.78411000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.36416230
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.89815969  0.20572312  0.33772541  1
+  C  C1  1  0.89801807  0.53898490  0.00450483  1
+  C  C2  1  0.56498837  0.42838512  0.44842798  1
+  C  C3  1  0.56492369  0.09493760  0.78176183  1
+  C  C4  1  0.56479641  0.76157251  0.11530496  1
+  C  C5  1  0.89818217  0.87243644  0.67091720  1
+",-154.44888083333333
+2725,C-145309-7611-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.41554000
+_cell_length_b   4.89562000
+_cell_length_c   3.41982000
+_cell_angle_alpha   101.53619000
+_cell_angle_beta   105.00704000
+_cell_angle_gamma   108.38521000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.87796099
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.12131975  0.55069524  1.02590666  1
+  C  C1  1  0.32835424  0.63572788  0.48839251  1
+  C  C2  1  0.28575277  0.38578564  0.69606410  1
+  C  C3  1  0.82835424  0.13572788  0.48839251  1
+  C  C4  1  0.16388248  0.80068079  0.81816093  1
+  C  C5  1  0.78575277  0.88578564  0.69606410  1
+  C  C6  1  0.62131975  0.05069524  0.02590666  1
+  C  C7  1  0.66388248  0.30068079  0.81816093  1
+",-154.1088425
+5592,C-141033-8048-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47736000
+_cell_length_b   2.47766000
+_cell_length_c   6.77928000
+_cell_angle_alpha   89.99263000
+_cell_angle_beta   111.44615000
+_cell_angle_gamma   120.02569000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.65850041
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20376158  0.75447726  0.30888308  1
+  C  C1  1  0.31102444  0.30834198  0.63947968  1
+  C  C2  1  0.42525586  0.86569901  0.97391009  1
+  C  C3  1  0.98137057  0.14316717  0.39225237  1
+  C  C4  1  0.87072780  0.58811963  0.05799873  1
+  C  C5  1  0.08974545  0.69827824  0.72295844  1
+",-154.53282566666667
+3293,C-172917-5417-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.51729000
+_cell_length_b   3.31903000
+_cell_length_c   4.83663000
+_cell_angle_alpha   133.35728000
+_cell_angle_beta   111.34453000
+_cell_angle_gamma   89.98654000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.54440675
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46790346  0.04262542  0.71026510  1
+  C  C1  1  0.16325354  0.40490219  0.40572127  1
+  C  C2  1  0.69939335  0.34013016  0.17369169  1
+  C  C3  1  0.16316515  0.37615168  0.71033998  1
+  C  C4  1  0.39567877  0.00690036  0.17424143  1
+  C  C5  1  0.69960453  -0.02187161  0.47830552  1
+",-154.40934716666666
+4776,C-73626-2668-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48789000
+_cell_length_b   4.30502000
+_cell_length_c   6.57966000
+_cell_angle_alpha   109.09618000
+_cell_angle_beta   79.09234000
+_cell_angle_gamma   89.98587000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   65.24297220
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.14942585  -0.05522554  0.90679756  1
+  C  C1  1  0.98323764  0.77822449  0.23986367  1
+  C  C2  1  0.64946108  0.44480807  0.90682456  1
+  C  C3  1  0.52587253  0.56993247  0.15670111  1
+  C  C4  1  0.85904022  -0.09677749  0.48985638  1
+  C  C5  1  0.81617227  0.61175976  0.57359321  1
+  C  C6  1  0.48336674  0.27820699  0.23982801  1
+  C  C7  1  0.69209028  0.73646840  0.82355209  1
+  C  C8  1  0.19213064  0.23650590  0.82358534  1
+  C  C9  1  0.31610823  0.11179410  0.57362331  1
+  C  C10  1  0.02597025  1.06990904  1.15668703  1
+  C  C11  1  0.35913248  0.40320411  0.48981303  1
+",-154.5486975
+9071,C-73653-6772-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48284000
+_cell_length_b   3.54221000
+_cell_length_c   7.04106000
+_cell_angle_alpha   63.10405000
+_cell_angle_beta   80.05043000
+_cell_angle_gamma   69.75318000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   51.80378608
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55136109  0.77538154  0.51854970  1
+  C  C1  1  -0.12818764  0.40343647  0.24828383  1
+  C  C2  1  0.16450058  0.29277007  0.77102281  1
+  C  C3  1  0.37390313  0.27045828  0.37707279  1
+  C  C4  1  0.84604376  0.66431023  0.04182700  1
+  C  C5  1  0.17996850  0.51495348  0.52051148  1
+  C  C6  1  0.53693760  0.55308980  0.76903828  1
+  C  C7  1  0.34359958  0.79725844  0.91289621  1
+",-154.13113
+3552,C-193911-8410-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.40168000
+_cell_length_b   3.45238000
+_cell_length_c   5.34286000
+_cell_angle_alpha   97.42184000
+_cell_angle_beta   98.01805000
+_cell_angle_gamma   92.16724000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   61.51234545
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.33148330  0.67652254  0.86291230  1
+  C  C1  1  -0.14576465  0.64368190  0.17893774  1
+  C  C2  1  0.49587944  0.31734112  0.18942806  1
+  C  C3  1  0.14106531  0.42702858  1.01710814  1
+  C  C4  1  0.38250783  0.42233239  0.44437073  1
+  C  C5  1  0.97590392  0.78608092  0.69011612  1
+  C  C6  1  0.61870312  0.46020348  0.69993518  1
+  C  C7  1  0.62833480  -0.04108655  0.03929752  1
+  C  C8  1  0.08821288  0.68179524  0.43472200  1
+  C  C9  1  0.84546545  0.14500828  0.84002000  1
+",-154.113471
+10051,C-96694-8817-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43095000
+_cell_length_b   3.26245000
+_cell_length_c   6.56718000
+_cell_angle_alpha   90.87634000
+_cell_angle_beta   110.82083000
+_cell_angle_gamma   113.83758000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.75298183
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.20944187  0.88501624  0.65042616  1
+  C  C1  1  0.20820214  0.54866244  0.31784497  1
+  C  C2  1  0.87659905  0.33022885  0.09525665  1
+  C  C3  1  0.21008161  0.21790641  0.98418713  1
+  C  C4  1  0.87467518  0.66220812  0.42829123  1
+  C  C5  1  -0.12341945  0.99795473  0.76166737  1
+",-154.46798983333335
+2372,C-57126-7464-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42510000
+_cell_length_b   4.15220000
+_cell_length_c   6.19035000
+_cell_angle_alpha   70.43737000
+_cell_angle_beta   78.41162000
+_cell_angle_gamma   89.83754000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.39799672
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64016707  0.02608681  -0.05621747  1
+  C  C1  1  0.87567932  0.32539313  0.47810655  1
+  C  C2  1  0.18980517  0.17204073  0.84562308  1
+  C  C3  1  -0.00309233  0.56534530  0.23050157  1
+  C  C4  1  0.54493582  0.71168954  0.13316053  1
+  C  C5  1  0.34299138  0.78240595  0.55317527  1
+  C  C6  1  0.31443888  0.41001722  0.59755053  1
+  C  C7  1  0.85874319  0.95340971  0.52032866  1
+",-154.2219875
+1183,C-136212-1087-54,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51360000
+_cell_length_b   4.62662000
+_cell_length_c   5.47749000
+_cell_angle_alpha   111.72446000
+_cell_angle_beta   92.83630000
+_cell_angle_gamma   81.47792000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.52160724
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.14927865  0.25848767  0.07272879  1
+  C  C1  1  0.62203786  0.48711712  0.77031806  1
+  C  C2  1  0.68354135  0.04415363  -0.01150759  1
+  C  C3  1  -0.11287235  -0.05937316  0.38401184  1
+  C  C4  1  0.68555505  0.27848776  0.48410855  1
+  C  C5  1  0.14337933  0.39528563  0.37832178  1
+  C  C6  1  0.06870128  0.75443847  0.54375397  1
+  C  C7  1  0.59359837  0.79650823  0.71653547  1
+  C  C8  1  0.90507356  0.82621431  0.12654019  1
+  C  C9  1  1.10853969  0.50180474  0.93902484  1
+",-154.129085
+7270,C-170877-2118-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52290000
+_cell_length_b   3.99023000
+_cell_length_c   4.94874000
+_cell_angle_alpha   92.48800000
+_cell_angle_beta   75.27164000
+_cell_angle_gamma   99.75844000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.48464235
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.65645299  0.89898500  0.65260431  1
+  C  C1  1  0.63108624  0.75215726  0.90387947  1
+  C  C2  1  0.23066384  0.19639071  0.15835943  1
+  C  C3  1  0.67727632  0.95457796  0.15843382  1
+  C  C4  1  0.05776874  0.45469478  0.39826167  1
+  C  C5  1  0.61108059  0.69647380  0.39824280  1
+  C  C6  1  0.53046528  0.39883221  0.90386043  1
+  C  C7  1  0.75843861  0.25226147  0.65250477  1
+",-154.07628875
+5829,C-134164-924-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48473000
+_cell_length_b   4.08580000
+_cell_length_c   4.67960000
+_cell_angle_alpha   96.67087000
+_cell_angle_beta   74.56221000
+_cell_angle_gamma   89.99916000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.45994956
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.04337640  0.91028921  0.77419574  1
+  C  C1  1  -0.01463799  0.26596719  0.89029195  1
+  C  C2  1  1.20212981  0.72905857  0.46001009  1
+  C  C3  1  0.70089076  0.50358378  0.46245439  1
+  C  C4  1  0.31283787  0.97145462  0.23264585  1
+  C  C5  1  -0.18616166  0.19699424  0.23078175  1
+  C  C6  1  0.52944464  0.43499761  0.80373429  1
+  C  C7  1  0.47040316  0.79066848  0.91843674  1
+",-154.3688425
+3567,C-102891-3492-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43056000
+_cell_length_b   5.28512000
+_cell_length_c   7.21733000
+_cell_angle_alpha   88.09952000
+_cell_angle_beta   71.70750000
+_cell_angle_gamma   77.65329000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   85.93375398
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.03033442  0.27695182  0.35373318  1
+  C  C1  1  0.52924938  -0.05561259  0.52110404  1
+  C  C2  1  0.02891727  0.38874654  0.79922740  1
+  C  C3  1  1.02828480  0.61193435  0.68839403  1
+  C  C4  1  0.02927841  0.94436608  1.02107695  1
+  C  C5  1  0.53026840  0.27699345  0.85381920  1
+  C  C6  1  0.52837279  0.05591150  0.96613540  1
+  C  C7  1  0.52836943  0.61186785  0.18828358  1
+  C  C8  1  0.02698613  0.72363510  0.13369119  1
+  C  C9  1  1.02839940  0.05591039  0.46611425  1
+  C  C10  1  0.52691276  0.72370487  0.63378447  1
+  C  C11  1  0.52900241  0.38869132  0.29911741  1
+",-154.43528166666667
+4940,C-80160-4880-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49844000
+_cell_length_b   4.26138000
+_cell_length_c   4.83695000
+_cell_angle_alpha   111.32514000
+_cell_angle_beta   90.17326000
+_cell_angle_gamma   89.97586000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.97183681
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.60542897  -0.10358833  0.37477340  1
+  C  C1  1  0.10447491  0.46254416  0.42958261  1
+  C  C2  1  0.10505335  0.69164518  0.24941342  1
+  C  C3  1  0.60582512  0.32236884  0.79564956  1
+  C  C4  1  1.10645476  0.75647601  0.74076287  1
+  C  C5  1  0.10625986  0.52709842  0.92099764  1
+  C  C6  1  0.60464327  0.27780588  0.45511882  1
+  C  C7  1  0.60636566  -0.05900656  0.71523907  1
+",-154.2380525
+3077,C-145343-7716-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48978000
+_cell_length_b   4.94586000
+_cell_length_c   6.09453000
+_cell_angle_alpha   69.25335000
+_cell_angle_beta   78.22567000
+_cell_angle_gamma   90.01322000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   68.48962279
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.83846837  0.85594025  0.87035215  1
+  C  C1  1  0.38412964  0.06324928  0.77774370  1
+  C  C2  1  0.20790184  0.20434683  0.13719807  1
+  C  C3  1  0.54884749  0.89594447  0.45385008  1
+  C  C4  1  0.34014120  0.36501226  0.86855985  1
+  C  C5  1  -0.11578184  0.55468568  0.77874431  1
+  C  C6  1  0.68040351  0.02535079  0.19285263  1
+  C  C7  1  1.09611754  0.30583449  0.36265941  1
+  C  C8  1  1.13283443  0.61534676  0.28466982  1
+  C  C9  1  0.02105844  0.71676863  0.51013216  1
+  C  C10  1  0.70487113  0.75768322  0.14111442  1
+  C  C11  1  0.52364475  0.16319364  0.50666579  1
+",-154.21543833333334
+2664,C-126159-6870-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.47262000
+_cell_length_b   3.65430000
+_cell_length_c   6.35229000
+_cell_angle_alpha   62.58034000
+_cell_angle_beta   75.94832000
+_cell_angle_gamma   58.21310000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   60.82229364
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.01081487  0.76308201  0.97634345  1
+  C  C1  1  0.49240393  0.98044900  0.26974483  1
+  C  C2  1  0.72700774  0.29721386  0.87490690  1
+  C  C3  1  0.24489568  0.08020119  0.58103128  1
+  C  C4  1  0.24529878  0.60418719  0.76959781  1
+  C  C5  1  0.01060978  1.15516270  0.37486242  1
+  C  C6  1  0.49222004  0.45667913  0.08114124  1
+  C  C7  1  1.01373163  0.45793950  0.67539553  1
+  C  C8  1  0.72387736  0.60253196  0.17547523  1
+  C  C9  1  0.72689159  0.90504588  0.47628051  1
+",-154.08534500000002
+1335,C-170366-7168-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.51660000
+_cell_length_b   3.31944000
+_cell_length_c   3.51856000
+_cell_angle_alpha   89.99618000
+_cell_angle_beta   120.00073000
+_cell_angle_gamma   90.01373000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.56969815
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.51768258  0.32285699  0.31579876  1
+  C  C1  1  0.21298113  -0.01187308  0.31556561  1
+  C  C2  1  0.21315814  0.65553557  1.01183710  1
+  C  C3  1  0.44507750  0.82285414  0.77975539  1
+  C  C4  1  0.74957506  0.48807240  0.77967621  1
+  C  C5  1  0.74937978  0.15555127  0.08386194  1
+",-154.41202833333332
+8836,C-13679-1830-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45938000
+_cell_length_b   5.27360000
+_cell_length_c   7.49897000
+_cell_angle_alpha   73.25364000
+_cell_angle_beta   93.78544000
+_cell_angle_gamma   90.02601000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   92.91446289
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.00071072  0.32957400  0.64211508  1
+  C  C1  1  0.08958636  0.55247015  0.73147509  1
+  C  C2  1  0.14615538  0.81916725  0.37392266  1
+  C  C3  1  0.55320232  0.14356118  0.70711599  1
+  C  C4  1  0.66889069  0.16728161  0.39412927  1
+  C  C5  1  0.60828767  0.53010004  0.85169618  1
+  C  C6  1  0.21636076  0.58118566  0.32155851  1
+  C  C7  1  0.61966628  0.97090701  0.58438486  1
+  C  C8  1  0.15785719  0.58365058  0.11316700  1
+  C  C9  1  0.11704103  0.80771900  0.57956039  1
+  C  C10  1  0.13854888  0.27968267  0.10532557  1
+  C  C11  1  0.62226602  0.25126360  0.99590829  1
+  C  C12  1  0.62869000  0.70844643  0.99520416  1
+  C  C13  1  0.59915002  0.01781830  0.91009946  1
+  C  C14  1  0.15350940  0.10624885  0.29663306  1
+  C  C15  1  0.76400361  0.42612307  0.42191152  1
+",-154.073185625
+6606,C-136208-4716-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48758000
+_cell_length_b   4.30389000
+_cell_length_c   3.51634000
+_cell_angle_alpha   65.89995000
+_cell_angle_beta   90.00231000
+_cell_angle_gamma   73.21481000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.60011124
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.14268309  0.04560592  0.41695283  1
+  C  C1  1  1.19065025  0.37893925  0.75028616  1
+  C  C2  1  0.69054617  0.37886218  0.50038575  1
+  C  C3  1  1.02387951  0.71219551  0.83371909  1
+  C  C4  1  0.52398358  0.71227258  0.08361950  1
+  C  C5  1  0.35721284  0.04552885  0.16705242  1
+",-154.546343
+3961,C-41300-4225-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48383000
+_cell_length_b   5.70003000
+_cell_length_c   6.18942000
+_cell_angle_alpha   67.65400000
+_cell_angle_beta   101.58922000
+_cell_angle_gamma   102.60295000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   78.41778697
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.51413397  0.59589343  0.88960302  1
+  C  C1  1  0.59263358  0.87372654  0.76912451  1
+  C  C2  1  0.78175842  0.42261811  0.59984521  1
+  C  C3  1  0.04405445  0.33392760  0.21623384  1
+  C  C4  1  0.92184647  0.47114968  0.83075664  1
+  C  C5  1  0.89199420  0.21119218  0.03762571  1
+  C  C6  1  0.32036797  0.04637811  0.05876419  1
+  C  C7  1  0.60528109  0.50023524  0.16999391  1
+  C  C8  1  0.33687890  0.81861543  0.31456461  1
+  C  C9  1  0.49770277  0.96889009  0.48904257  1
+  C  C10  1  0.20956538  0.25789545  0.62120641  1
+  C  C11  1  0.76872297  0.64988089  0.34535748  1
+  C  C12  1  1.05710459  0.13499031  0.44290161  1
+  C  C13  1  0.18433144  -0.00126956  0.82749280  1
+",-154.37197785714287
+4247,C-13897-9657-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47507000
+_cell_length_b   3.72195000
+_cell_length_c   4.24890000
+_cell_angle_alpha   115.99166000
+_cell_angle_beta   90.00805000
+_cell_angle_gamma   90.00077000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.18240622
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.72282683  0.21274692  0.38723095  1
+  C  C1  1  0.22285119  0.23301745  0.61013459  1
+  C  C2  1  0.22265046  0.82419956  0.60985408  1
+  C  C3  1  0.72274002  0.77811508  0.10923395  1
+  C  C4  1  0.72264392  0.62157417  0.38747504  1
+  C  C5  1  0.22277888  0.66765283  0.88812908  1
+",-154.28846233333334
+7921,C-90858-8157-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.33939000
+_cell_length_b   3.35734000
+_cell_length_c   7.55085000
+_cell_angle_alpha   105.87969000
+_cell_angle_beta   105.71688000
+_cell_angle_gamma   42.97628000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   55.18381525
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36914060  0.28423198  0.21197814  1
+  C  C1  1  0.35196446  0.26896113  0.55794276  1
+  C  C2  1  0.61134304  0.52955483  0.26963687  1
+  C  C3  1  0.62422870  0.54036652  0.92632561  1
+  C  C4  1  0.23387736  0.15099229  0.36062834  1
+  C  C5  1  -0.08205008  0.83451458  0.64812866  1
+  C  C6  1  0.74628362  0.66240509  0.12218464  1
+  C  C7  1  0.05635100  0.97290628  0.83717188  1
+",-154.18953
+9488,C-53801-6753-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43190000
+_cell_length_b   3.99256000
+_cell_length_c   4.62856000
+_cell_angle_alpha   96.06045000
+_cell_angle_beta   74.63770000
+_cell_angle_gamma   90.14290000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.07787769
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.85486350  0.18160093  0.83095190  1
+  C  C1  1  0.29978998  0.06932215  -0.05857709  1
+  C  C2  1  0.18820171  0.84730474  0.16354749  1
+  C  C3  1  0.63337847  0.73427465  0.27377540  1
+  C  C4  1  0.96608524  0.40379683  0.60893760  1
+  C  C5  1  0.52090100  0.51671459  0.49882819  1
+",-154.45855266666666
+4358,C-184058-8674-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.45539000
+_cell_length_b   4.78569000
+_cell_length_c   5.88727000
+_cell_angle_alpha   101.66478000
+_cell_angle_beta   97.91588000
+_cell_angle_gamma   135.44914000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   61.00245495
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.04865298  -0.14321492  0.47123228  1
+  C  C1  1  1.06150196  0.18268121  0.47706842  1
+  C  C2  1  0.69075967  0.12493369  0.61341741  1
+  C  C3  1  0.67462475  0.91714023  0.78006360  1
+  C  C4  1  1.11882259  0.62105679  0.05578882  1
+  C  C5  1  0.81015622  0.99898244  0.19286237  1
+  C  C6  1  0.03591206  0.58443858  0.78295701  1
+  C  C7  1  0.78536485  0.64872832  1.17306982  1
+  C  C8  1  0.71402120  0.64046730  0.63544635  1
+  C  C9  1  0.09042650  0.27171968  0.05258493  1
+",-154.24503
+3453,C-47618-2147-59,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42993000
+_cell_length_b   4.20530000
+_cell_length_c   5.88054000
+_cell_angle_alpha   87.21099000
+_cell_angle_beta   73.98654000
+_cell_angle_gamma   90.01200000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.68485487
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.95992622  0.84438638  0.57030002  1
+  C  C1  1  -0.03945097  0.17765798  0.56951955  1
+  C  C2  1  0.12225425  0.31056549  0.05401462  1
+  C  C3  1  0.62169453  0.47732222  0.05472489  1
+  C  C4  1  0.12167139  0.97730402  1.05474099  1
+  C  C5  1  0.45992048  0.34438020  0.57033709  1
+  C  C6  1  0.46054421  0.67765820  0.56954742  1
+  C  C7  1  0.62224221  0.81058131  0.05403683  1
+",-154.43626375
+449,C-193936-350-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48432000
+_cell_length_b   4.59650000
+_cell_length_c   6.02171000
+_cell_angle_alpha   101.92404000
+_cell_angle_beta   114.35111000
+_cell_angle_gamma   105.70902000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.19486189
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.51132832  0.20403191  0.22680659  1
+  C  C1  1  0.57107493  1.12037519  0.82999379  1
+  C  C2  1  0.23475416  0.30330916  0.40137484  1
+  C  C3  1  0.59255237  0.63926959  0.59112852  1
+  C  C4  1  0.30170414  0.28483100  0.97789171  1
+  C  C5  1  0.52541137  0.65621935  0.01465832  1
+  C  C6  1  0.25568258  0.82069156  0.16233055  1
+  C  C7  1  0.26364920  0.07237207  0.54545277  1
+  C  C8  1  0.31530045  0.73727192  0.76548194  1
+  C  C9  1  0.56426238  -0.12996834  0.44740338  1
+",-154.381382
+8688,C-148270-9360-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43049000
+_cell_length_b   4.20468000
+_cell_length_c   5.65732000
+_cell_angle_alpha   90.31301000
+_cell_angle_beta   94.79510000
+_cell_angle_gamma   90.21799000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.61086406
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.13196133  0.18900810  0.41696558  1
+  C  C1  1  0.63196133  0.68900810  0.41696558  1
+  C  C2  1  0.39109754  -0.02578311  0.91755429  1
+  C  C3  1  0.13153724  0.85632899  0.41742762  1
+  C  C4  1  0.63153724  0.35632899  0.41742762  1
+  C  C5  1  0.89109754  0.47421689  -0.08244571  1
+  C  C6  1  0.39067346  0.64153779  0.91801633  1
+  C  C7  1  -0.10932654  0.14153779  0.91801633  1
+",-154.454205
+749,C-126159-6870-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43124000
+_cell_length_b   3.17651000
+_cell_length_c   7.68178000
+_cell_angle_alpha   61.70566000
+_cell_angle_beta   98.11315000
+_cell_angle_gamma   66.08632000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.46791037
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.34084567  0.55611656  0.61646763  1
+  C  C1  1  0.33990016  -0.10909299  -0.05000316  1
+  C  C2  1  0.00811340  0.99777642  0.39402779  1
+  C  C3  1  0.34114896  0.22157797  0.28302655  1
+  C  C4  1  0.00724899  0.33337290  0.72768435  1
+  C  C5  1  1.00706602  0.66627553  0.06095713  1
+",-154.46217633333333
+2738,C-157681-4063-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47949000
+_cell_length_b   3.80184000
+_cell_length_c   7.90077000
+_cell_angle_alpha   108.32530000
+_cell_angle_beta   89.98915000
+_cell_angle_gamma   89.98299000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   70.70058222
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.93955326  0.58256841  0.99303982  1
+  C  C1  1  0.44006410  0.48468316  0.26067948  1
+  C  C2  1  -0.06045320  0.19436923  0.98107503  1
+  C  C3  1  0.43977022  1.02470058  0.88781199  1
+  C  C4  1  0.93999625  0.48416034  0.16602740  1
+  C  C5  1  0.44006488  0.23475658  0.73840080  1
+  C  C6  1  0.44021596  0.38378427  0.41076309  1
+  C  C7  1  0.94023175  0.32160202  0.48839248  1
+  C  C8  1  0.43971252  0.63267174  0.89889499  1
+  C  C9  1  0.94013647  0.22040767  0.63845721  1
+",-154.071557
+1485,C-170882-2973-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45436000
+_cell_length_b   5.31290000
+_cell_length_c   7.90447000
+_cell_angle_alpha   77.75911000
+_cell_angle_beta   103.38900000
+_cell_angle_gamma   87.51290000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   97.52648370
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.45561509  0.32306079  0.43783186  1
+  C  C1  1  0.41584660  0.05631522  1.00005820  1
+  C  C2  1  0.61507753  0.50238037  0.14657645  1
+  C  C3  1  -0.54829775  0.57662165  0.96875458  1
+  C  C4  1  0.29366723  0.19922241  0.81104544  1
+  C  C5  1  0.62675435  0.75616080  0.53180588  1
+  C  C6  1  0.86164848  0.59895581  0.86064231  1
+  C  C7  1  0.20128314  0.51642725  0.25111618  1
+  C  C8  1  1.07455438  0.80987781  0.25672596  1
+  C  C9  1  0.73751712  0.84435761  0.70662512  1
+  C  C10  1  0.04498808  0.88097422  0.42574580  1
+  C  C11  1  0.20585648  0.01408760  0.68772231  1
+  C  C12  1  1.02240098  0.14722787  0.47846519  1
+  C  C13  1  0.75486387  0.36866601  0.76439025  1
+  C  C14  1  0.60724185  0.48059687  0.57236730  1
+  C  C15  1  0.98131786  -0.01314367  0.08568239  1
+",-154.104555625
+5541,C-72703-290-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46383000
+_cell_length_b   3.79618000
+_cell_length_c   8.57597000
+_cell_angle_alpha   109.61037000
+_cell_angle_beta   106.69955000
+_cell_angle_gamma   108.92999000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   64.01765885
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.39558597  0.38863430  0.28051859  1
+  C  C1  1  0.15599745  0.30968876  0.08034731  1
+  C  C2  1  1.11134909  0.66894342  0.35562067  1
+  C  C3  1  0.17341090  0.66552940  0.91989900  1
+  C  C4  1  1.11579460  0.09824079  0.64484621  1
+  C  C5  1  0.45542449  -0.04419032  0.55574225  1
+  C  C6  1  0.12159331  0.92817774  0.23730578  1
+  C  C7  1  0.41236103  0.74434380  0.12003176  1
+  C  C8  1  0.45847034  0.38533673  0.84489491  1
+  C  C9  1  0.44737961  0.12606426  0.96319372  1
+",-154.21067399999998
+3110,C-184070-3159-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48470000
+_cell_length_b   4.59649000
+_cell_length_c   5.48712000
+_cell_angle_alpha   69.49981000
+_cell_angle_beta   90.01558000
+_cell_angle_gamma   105.66103000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.21041047
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.19753942  0.53361675  0.35148868  1
+  C  C1  1  0.34734723  0.61719581  0.95398342  1
+  C  C2  1  0.53707974  1.00013473  0.88957654  1
+  C  C3  1  0.96952696  -0.13154866  0.57146019  1
+  C  C4  1  0.08623566  0.09907783  0.71561703  1
+  C  C5  1  -0.00635239  0.91724050  0.28598260  1
+  C  C6  1  0.57602250  1.08143999  0.13803539  1
+  C  C7  1  0.25392756  0.43521818  0.52611848  1
+  C  C8  1  0.36962526  0.66626567  0.66942878  1
+  C  C9  1  0.76507140  0.45284249  0.10166320  1
+",-154.380836
+5990,C-102754-6012-69,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46819000
+_cell_length_b   5.26429000
+_cell_length_c   9.30035000
+_cell_angle_alpha   89.92500000
+_cell_angle_beta   71.09298000
+_cell_angle_gamma   84.54792000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C20
+_cell_volume   113.74903674
+_cell_formula_units_Z   20
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.08491210  0.78680583  0.86453771  1
+  C  C1  1  0.66586974  0.13672085  0.08874700  1
+  C  C2  1  0.27155445  0.45124582  0.55009752  1
+  C  C3  1  0.88092433  0.21468277  0.92212705  1
+  C  C4  1  0.81819787  0.91239820  0.53997557  1
+  C  C5  1  0.36430741  0.37747116  0.91544825  1
+  C  C6  1  0.07812211  0.03280941  0.78427690  1
+  C  C7  1  0.35194270  0.39710322  0.17260480  1
+  C  C8  1  0.45824878  0.27127077  0.40687481  1
+  C  C9  1  0.69253658  0.44706004  0.27102074  1
+  C  C10  1  0.65145835  0.38908240  0.64456831  1
+  C  C11  1  0.19289688  0.97982873  0.11600686  1
+  C  C12  1  0.39222592  0.53875060  0.78881326  1
+  C  C13  1  0.10099193  0.88038953  0.27822392  1
+  C  C14  1  0.32305716  0.54219587  0.04201189  1
+  C  C15  1  0.67072972  1.08439673  0.68636846  1
+  C  C16  1  0.58445713  0.72835579  0.32412608  1
+  C  C17  1  -0.03477091  0.09622674  0.40429851  1
+  C  C18  1  0.40275448  0.78675250  -0.01615335  1
+  C  C19  1  0.36589907  0.74256030  0.50254618  1
+",-154.0813235
+3544,C-170918-845-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.35412000
+_cell_length_b   4.50923000
+_cell_length_c   6.05503000
+_cell_angle_alpha   104.21519000
+_cell_angle_beta   87.23295000
+_cell_angle_gamma   83.22060000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   87.87001892
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.17517522  0.49387869  0.61593928  1
+  C  C1  1  -0.08028272  0.25474387  0.70686751  1
+  C  C2  1  0.62906186  0.52125303  0.41439886  1
+  C  C3  1  0.12739170  0.90503944  0.91112542  1
+  C  C4  1  1.29464445  0.76777252  0.07514027  1
+  C  C5  1  0.46410171  0.30752367  0.24740127  1
+  C  C6  1  0.93395172  0.77071649  0.72283726  1
+  C  C7  1  0.29179777  0.43966222  0.07278180  1
+  C  C8  1  0.81048901  0.97807175  0.59949300  1
+  C  C9  1  0.46145073  0.97950604  0.24497910  1
+  C  C10  1  0.62406227  0.84229200  0.40979967  1
+  C  C11  1  0.12264891  0.22645608  0.90673807  1
+",-154.2117475
+8533,C-134208-315-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52839000
+_cell_length_b   5.26286000
+_cell_length_c   5.55160000
+_cell_angle_alpha   89.95035000
+_cell_angle_beta   76.81414000
+_cell_angle_gamma   89.98278000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   71.92504825
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.48695981  0.16807786  -0.02101879  1
+  C  C1  1  0.12243471  0.81863662  0.70608778  1
+  C  C2  1  0.78974566  0.30416432  0.37228739  1
+  C  C3  1  0.25803180  0.43819265  0.43557597  1
+  C  C4  1  0.91057608  0.16772294  0.13129743  1
+  C  C5  1  0.25866570  0.89692099  0.43512396  1
+  C  C6  1  0.54883743  0.44302376  0.85295016  1
+  C  C7  1  0.33742266  0.66772970  0.27886161  1
+  C  C8  1  0.45666728  0.66835106  1.03637362  1
+  C  C9  1  0.79031855  0.03071895  0.37156112  1
+  C  C10  1  0.12198968  0.51796217  0.70622686  1
+  C  C11  1  0.54921673  0.89379459  0.85274079  1
+",-154.15535583333337
+10031,C-72714-6010-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.06429000
+_cell_length_b   2.43293000
+_cell_length_c   7.58632000
+_cell_angle_alpha   71.93574000
+_cell_angle_beta   56.25288000
+_cell_angle_gamma   68.32787000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.29839598
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.60279633  0.89375512  0.08365492  1
+  C  C1  1  0.49273119  0.33809599  0.19472517  1
+  C  C2  1  0.15903059  0.67158240  0.52813700  1
+  C  C3  1  0.82567638  0.00491464  0.86139846  1
+  C  C4  1  0.93562896  0.56061190  0.75040066  1
+  C  C5  1  0.26934264  0.22706785  0.41706638  1
+",-154.44498083333335
+328,C-102864-296-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.04818000
+_cell_length_b   4.92007000
+_cell_length_c   7.06266000
+_cell_angle_alpha   62.80705000
+_cell_angle_beta   77.23431000
+_cell_angle_gamma   68.24004000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   87.32972243
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.24012175  0.77111992  0.95000866  1
+  C  C1  1  0.63760873  0.37899211  0.73657391  1
+  C  C2  1  0.73649123  0.27376632  0.25905062  1
+  C  C3  1  1.04593977  -0.04215680  0.25944169  1
+  C  C4  1  0.73657552  0.27622111  0.93981983  1
+  C  C5  1  0.03344012  0.97494481  0.05402838  1
+  C  C6  1  1.13119390  0.88297438  0.72777713  1
+  C  C7  1  0.55060824  0.46336686  1.05250893  1
+  C  C8  1  0.63243838  0.37938046  0.41907962  1
+  C  C9  1  0.31898211  0.69470004  0.41924913  1
+  C  C10  1  0.82382149  0.19124578  0.62433837  1
+  C  C11  1  0.33728846  0.67952282  0.62336791  1
+",-154.25587
+4478,C-80199-6032-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45984000
+_cell_length_b   5.07239000
+_cell_length_c   6.44891000
+_cell_angle_alpha   80.26313000
+_cell_angle_beta   88.81253000
+_cell_angle_gamma   84.56389000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   78.94808215
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.47182270  0.21984366  0.80400287  1
+  C  C1  1  -0.01731475  0.63655165  0.14330511  1
+  C  C2  1  0.97184099  0.18699225  0.91111970  1
+  C  C3  1  -0.01183231  0.69383974  0.91292804  1
+  C  C4  1  0.48984113  0.71942542  0.80572569  1
+  C  C5  1  0.97556627  0.36395658  0.24512897  1
+  C  C6  1  -0.00893086  0.81230990  0.47791837  1
+  C  C7  1  -0.02557505  0.13616243  0.14161543  1
+  C  C8  1  0.47239721  0.27944409  0.58245812  1
+  C  C9  1  0.49115570  0.77973276  0.58412932  1
+  C  C10  1  -0.01560685  0.86421317  0.24704195  1
+  C  C11  1  0.97334544  0.30602463  0.47611034  1
+",-154.0686975
+8923,C-90829-2589-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44766000
+_cell_length_b   4.81038000
+_cell_length_c   6.46265000
+_cell_angle_alpha   90.76911000
+_cell_angle_beta   112.22020000
+_cell_angle_gamma   104.61116000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.65867123
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70978386  0.25455959  0.61681335  1
+  C  C1  1  0.71663342  0.11837214  0.19119970  1
+  C  C2  1  0.50360508  0.72962736  0.67213788  1
+  C  C3  1  0.22175229  0.55373714  -0.02035359  1
+  C  C4  1  -0.04006257  0.25185348  0.86871286  1
+  C  C5  1  0.45380833  0.08766200  0.94374996  1
+  C  C6  1  0.48476741  0.58479793  0.22705917  1
+  C  C7  1  0.43780871  0.94192181  0.49855559  1
+  C  C8  1  0.22631977  0.41762166  0.55245800  1
+  C  C9  1  0.97670013  0.42060905  0.30101891  1
+  C  C10  1  0.18133946  0.77764477  0.82622927  1
+  C  C11  1  0.76050889  -0.10587833  0.34484870  1
+",-154.31598
+3768,C-126136-4977-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.88999000
+_cell_length_b   4.83034000
+_cell_length_c   4.88970000
+_cell_angle_alpha   108.22391000
+_cell_angle_beta   59.54217000
+_cell_angle_gamma   66.76104000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   69.72637799
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.06697148  0.55724939  0.93057212  1
+  C  C1  1  0.12925710  1.00804007  0.44844090  1
+  C  C2  1  0.27481143  0.04147399  0.14474845  1
+  C  C3  1  0.06666259  0.09922440  0.00425287  1
+  C  C4  1  0.50531646  0.16404373  0.56236228  1
+  C  C5  1  0.81898370  0.51990861  0.18088396  1
+  C  C6  1  0.75543530  0.06959103  0.66496525  1
+  C  C7  1  0.38056101  0.91309811  0.54991333  1
+  C  C8  1  0.60999186  0.03596673  -0.03151421  1
+  C  C9  1  0.81910845  -0.02187016  1.10807184  1
+",-154.144283
+5161,C-177222-86-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.87073000
+_cell_length_b   4.66796000
+_cell_length_c   5.76508000
+_cell_angle_alpha   51.91510000
+_cell_angle_beta   80.77865000
+_cell_angle_gamma   94.17404000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.53824195
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.38629868  0.73456249  0.41036958  1
+  C  C1  1  0.38482929  0.23836727  -0.06714066  1
+  C  C2  1  0.38583758  0.73434061  0.95962335  1
+  C  C3  1  0.38428698  0.36687842  0.09431514  1
+  C  C4  1  0.38565731  0.86295047  0.12097088  1
+  C  C5  1  0.38353010  0.05038068  0.64827431  1
+  C  C6  1  0.38493446  0.36705204  0.64329543  1
+  C  C7  1  0.38700831  0.05095151  0.40552197  1
+",-154.185435
+2270,C-90825-876-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47432000
+_cell_length_b   3.69605000
+_cell_length_c   6.19771000
+_cell_angle_alpha   76.37667000
+_cell_angle_beta   78.51235000
+_cell_angle_gamma   90.01553000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   53.91494598
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.24183796  0.77820685  0.25125247  1
+  C  C1  1  0.57846146  0.44420880  0.57948207  1
+  C  C2  1  1.01192332  0.37132050  0.71337988  1
+  C  C3  1  0.33369838  0.14633632  0.06788879  1
+  C  C4  1  0.90011095  0.21670524  0.93410505  1
+  C  C5  1  0.24131894  0.37043201  0.25233773  1
+  C  C6  1  0.67056374  0.81380000  0.39529967  1
+  C  C7  1  0.67144405  0.22204677  0.39339433  1
+",-154.2068175
+7395,C-136208-4716-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48314000
+_cell_length_b   2.48264000
+_cell_length_c   10.49753000
+_cell_angle_alpha   103.66030000
+_cell_angle_beta   83.20332000
+_cell_angle_gamma   120.03087000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   54.44218331
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.61272187  0.60724260  0.73819906  1
+  C  C1  1  0.27948841  0.33869410  0.13720016  1
+  C  C2  1  0.28003910  1.19030751  0.98785220  1
+  C  C3  1  0.61277638  0.20486114  0.33588686  1
+  C  C4  1  0.94622365  0.47312989  0.93775435  1
+  C  C5  1  -0.05459889  0.07178172  0.53669241  1
+  C  C6  1  0.61197700  0.45576108  0.58713433  1
+  C  C7  1  0.61238747  0.05506617  0.18698162  1
+  C  C8  1  0.94640235  0.92119834  0.38577348  1
+  C  C9  1  -0.05390965  0.32368266  0.78848073  1
+",-154.53383100000002
+209,C-28250-3871-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43258000
+_cell_length_b   3.99065000
+_cell_length_c   4.64484000
+_cell_angle_alpha   84.16839000
+_cell_angle_beta   105.58738000
+_cell_angle_gamma   89.77167000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.18399423
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.22953394  0.60057545  0.49376191  1
+  C  C1  1  1.00850637  0.15585802  0.04950811  1
+  C  C2  1  0.56177451  1.26926569  0.15888497  1
+  C  C3  1  0.67638806  0.48660294  0.38465058  1
+  C  C4  1  0.34260454  0.82100788  0.71741995  1
+  C  C5  1  -0.10413082  -0.06607277  0.82686599  1
+",-154.4605776666667
+7732,C-172930-9950-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48197000
+_cell_length_b   3.84325000
+_cell_length_c   4.48867000
+_cell_angle_alpha   89.96542000
+_cell_angle_beta   123.57151000
+_cell_angle_gamma   89.99728000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.67467737
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.00268160  1.00442483  0.37211699  1
+  C  C1  1  0.73838585  0.59300042  0.60832389  1
+  C  C2  1  0.73503192  0.29873616  0.10463686  1
+  C  C3  1  0.73902177  0.00381795  0.60874140  1
+  C  C4  1  1.00188759  0.59331987  0.37169330  1
+  C  C5  1  0.00714068  0.29818168  0.87613797  1
+",-154.15138066666665
+744,C-41262-9862-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.77673000
+_cell_length_b   4.75913000
+_cell_length_c   3.90599000
+_cell_angle_alpha   114.24728000
+_cell_angle_beta   90.03521000
+_cell_angle_gamma   66.90332000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.79356341
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.72720832  0.55650283  0.10595556  1
+  C  C1  1  0.33056847  0.28577610  -0.31455028  1
+  C  C2  1  0.96187738  0.95465965  0.63104107  1
+  C  C3  1  0.57919568  1.15419335  1.26661138  1
+  C  C4  1  0.54458197  0.03964573  0.84671672  1
+  C  C5  1  -0.05911486  0.31026361  0.69839273  1
+  C  C6  1  0.69206668  0.44232968  0.41119618  1
+  C  C7  1  0.36442243  0.77825024  0.71245872  1
+  C  C8  1  0.31088318  0.64102964  -0.02539157  1
+  C  C9  1  0.90819004  0.81759327  0.23159038  1
+",-154.079439
+5150,C-107746-1080-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48019000
+_cell_length_b   2.48082000
+_cell_length_c   8.66194000
+_cell_angle_alpha   106.63044000
+_cell_angle_beta   89.99664000
+_cell_angle_gamma   120.01264000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.55685715
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.33294911  0.45052386  0.60565816  1
+  C  C1  1  0.83316114  0.45147986  0.85705419  1
+  C  C2  1  0.79261182  0.36859262  0.29485762  1
+  C  C3  1  0.66744555  0.11956052  0.10844403  1
+  C  C4  1  0.45798567  0.70089014  0.79392222  1
+  C  C5  1  0.62468837  0.03344949  0.54301567  1
+  C  C6  1  0.50073302  0.78510322  0.35700054  1
+  C  C7  1  0.95901843  0.70257499  0.04585837  1
+",-154.53175125
+2758,C-136249-3748-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47434000
+_cell_length_b   3.68228000
+_cell_length_c   8.34442000
+_cell_angle_alpha   67.96200000
+_cell_angle_beta   72.86575000
+_cell_angle_gamma   90.10301000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   66.80122175
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.01424300  0.84059195  0.32332213  1
+  C  C1  1  0.37961670  0.41036125  0.95454531  1
+  C  C2  1  0.61772809  0.98175650  0.21930382  1
+  C  C3  1  -0.23604886  0.40403986  0.07158300  1
+  C  C4  1  0.52762616  0.83131640  0.80685851  1
+  C  C5  1  0.76727968  0.81273935  0.06850567  1
+  C  C6  1  0.37711258  0.00141394  0.95754431  1
+  C  C7  1  0.13124692  0.97165804  0.70268052  1
+  C  C8  1  0.28420789  0.31040573  0.55223088  1
+  C  C9  1  0.86470115  0.49787448  0.47217865  1
+",-154.185889
+9728,C-73637-6506-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.30613000
+_cell_length_b   3.28834000
+_cell_length_c   4.79966000
+_cell_angle_alpha   72.68033000
+_cell_angle_beta   63.30397000
+_cell_angle_gamma   49.01927000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.83780038
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.69374036  0.77445288  0.86307273  1
+  C  C1  1  0.05463052  0.27426175  0.36304365  1
+  C  C2  1  0.69387343  0.27423152  0.36307354  1
+  C  C3  1  0.69365189  0.31557668  0.04362716  1
+  C  C4  1  0.33281254  0.31597571  0.04382295  1
+  C  C5  1  0.33299551  0.81572367  0.54383842  1
+  C  C6  1  0.05445796  0.77451347  0.86306330  1
+  C  C7  1  0.69382248  0.81533141  0.54360466  1
+",-154.331275
+2111,C-90833-5103-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44496000
+_cell_length_b   3.38252000
+_cell_length_c   8.65710000
+_cell_angle_alpha   122.46896000
+_cell_angle_beta   81.82759000
+_cell_angle_gamma   111.20790000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.18934821
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87241901  0.32078107  0.75105263  1
+  C  C1  1  0.15898458  0.24132279  0.08933764  1
+  C  C2  1  0.70913356  0.42970982  0.17982741  1
+  C  C3  1  0.65765068  0.94048414  0.79645234  1
+  C  C4  1  0.09427097  -0.09195043  0.89075986  1
+  C  C5  1  0.36523214  1.01607963  0.45850648  1
+  C  C6  1  0.43652278  0.35340575  0.65687307  1
+  C  C7  1  0.81267109  0.82531404  0.36835727  1
+",-154.17354625
+445,C-102875-8418-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.18840000
+_cell_length_b   4.44510000
+_cell_length_c   4.32836000
+_cell_angle_alpha   82.24980000
+_cell_angle_beta   75.08633000
+_cell_angle_gamma   73.42719000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.69066124
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46220308  0.36635242  0.78652157  1
+  C  C1  1  0.64766626  0.65230040  0.31439043  1
+  C  C2  1  0.33205650  0.65694490  0.62570574  1
+  C  C3  1  -0.03412185  0.34119063  0.30944686  1
+  C  C4  1  0.96729284  0.89025948  0.76282741  1
+  C  C5  1  0.83755246  0.18081179  0.60121261  1
+  C  C6  1  0.33378819  0.20626805  1.07807168  1
+  C  C7  1  0.64913703  0.89448363  1.07296400  1
+",-154.1678275
+8321,C-130530-3416-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42929000
+_cell_length_b   2.42931000
+_cell_length_c   8.77541000
+_cell_angle_alpha   86.16204000
+_cell_angle_beta   102.80921000
+_cell_angle_gamma   59.98832000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.74774493
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.62079774  -0.16989235  0.49143741  1
+  C  C1  1  0.68557427  0.27262525  0.82163064  1
+  C  C2  1  0.42675730  0.29012124  0.15167527  1
+  C  C3  1  0.35343973  -0.06103544  0.82244244  1
+  C  C4  1  0.75989801  0.62421499  0.15133951  1
+  C  C5  1  0.28739054  0.49657580  0.49174673  1
+",-154.44724033333333
+7979,C-113064-8679-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43144000
+_cell_length_b   3.03277000
+_cell_length_c   8.74409000
+_cell_angle_alpha   72.28118000
+_cell_angle_beta   73.81044000
+_cell_angle_gamma   84.58405000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.98128070
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.95541092  0.95492288  0.84883222  1
+  C  C1  1  0.62147210  -0.04637959  0.18259925  1
+  C  C2  1  0.37167765  -0.04534740  0.93243819  1
+  C  C3  1  0.45567062  -0.04466473  0.34864277  1
+  C  C4  1  0.20524474  -0.04604667  0.09893714  1
+  C  C5  1  0.12207664  0.95607659  0.68207647  1
+  C  C6  1  0.70582070  0.95651247  0.59844355  1
+  C  C7  1  0.87195133  0.95496715  0.43225382  1
+",-154.4598525
+132,C-145350-4405-55,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45599000
+_cell_length_b   3.66261000
+_cell_length_c   6.44473000
+_cell_angle_alpha   104.71596000
+_cell_angle_beta   101.00571000
+_cell_angle_gamma   70.43717000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.47657901
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.56117454  0.66356533  0.24370315  1
+  C  C1  1  0.57661945  0.87647804  0.48818142  1
+  C  C2  1  0.20326422  0.71172775  0.57608375  1
+  C  C3  1  0.83812768  0.78657161  -0.07951843  1
+  C  C4  1  0.78954430  0.26077710  0.29409690  1
+  C  C5  1  0.29597849  0.76283437  0.81327744  1
+  C  C6  1  0.93570915  -0.16981951  0.15717586  1
+  C  C7  1  0.35271026  0.28053161  0.44014070  1
+",-154.2811725
+7413,C-150719-574-54,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44373000
+_cell_length_b   6.94499000
+_cell_length_c   7.99015000
+_cell_angle_alpha   96.21026000
+_cell_angle_beta   107.85268000
+_cell_angle_gamma   100.13058000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   125.14831670
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.92339536  0.55814199  1.02644222  1
+  C  C1  1  0.41482915  0.31670667  0.64327242  1
+  C  C2  1  0.32431413  0.59554298  0.41302035  1
+  C  C3  1  0.84416437  0.36861832  1.04086020  1
+  C  C4  1  0.27868133  0.25070216  1.03461453  1
+  C  C5  1  0.48939717  0.67578969  1.03423199  1
+  C  C6  1  0.83241937  0.02892017  0.20335157  1
+  C  C7  1  0.33426060  0.77776812  0.33102555  1
+  C  C8  1  -0.24869861  -0.18354716  0.22848279  1
+  C  C9  1  0.18341084  -0.00890744  0.57122953  1
+  C  C10  1  0.89136876  0.38501190  0.58611740  1
+  C  C11  1  0.42434680  0.14231223  0.73589590  1
+  C  C12  1  0.33925615  0.11272454  0.16732553  1
+  C  C13  1  0.57536609  0.92351001  0.49811507  1
+  C  C14  1  0.84243721  0.52342551  0.46703041  1
+  C  C15  1  0.43022665  0.81400523  0.90298573  1
+  C  C16  1  0.01250166  0.10801117  0.84008135  1
+  C  C17  1  0.93651886  0.89740530  0.86764166  1
+",-154.21701833333333
+2454,C-193926-6320-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.53264000
+_cell_length_b   2.45733000
+_cell_length_c   6.43215000
+_cell_angle_alpha   90.03227000
+_cell_angle_beta   98.98490000
+_cell_angle_gamma   90.07193000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.53945486
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.14886598  0.98522343  0.40980097  1
+  C  C1  1  0.31164329  0.48599736  0.74672893  1
+  C  C2  1  0.43849206  0.48680408  -0.03150936  1
+  C  C3  1  0.49997655  -0.01299861  0.07518169  1
+  C  C4  1  0.25221377  0.98565119  0.64032170  1
+  C  C5  1  0.60815395  -0.01405455  0.30557886  1
+",-154.08318466666665
+8444,C-76032-8953-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51154000
+_cell_length_b   5.86931000
+_cell_length_c   4.82383000
+_cell_angle_alpha   96.95536000
+_cell_angle_beta   92.31678000
+_cell_angle_gamma   98.75770000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   69.63619204
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.39535558  0.67697520  0.42940066  1
+  C  C1  1  0.50525248  0.44504841  0.47959492  1
+  C  C2  1  0.86180674  0.94415784  0.19837839  1
+  C  C3  1  -0.04762936  0.18702802  0.07770020  1
+  C  C4  1  0.31145552  0.78682388  0.16916341  1
+  C  C5  1  0.19132452  0.63198697  0.88912340  1
+  C  C6  1  0.87442708  0.08292050  0.48793700  1
+  C  C7  1  0.36585644  0.04626518  0.65495840  1
+  C  C8  1  0.29754905  0.79344552  0.67297349  1
+  C  C9  1  0.59535643  0.47644123  0.81066122  1
+  C  C10  1  0.96171927  0.31309250  0.37829616  1
+  C  C11  1  0.46427266  0.22742684  0.91216056  1
+",-154.1124425
+6011,C-40110-5594-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43076000
+_cell_length_b   2.43061000
+_cell_length_c   8.86586000
+_cell_angle_alpha   105.58652000
+_cell_angle_beta   90.38054000
+_cell_angle_gamma   120.01911000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.05766586
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55060989  1.01530550  0.62509445  1
+  C  C1  1  0.97547845  0.93157151  0.28601579  1
+  C  C2  1  0.78416342  0.47503560  -0.04108540  1
+  C  C3  1  0.11751042  0.14171227  0.95889611  1
+  C  C4  1  0.21686358  0.34772984  0.62446405  1
+  C  C5  1  0.64217953  0.26508198  0.28608529  1
+",-154.46577
+7626,C-106857-1903-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43219000
+_cell_length_b   4.08785000
+_cell_length_c   6.21015000
+_cell_angle_alpha   69.93340000
+_cell_angle_beta   86.97699000
+_cell_angle_gamma   87.71900000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.89955199
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.77211380  0.28384586  0.01388663  1
+  C  C1  1  0.77190354  0.61630619  0.34682996  1
+  C  C2  1  0.27195511  0.11619020  0.09631325  1
+  C  C3  1  -0.22811033  0.61636065  0.84689974  1
+  C  C4  1  0.77212052  0.28382271  0.51385794  1
+  C  C5  1  0.27194839  0.11621335  0.59634193  1
+  C  C6  1  0.27216537  0.78372987  0.76336992  1
+  C  C7  1  1.27217924  0.78367541  0.26330014  1
+",-154.471575
+5274,C-148225-7911-51,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.29963000
+_cell_length_b   3.29995000
+_cell_length_c   6.41715000
+_cell_angle_alpha   125.68096000
+_cell_angle_beta   105.07360000
+_cell_angle_gamma   100.36932000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.66267069
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.44837197  0.29527558  0.29859712  1
+  C  C1  1  0.22625400  0.44285144  0.12503426  1
+  C  C2  1  0.08522931  0.93202727  0.29870910  1
+  C  C3  1  0.52297893  0.61441163  0.84055690  1
+  C  C4  1  0.15251669  1.12379013  0.58350824  1
+  C  C5  1  0.59015645  0.80622249  0.12540247  1
+  C  C6  1  0.82602447  -0.20199652  0.58353540  1
+  C  C7  1  0.84848449  -0.05962151  0.84009071  1
+",-154.22111
+7751,C-189705-3285-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47678000
+_cell_length_b   2.47719000
+_cell_length_c   10.36214000
+_cell_angle_alpha   96.86908000
+_cell_angle_beta   89.99268000
+_cell_angle_gamma   59.98255000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   54.52088333
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.56270210  0.90944091  0.82168143  1
+  C  C1  1  0.10361513  0.84079550  0.22005641  1
+  C  C2  1  0.64457686  0.74282878  0.57086704  1
+  C  C3  1  0.78732839  0.47354420  0.17009417  1
+  C  C4  1  0.91264491  0.20934084  0.77128163  1
+  C  C5  1  0.51778933  1.00976149  -0.02810443  1
+  C  C6  1  1.04886160  -0.05776729  0.37044593  1
+  C  C7  1  0.96096833  0.11014271  0.62134140  1
+  C  C8  1  0.69861084  0.64208035  0.42081740  1
+  C  C9  1  -0.16555428  0.37650550  0.02197832  1
+",-154.52429
+9057,C-136243-305-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.67159000
+_cell_length_b   5.29418000
+_cell_length_c   3.64916000
+_cell_angle_alpha   111.16851000
+_cell_angle_beta   88.11846000
+_cell_angle_gamma   114.91211000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.21593852
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.95151714  0.11579970  0.97786893  1
+  C  C1  1  0.25338088  0.42357671  0.01719592  1
+  C  C2  1  0.44502259  0.61495338  0.42064686  1
+  C  C3  1  0.25374606  0.42365071  0.63251087  1
+  C  C4  1  0.75951078  0.92471866  0.57501956  1
+  C  C5  1  0.95099785  0.11537873  0.36227727  1
+",-154.09573183333333
+9548,C-130501-2246-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.32744000
+_cell_length_b   4.98627000
+_cell_length_c   4.98634000
+_cell_angle_alpha   66.90891000
+_cell_angle_beta   65.18326000
+_cell_angle_gamma   65.22785000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   85.56263016
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.33799528  0.46841934  0.48349383  1
+  C  C1  1  0.33850810  0.74268468  0.20841441  1
+  C  C2  1  0.36991846  0.26021722  0.31436385  1
+  C  C3  1  0.69655624  0.45976571  0.47585447  1
+  C  C4  1  0.66517674  0.94315871  0.36873332  1
+  C  C5  1  1.01282010  0.02042731  0.76175453  1
+  C  C6  1  0.69696328  0.73441913  0.20040240  1
+  C  C7  1  0.37011057  0.57342815  1.00069564  1
+  C  C8  1  1.01718112  1.01847230  0.24312623  1
+  C  C9  1  0.01657172  0.50294764  0.75937830  1
+  C  C10  1  0.66483242  0.62863064  0.68404150  1
+  C  C11  1  1.01818715  0.18459238  0.44029363  1
+  C  C12  1  0.02204523  0.18209588  0.92263138  1
+  C  C13  1  0.01844909  0.69907682  -0.07434541  1
+",-154.08052142857144
+3137,C-193934-9379-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44626000
+_cell_length_b   4.57224000
+_cell_length_c   6.37918000
+_cell_angle_alpha   87.48387000
+_cell_angle_beta   101.06090000
+_cell_angle_gamma   105.54819000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   67.46031722
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.66482898  0.35372561  0.64188747  1
+  C  C1  1  0.67482027  0.82341478  0.18991817  1
+  C  C2  1  0.88279699  0.13173594  1.30048758  1
+  C  C3  1  0.08559958  0.68128911  0.15495105  1
+  C  C4  1  0.30222215  0.29643142  0.97820120  1
+  C  C5  1  0.20195209  0.30207850  0.76768135  1
+  C  C6  1  0.80410596  0.68470842  0.58992693  1
+  C  C7  1  0.89134656  0.34822332  0.10464213  1
+  C  C8  1  0.45637913  0.13277276  0.44559187  1
+  C  C9  1  0.35886589  0.82654975  0.55555755  1
+",-154.162216
+1556,C-130522-136-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43358000
+_cell_length_b   3.11945000
+_cell_length_c   6.40546000
+_cell_angle_alpha   95.60343000
+_cell_angle_beta   79.26799000
+_cell_angle_gamma   68.30036000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.64588783
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.29835119  0.85892161  0.50511964  1
+  C  C1  1  0.96690553  0.85561850  0.17143208  1
+  C  C2  1  0.07921345  0.85091916  0.94909731  1
+  C  C3  1  0.40970650  -0.14399261  0.28292112  1
+  C  C4  1  0.63527949  0.85288867  0.83750691  1
+  C  C5  1  0.74380203  0.85475037  0.61574624  1
+",-154.457959
+7001,C-13655-7913-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48450000
+_cell_length_b   4.08771000
+_cell_length_c   4.67625000
+_cell_angle_alpha   83.28582000
+_cell_angle_beta   105.37503000
+_cell_angle_gamma   90.02485000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.45470030
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.10483810  0.86826365  0.61608569  1
+  C  C1  1  0.53253049  0.74914379  0.47237141  1
+  C  C2  1  0.87463209  0.15621945  0.15971180  1
+  C  C3  1  0.26140263  0.68726702  -0.06890853  1
+  C  C4  1  0.76027216  0.46262382  0.92914625  1
+  C  C5  1  0.37368066  0.92987710  0.15744794  1
+  C  C6  1  0.58929320  0.39314710  0.58815290  1
+  C  C7  1  0.04559736  0.22370138  0.50160615  1
+",-154.3676825
+9565,C-157674-4910-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48133000
+_cell_length_b   3.68860000
+_cell_length_c   4.89533000
+_cell_angle_alpha   67.07298000
+_cell_angle_beta   59.49107000
+_cell_angle_gamma   70.36138000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.00809036
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.78036664  0.52240114  0.42374077  1
+  C  C1  1  0.07033858  0.67935903  0.55496371  1
+  C  C2  1  0.03210607  0.76395249  0.05114642  1
+  C  C3  1  0.75920308  0.16197653  0.12632804  1
+  C  C4  1  0.05507653  0.12450711  0.34856711  1
+  C  C5  1  0.74070369  0.60724490  0.92024565  1
+",-154.30933516666667
+8615,C-80168-1847-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.40025000
+_cell_length_b   3.39899000
+_cell_length_c   5.23045000
+_cell_angle_alpha   116.72289000
+_cell_angle_beta   116.74007000
+_cell_angle_gamma   93.86728000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.37818890
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.91762000  0.61740333  0.80740724  1
+  C  C1  1  0.56400511  0.26350939  0.81063561  1
+  C  C2  1  0.14484481  0.36372998  0.36230191  1
+  C  C3  1  0.67128836  0.37104261  0.14891226  1
+  C  C4  1  0.66405285  0.84477275  0.36222433  1
+  C  C5  1  0.31739595  1.01753197  1.15213543  1
+  C  C6  1  0.57113707  0.78988838  0.59721905  1
+  C  C7  1  0.09023206  0.27071728  0.59736747  1
+",-154.33012875
+5642,C-145327-8310-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47592000
+_cell_length_b   4.23351000
+_cell_length_c   7.01645000
+_cell_angle_alpha   103.90309000
+_cell_angle_beta   100.15248000
+_cell_angle_gamma   90.00173000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   70.20364069
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.07475864  0.28328465  0.35380928  1
+  C  C1  1  0.62004541  0.97177248  0.74358461  1
+  C  C2  1  0.86645324  0.55753050  0.23617431  1
+  C  C3  1  0.51980017  0.73207740  0.53850853  1
+  C  C4  1  1.13064786  0.49890877  0.76778377  1
+  C  C5  1  0.40474557  0.75413717  0.31463076  1
+  C  C6  1  0.76952925  0.31734453  0.03833120  1
+  C  C7  1  1.02634246  0.52287253  0.55171139  1
+  C  C8  1  0.38532978  0.08692480  0.27572337  1
+  C  C9  1  0.27623536  0.10806828  0.05168541  1
+  C  C10  1  0.17137673  0.86854769  0.84633696  1
+  C  C11  1  0.65745391  0.34124072  0.82170672  1
+",-154.30293833333334
+6619,C-57162-5454-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.48850000
+_cell_length_b   3.36422000
+_cell_length_c   8.84761000
+_cell_angle_alpha   79.03284000
+_cell_angle_beta   66.77524000
+_cell_angle_gamma   90.00093000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   93.35455990
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.82580275  0.81316030  0.90986738  1
+  C  C1  1  0.49096675  0.30315429  0.58052020  1
+  C  C2  1  0.62323071  0.27739554  0.29434193  1
+  C  C3  1  0.63904557  0.87968630  0.08843533  1
+  C  C4  1  -0.06714756  0.61269972  0.29452143  1
+  C  C5  1  0.63105881  1.01823616  0.69118205  1
+  C  C6  1  0.26214636  0.68912951  0.80927140  1
+  C  C7  1  0.76305180  0.68178666  0.47285964  1
+  C  C8  1  0.49696537  0.46312010  0.90988972  1
+  C  C9  1  0.76911256  0.19232042  0.80235535  1
+  C  C10  1  0.43441216  0.03175832  0.47289832  1
+  C  C11  1  0.89266248  1.00209148  0.17999782  1
+  C  C12  1  0.13062699  0.47745063  0.69147118  1
+  C  C13  1  0.36924708  0.48999196  0.20296986  1
+  C  C14  1  -0.00147926  0.80660575  0.57313793  1
+  C  C15  1  0.32851453  0.21515697  0.08841015  1
+",-154.324081875
+4251,C-106844-7188-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.95485000
+_cell_length_b   4.92553000
+_cell_length_c   6.20170000
+_cell_angle_alpha   62.78816000
+_cell_angle_beta   97.92571000
+_cell_angle_gamma   86.54308000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   105.36184212
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.32022236  0.08497790  0.42655543  1
+  C  C1  1  0.73033229  0.47097444  0.30323218  1
+  C  C2  1  0.40589586  0.06690755  0.20135933  1
+  C  C3  1  0.28393019  0.81244252  0.63759647  1
+  C  C4  1  0.19594071  0.84257590  0.14402586  1
+  C  C5  1  0.66791320  0.05921899  0.75849366  1
+  C  C6  1  0.41139667  0.62642298  0.08496225  1
+  C  C7  1  0.57615414  0.24306308  0.51012158  1
+  C  C8  1  -0.02919036  0.26446755  0.25246987  1
+  C  C9  1  0.47571264  0.80946520  0.83659481  1
+  C  C10  1  0.94573012  0.70249308  0.34015162  1
+  C  C11  1  0.89462841  0.09851007  0.94006910  1
+  C  C12  1  0.77036813  0.04215348  0.18844044  1
+  C  C13  1  1.07192306  0.60951955  0.60721519  1
+  C  C14  1  1.02348271  0.39690896  0.83054046  1
+  C  C15  1  0.19647766  0.39199887  1.05741676  1
+",-154.081166875
+5393,C-142740-3180-53,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43369000
+_cell_length_b   4.22378000
+_cell_length_c   4.81578000
+_cell_angle_alpha   90.58188000
+_cell_angle_beta   75.34964000
+_cell_angle_gamma   106.71061000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.76642860
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.68283069  0.97993129  0.80804165  1
+  C  C1  1  0.76848979  0.67848073  0.33625066  1
+  C  C2  1  0.46599353  0.61242672  0.87078700  1
+  C  C3  1  0.82072318  0.50521095  0.05526792  1
+  C  C4  1  0.38174575  0.91413798  0.34320569  1
+  C  C5  1  0.32713755  0.08751673  0.62391216  1
+  C  C6  1  0.62481824  0.14053646  1.08363276  1
+  C  C7  1  0.52553837  0.45193463  0.59553235  1
+",-154.2268225
+798,C-157670-1845-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47339000
+_cell_length_b   5.45941000
+_cell_length_c   4.23367000
+_cell_angle_alpha   89.98466000
+_cell_angle_beta   90.00090000
+_cell_angle_gamma   90.01113000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.16830172
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.73001511  0.14763524  0.93088300  1
+  C  C1  1  0.22984591  1.04325768  0.77347532  1
+  C  C2  1  0.23037927  0.78135525  0.90994580  1
+  C  C3  1  0.23015547  1.12785340  0.43399700  1
+  C  C4  1  0.73040906  0.52089564  0.26233513  1
+  C  C5  1  0.73059060  0.78129701  0.13164891  1
+  C  C6  1  -0.26982403  0.04144302  0.26230160  1
+  C  C7  1  0.23029203  0.43340848  0.43378407  1
+  C  C8  1  0.73011215  0.41533404  0.93075984  1
+  C  C9  1  1.23010114  0.51939573  0.77314943  1
+",-154.354296
+3285,C-40114-7976-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46348000
+_cell_length_b   3.39092000
+_cell_length_c   5.83215000
+_cell_angle_alpha   78.35897000
+_cell_angle_beta   64.97993000
+_cell_angle_gamma   68.60285000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.03887223
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63976586  0.87686192  0.79907124  1
+  C  C1  1  0.41272311  0.13405206  0.39797853  1
+  C  C2  1  0.17164267  0.06418198  0.67342033  1
+  C  C3  1  0.02234600  1.16836084  0.27187123  1
+  C  C4  1  0.79445966  0.42436410  0.87094144  1
+  C  C5  1  0.26316470  0.23776950  -0.00351987  1
+",-154.16127133333333
+7426,C-53828-4519-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.33615000
+_cell_length_b   5.54378000
+_cell_length_c   5.80505000
+_cell_angle_alpha   54.96906000
+_cell_angle_beta   56.85250000
+_cell_angle_gamma   80.67216000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   71.78064914
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.75647305  0.08254736  0.30307743  1
+  C  C1  1  0.19380185  0.73836509  0.25877547  1
+  C  C2  1  0.73892594  0.76790486  0.47113138  1
+  C  C3  1  0.37427269  0.21058188  0.43266525  1
+  C  C4  1  0.21899306  0.24958840  -0.01156557  1
+  C  C5  1  0.31197217  0.56296989  0.78807432  1
+  C  C6  1  0.94698441  0.00561461  0.74930745  1
+  C  C7  1  0.49109450  1.03457932  -0.03915173  1
+  C  C8  1  0.46692375  0.52379039  0.23193812  1
+  C  C9  1  -0.07015982  0.69103910  0.91761698  1
+",-154.234531
+8202,C-92111-7590-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45251000
+_cell_length_b   4.59199000
+_cell_length_c   5.89783000
+_cell_angle_alpha   88.72761000
+_cell_angle_beta   114.59591000
+_cell_angle_gamma   105.49168000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.89922220
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53142435  0.02201081  0.55028149  1
+  C  C1  1  0.50506968  0.30040051  0.88425486  1
+  C  C2  1  0.36247370  0.94892212  0.91776137  1
+  C  C3  1  0.85192908  0.52048304  0.12083102  1
+  C  C4  1  0.78629402  0.54476296  0.54246346  1
+  C  C5  1  0.03561217  0.85708494  0.63559343  1
+  C  C6  1  0.30598062  1.09093904  0.29067508  1
+  C  C7  1  0.96599995  0.86345454  0.06425060  1
+  C  C8  1  0.84680063  0.31746950  0.71804036  1
+  C  C9  1  0.45863911  0.42997253  0.27174533  1
+",-154.20675599999998
+6840,C-47616-513-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42663000
+_cell_length_b   6.32030000
+_cell_length_c   5.63122000
+_cell_angle_alpha   84.09625000
+_cell_angle_beta   78.01728000
+_cell_angle_gamma   101.31504000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   81.90866300
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.88316672  0.22811536  0.75888870  1
+  C  C1  1  0.53452557  0.05951495  0.30493106  1
+  C  C2  1  -0.04067583  0.94536841  0.33451477  1
+  C  C3  1  0.60248199  0.77381236  -0.12224673  1
+  C  C4  1  0.20927748  0.61475438  0.49864775  1
+  C  C5  1  0.01371766  0.46928277  0.74625563  1
+  C  C6  1  0.28544304  0.38835134  0.13554479  1
+  C  C7  1  0.47632446  0.53327318  0.88846452  1
+  C  C8  1  0.69751880  0.28268458  0.20599352  1
+  C  C9  1  0.16784175  0.88555489  0.85486369  1
+  C  C10  1  0.79750688  0.72137771  0.42936385  1
+  C  C11  1  0.31518208  0.11625297  0.78553706  1
+",-154.22918583333333
+748,C-184031-5230-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48170000
+_cell_length_b   3.68855000
+_cell_length_c   4.89838000
+_cell_angle_alpha   66.79216000
+_cell_angle_beta   59.55959000
+_cell_angle_gamma   70.31053000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99298617
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87075558  0.13565337  0.39929192  1
+  C  C1  1  0.88669733  0.68953849  0.60639879  1
+  C  C2  1  0.20269358  0.20234853  1.03465482  1
+  C  C3  1  0.91137670  1.04579256  0.90392313  1
+  C  C4  1  0.16142409  0.29276959  0.52981206  1
+  C  C5  1  0.18638842  0.64857995  0.82785857  1
+",-154.3120585
+7412,C-142773-2815-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52284000
+_cell_length_b   4.45469000
+_cell_length_c   4.30627000
+_cell_angle_alpha   76.90953000
+_cell_angle_beta   85.37933000
+_cell_angle_gamma   97.55614000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.42280157
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.21052360  1.01662025  1.05206818  1
+  C  C1  1  1.15161419  0.32431933  0.53887536  1
+  C  C2  1  0.69045677  0.44514953  0.33894764  1
+  C  C3  1  0.28025917  0.47773620  0.81984991  1
+  C  C4  1  0.63992299  0.78601745  0.30841635  1
+  C  C5  1  0.45247625  0.81731320  0.64182437  1
+  C  C6  1  -0.02317388  0.98447113  0.71885037  1
+  C  C7  1  0.74151961  0.35727832  0.02028721  1
+",-154.09689125
+4946,C-126181-8319-55,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48184000
+_cell_length_b   4.21855000
+_cell_length_c   3.68882000
+_cell_angle_alpha   104.91916000
+_cell_angle_beta   109.64218000
+_cell_angle_gamma   89.94590000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99175629
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.66631774  0.76634843  0.35839449  1
+  C  C1  1  0.46770043  0.84241602  0.96111169  1
+  C  C2  1  0.92583026  0.33779037  0.87247886  1
+  C  C3  1  0.34764189  0.46859341  0.71583748  1
+  C  C4  1  0.14606382  0.54396823  0.31796073  1
+  C  C5  1  0.88893626  -0.02714966  0.80372335  1
+",-154.31122366666668
+1317,C-53820-5674-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.21954000
+_cell_length_b   2.48124000
+_cell_length_c   4.83901000
+_cell_angle_alpha   104.90991000
+_cell_angle_beta   132.55213000
+_cell_angle_gamma   89.96286000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.97920522
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.12967858  0.58026004  0.20730685  1
+  C  C1  1  0.47371318  0.90095233  0.84931489  1
+  C  C2  1  0.71316444  0.12547979  0.29530750  1
+  C  C3  1  0.41708527  0.15864897  0.36409623  1
+  C  C4  1  0.00068202  0.70396201  0.45184683  1
+  C  C5  1  0.65618391  0.38120705  0.80988241  1
+",-154.30950833333333
+3194,C-193926-6320-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46729000
+_cell_length_b   4.17269000
+_cell_length_c   8.51892000
+_cell_angle_alpha   90.48152000
+_cell_angle_beta   74.44364000
+_cell_angle_gamma   90.03723000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   84.48833214
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.22232408  0.17857248  0.62895704  1
+  C  C1  1  0.71481555  0.12318798  -0.04176282  1
+  C  C2  1  0.63265823  0.86151335  0.28028050  1
+  C  C3  1  -0.27791447  1.01319348  0.62930822  1
+  C  C4  1  0.71866213  0.67863047  0.63354755  1
+  C  C5  1  0.21675117  0.12312521  -0.04239028  1
+  C  C6  1  0.13159080  0.36192498  0.28178112  1
+  C  C7  1  0.63016138  0.19584844  0.28338570  1
+  C  C8  1  0.21863156  0.51352598  0.63351858  1
+  C  C9  1  0.13363407  0.69552564  0.27915759  1
+",-154.186352
+9661,C-141057-8821-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.37095000
+_cell_length_b   4.29858000
+_cell_length_c   5.13212000
+_cell_angle_alpha   65.18554000
+_cell_angle_beta   93.78123000
+_cell_angle_gamma   89.88974000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   67.31693820
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.07674779  0.62932237  0.22154776  1
+  C  C1  1  0.03514697  0.33007819  0.49021510  1
+  C  C2  1  1.03582483  0.01576483  0.49020381  1
+  C  C3  1  0.73265071  0.75519057  -0.02724471  1
+  C  C4  1  0.07709328  0.98480183  0.22177688  1
+  C  C5  1  0.34933398  0.23679535  0.00897283  1
+  C  C6  1  0.34957343  0.58998799  1.00894838  1
+  C  C7  1  0.00293062  0.36076710  0.75911772  1
+  C  C8  1  0.73280016  0.10799684  -0.02715080  1
+  C  C9  1  0.00334282  0.71627032  0.75917903  1
+",-154.072665
+5232,C-9603-8567-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48278000
+_cell_length_b   5.22956000
+_cell_length_c   6.35693000
+_cell_angle_alpha   102.40400000
+_cell_angle_beta   106.41871000
+_cell_angle_gamma   110.85311000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   69.25388847
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17532616  0.94843336  0.85825299  1
+  C  C1  1  0.65255731  0.39805748  0.91666196  1
+  C  C2  1  0.25892370  0.68479873  0.53176368  1
+  C  C3  1  0.21102365  0.12707740  0.69567147  1
+  C  C4  1  1.47119200  0.76125735  0.80076656  1
+  C  C5  1  0.27632610  0.24778445  0.22410996  1
+  C  C6  1  0.58113013  0.77442621  0.21593812  1
+  C  C7  1  0.57472694  0.57102867  0.38621869  1
+  C  C8  1  0.26034463  0.97412435  0.30028874  1
+  C  C9  1  0.32746574  0.58103430  0.95450611  1
+  C  C10  1  0.62919415  0.21441869  0.07446725  1
+  C  C11  1  0.52131249  0.01944400  0.55412989  1
+",-154.16742333333335
+8816,C-148252-2749-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47378000
+_cell_length_b   3.28894000
+_cell_length_c   6.08802000
+_cell_angle_alpha   89.98010000
+_cell_angle_beta   89.98894000
+_cell_angle_gamma   67.86297000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.88152380
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.66213692  1.02930215  0.44764694  1
+  C  C1  1  0.16182807  1.02954810  0.58660349  1
+  C  C2  1  1.16187774  0.02949470  0.94765074  1
+  C  C3  1  0.84337946  0.66773688  0.26720259  1
+  C  C4  1  0.48157074  0.39037684  0.26714244  1
+  C  C5  1  0.66204293  1.02943077  0.08659040  1
+  C  C6  1  0.98070461  0.39066006  -0.23282774  1
+  C  C7  1  0.34249474  0.66802922  0.76724704  1
+",-154.33348875
+1659,C-40089-3949-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.24840000
+_cell_length_b   3.64028000
+_cell_length_c   3.30104000
+_cell_angle_alpha   86.50706000
+_cell_angle_beta   101.66608000
+_cell_angle_gamma   118.52963000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.88832651
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.08125696  0.59674416  0.19273528  1
+  C  C1  1  0.58200559  1.03792299  0.69108694  1
+  C  C2  1  0.58169133  0.65728681  0.69139268  1
+  C  C3  1  0.27424503  0.38331211  0.38530751  1
+  C  C4  1  0.27478085  1.00318412  0.38537773  1
+  C  C5  1  0.77519785  0.44434161  0.88379335  1
+",-154.1434755
+8315,C-13694-2590-56,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43058000
+_cell_length_b   4.79974000
+_cell_length_c   5.89136000
+_cell_angle_alpha   103.19396000
+_cell_angle_beta   74.33778000
+_cell_angle_gamma   70.30028000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.31278847
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.73845659  -0.03615955  0.03400321  1
+  C  C1  1  0.73983593  0.29622291  0.69963500  1
+  C  C2  1  0.23946908  0.71282634  0.28344069  1
+  C  C3  1  0.23864716  0.21361055  0.78396590  1
+  C  C4  1  1.23963970  0.04668800  -0.04993612  1
+  C  C5  1  -0.26087246  0.46287884  0.53333373  1
+  C  C6  1  0.24066452  0.54543744  0.44922897  1
+  C  C7  1  0.74005007  0.79608228  0.19952523  1
+",-154.45724625
+10061,C-126187-3348-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44138000
+_cell_length_b   4.61492000
+_cell_length_c   6.33230000
+_cell_angle_alpha   93.93759000
+_cell_angle_beta   90.50940000
+_cell_angle_gamma   105.30357000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   68.62527831
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.22553405  0.56055431  0.32158699  1
+  C  C1  1  0.12442657  0.35123528  0.50227876  1
+  C  C2  1  1.19825426  0.47273098  0.10654761  1
+  C  C3  1  0.29985989  0.68191562  0.92450711  1
+  C  C4  1  0.66768575  0.43177988  0.62317939  1
+  C  C5  1  0.95787541  0.02403256  0.43329611  1
+  C  C6  1  0.03872831  0.15505688  0.02676552  1
+  C  C7  1  0.38370235  0.87845362  0.39816792  1
+  C  C8  1  0.75753683  0.60188082  0.80326445  1
+  C  C9  1  0.46477987  1.00970454  0.99080763  1
+",-154.072658
+9525,C-170340-7457-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42947000
+_cell_length_b   5.77943000
+_cell_length_c   6.21516000
+_cell_angle_alpha   121.86016000
+_cell_angle_beta   89.43805000
+_cell_angle_gamma   103.34352000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   71.45258912
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53174951  1.09595763  0.51717867  1
+  C  C1  1  0.79288582  0.62671867  0.58313131  1
+  C  C2  1  0.13083164  0.29570302  0.91716247  1
+  C  C3  1  0.19523349  0.42733657  0.18333255  1
+  C  C4  1  0.32673986  0.69483655  0.71700022  1
+  C  C5  1  0.72787210  0.49495680  0.31695372  1
+  C  C6  1  0.59771347  1.22783801  0.78337792  1
+  C  C7  1  0.39378923  0.82675367  -0.01677512  1
+  C  C8  1  -0.00308040  0.02746542  0.38337482  1
+  C  C9  1  0.92924519  0.89546616  0.11718057  1
+",-154.464124
+7977,C-172933-8739-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42982000
+_cell_length_b   2.42993000
+_cell_length_c   8.41657000
+_cell_angle_alpha   88.80818000
+_cell_angle_beta   90.31236000
+_cell_angle_gamma   59.98902000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.01488529
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.18390490  0.28483031  0.79595679  1
+  C  C1  1  0.79974384  -0.02422789  0.46524580  1
+  C  C2  1  0.05580917  0.31133496  0.13573999  1
+  C  C3  1  0.46581429  0.64251501  0.46415252  1
+  C  C4  1  0.38891692  0.64483304  0.13667145  1
+  C  C5  1  0.85099068  0.95138347  0.79504665  1
+",-154.45627783333333
+1909,C-92128-7037-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48070000
+_cell_length_b   4.21841000
+_cell_length_c   3.68878000
+_cell_angle_alpha   75.18950000
+_cell_angle_beta   70.34261000
+_cell_angle_gamma   90.01249000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98633190
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64533381  1.03219751  0.70687661  1
+  C  C1  1  0.22353348  0.90120707  0.55018545  1
+  C  C2  1  0.44870303  0.10795301  0.10443244  1
+  C  C3  1  0.19187848  0.53614749  0.62053605  1
+  C  C4  1  0.96758598  0.32973047  1.06626919  1
+  C  C5  1  0.77015393  0.40508256  0.46385215  1
+",-154.30999383333332
+888,C-40138-885-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.22477000
+_cell_length_b   3.87331000
+_cell_length_c   4.56481000
+_cell_angle_alpha   84.72293000
+_cell_angle_beta   102.18808000
+_cell_angle_gamma   93.23530000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   72.65206626
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.96368200  0.14244866  0.10536402  1
+  C  C1  1  0.36461444  0.74620331  0.21413636  1
+  C  C2  1  -0.25376192  0.36203415  0.45894809  1
+  C  C3  1  0.72196009  0.38540141  -0.03143438  1
+  C  C4  1  0.17499837  0.93089426  0.65992140  1
+  C  C5  1  0.59628184  0.51865812  1.18443252  1
+  C  C6  1  0.37622320  0.73427266  0.53684034  1
+  C  C7  1  0.16312649  0.94341692  -0.01843058  1
+  C  C8  1  0.61580946  0.48802333  0.67501608  1
+  C  C9  1  0.97664063  1.13321698  0.42885615  1
+",-154.17302
+4914,C-57115-1468-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46288000
+_cell_length_b   4.24784000
+_cell_length_c   4.24871000
+_cell_angle_alpha   100.42320000
+_cell_angle_beta   89.99759000
+_cell_angle_gamma   90.00043000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.71616959
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.15958265  0.12187355  0.39736056  1
+  C  C1  1  0.65951545  0.28555992  0.56124377  1
+  C  C2  1  -0.20962555  0.28367677  -0.07446353  1
+  C  C3  1  0.40961853  0.77223207  0.91069081  1
+  C  C4  1  1.03213752  0.75830448  0.39936053  1
+  C  C5  1  0.53215642  0.64965576  0.55895746  1
+  C  C6  1  0.29037697  0.12421199  0.03306939  1
+  C  C7  1  0.90965130  0.63612637  0.04756172  1
+",-154.2351075
+5814,C-53810-7621-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45711000
+_cell_length_b   3.39262000
+_cell_length_c   5.33105000
+_cell_angle_alpha   97.63709000
+_cell_angle_beta   89.99188000
+_cell_angle_gamma   69.17331000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.11380930
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.48919530  0.02028702  0.18449609  1
+  C  C1  1  0.05872446  -0.11760761  0.50540738  1
+  C  C2  1  0.52389769  0.96018351  0.90850576  1
+  C  C3  1  0.89027743  0.22015053  0.31255672  1
+  C  C4  1  1.03251588  0.94268594  0.78170005  1
+  C  C5  1  0.65773964  0.68081641  0.37835930  1
+",-154.14201116666666
+8807,C-80191-3962-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48649000
+_cell_length_b   5.31213000
+_cell_length_c   4.76214000
+_cell_angle_alpha   87.89039000
+_cell_angle_beta   121.52350000
+_cell_angle_gamma   117.88354000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.55684627
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53331717  0.39173077  0.07551825  1
+  C  C1  1  0.09929232  0.92481805  0.10768224  1
+  C  C2  1  0.79431571  0.69452426  0.53391133  1
+  C  C3  1  1.07412571  0.69954585  0.30858415  1
+  C  C4  1  0.37904289  0.92995638  0.88231435  1
+  C  C5  1  0.45585871  0.34746808  0.54198086  1
+  C  C6  1  0.64008420  0.23290970  0.34080625  1
+  C  C7  1  0.71780608  0.27724581  0.87442478  1
+",-154.36591875
+8692,C-193948-359-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.51831000
+_cell_length_b   3.51694000
+_cell_length_c   3.32038000
+_cell_angle_alpha   90.00289000
+_cell_angle_beta   90.00990000
+_cell_angle_gamma   59.96060000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.56681003
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.21406442  0.65677282  0.73546844  1
+  C  C1  1  0.67831847  0.42488925  0.56989896  1
+  C  C2  1  0.67846009  0.12093074  0.23540571  1
+  C  C3  1  0.21417365  0.35288744  0.06993474  1
+  C  C4  1  0.91046538  0.65675347  0.40306694  1
+  C  C5  1  -0.01802711  0.12103239  0.90306521  1
+",-154.41130266666667
+3682,C-170908-5383-54,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50374000
+_cell_length_b   6.72780000
+_cell_length_c   6.60733000
+_cell_angle_alpha   120.15164000
+_cell_angle_beta   79.08182000
+_cell_angle_gamma   89.99908000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   93.90210840
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.59570443  0.27581905  0.15212040  1
+  C  C1  1  0.82171143  0.97869667  0.69214628  1
+  C  C2  1  0.22012044  0.79902088  0.89424238  1
+  C  C3  1  0.97491397  0.09893827  0.38465939  1
+  C  C4  1  0.35276677  0.63698783  0.63602371  1
+  C  C5  1  0.55125893  1.07992892  0.23241450  1
+  C  C6  1  0.05259584  0.65109101  0.23139800  1
+  C  C7  1  0.30430190  0.88132556  0.72672237  1
+  C  C8  1  0.90376634  0.50702608  0.53307790  1
+  C  C9  1  -0.13158999  0.33032830  0.60458552  1
+  C  C10  1  0.95256082  0.90751708  0.43566725  1
+  C  C11  1  0.65312668  0.82836612  0.02781499  1
+  C  C12  1  0.62817278  0.62996006  0.07957991  1
+  C  C13  1  0.72088647  0.21907513  0.89329900  1
+  C  C14  1  1.03697262  0.42990672  0.26929795  1
+  C  C15  1  0.74410029  0.39473063  0.84684615  1
+",-154.110475
+1582,C-152589-5332-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48471000
+_cell_length_b   5.48679000
+_cell_length_c   4.59927000
+_cell_angle_alpha   69.48092000
+_cell_angle_beta   105.66378000
+_cell_angle_gamma   89.97879000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.22856582
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.38677624  0.63707480  1.01224309  1
+  C  C1  1  0.41300443  0.35167451  0.06110070  1
+  C  C2  1  1.12865379  0.39688845  0.49429227  1
+  C  C3  1  0.29769923  0.20742811  0.83060586  1
+  C  C4  1  0.57889827  0.57176230  0.39546950  1
+  C  C5  1  0.03912850  0.96880394  0.31232220  1
+  C  C6  1  0.84825069  0.03318533  -0.07005603  1
+  C  C7  1  1.01541409  0.25334306  0.26381818  1
+  C  C8  1  -0.19533789  0.78498774  -0.15215295  1
+  C  C9  1  0.62104524  0.82113685  0.47676469  1
+",-154.383126
+2499,C-170892-2455-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51055000
+_cell_length_b   4.29737000
+_cell_length_c   6.39776000
+_cell_angle_alpha   81.31823000
+_cell_angle_beta   86.62731000
+_cell_angle_gamma   92.99404000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.98411429
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.73197732  0.37418824  0.65847003  1
+  C  C1  1  0.67935071  1.02328758  0.34674214  1
+  C  C2  1  0.70417238  0.05481846  0.58480955  1
+  C  C3  1  0.21190209  0.16965891  0.22985208  1
+  C  C4  1  0.25543252  0.56644600  0.58664686  1
+  C  C5  1  0.63269438  0.62509242  -0.01218053  1
+  C  C6  1  0.69741373  0.31722277  0.89963879  1
+  C  C7  1  0.42853734  0.51272616  0.21077901  1
+  C  C8  1  0.15473939  0.81714629  0.91726142  1
+  C  C9  1  0.18769014  0.13735518  0.99040702  1
+  C  C10  1  0.46316436  0.68080362  0.36367388  1
+  C  C11  1  0.19445275  0.87417187  0.67529936  1
+",-154.2156575
+9657,C-189726-6424-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42658000
+_cell_length_b   4.22805000
+_cell_length_c   4.22975000
+_cell_angle_alpha   93.42835000
+_cell_angle_beta   89.92375000
+_cell_angle_gamma   89.88849000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.31818202
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.42108714  0.18655847  0.81756739  1
+  C  C1  1  0.42181796  0.53660347  -0.12110420  1
+  C  C2  1  0.92174745  0.67949330  0.73587302  1
+  C  C3  1  0.42243915  0.59819983  0.22886684  1
+  C  C4  1  0.92222616  0.61867455  0.38609203  1
+  C  C5  1  -0.07864337  0.02937767  0.79672302  1
+",-154.29878366666665
+5741,C-28236-2280-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42775000
+_cell_length_b   3.77587000
+_cell_length_c   6.06319000
+_cell_angle_alpha   87.58156000
+_cell_angle_beta   103.42251000
+_cell_angle_gamma   126.06089000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.38710525
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.89777946  0.33686141  0.66907636  1
+  C  C1  1  0.56368349  0.44658221  0.78079772  1
+  C  C2  1  0.56340653  0.77964698  0.11406521  1
+  C  C3  1  0.56353395  0.11310931  0.44743242  1
+  C  C4  1  0.89761450  0.67003748  1.00241044  1
+  C  C5  1  -0.10253932  0.00323591  0.33567864  1
+",-154.45609683333333
+9668,C-136223-1797-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.61043000
+_cell_length_b   3.67774000
+_cell_length_c   4.65041000
+_cell_angle_alpha   113.30212000
+_cell_angle_beta   105.46111000
+_cell_angle_gamma   89.99387000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.23970800
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.43178201  -0.01314017  0.44095005  1
+  C  C1  1  0.26299867  0.32545700  0.11797996  1
+  C  C2  1  0.26325879  0.95108127  0.11832596  1
+  C  C3  1  0.43167226  0.61209175  0.44101872  1
+  C  C4  1  0.14836116  0.52264662  0.88617019  1
+  C  C5  1  0.54896822  0.41623913  0.67397092  1
+",-154.0923395
+6587,C-106859-2905-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47383000
+_cell_length_b   4.94545000
+_cell_length_c   4.11744000
+_cell_angle_alpha   89.99058000
+_cell_angle_beta   89.95936000
+_cell_angle_gamma   59.97090000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.61200319
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.10601252  0.82728884  0.24122489  1
+  C  C1  1  0.10606577  0.32720818  0.61619287  1
+  C  C2  1  0.10601252  0.32728884  0.24122489  1
+  C  C3  1  1.10606577  0.82720818  0.61619287  1
+  C  C4  1  0.77257827  0.66057114  0.74122654  1
+  C  C5  1  0.77275610  1.16061884  0.11619856  1
+  C  C6  1  0.77275610  0.66061884  0.11619856  1
+  C  C7  1  0.77257827  0.16057114  0.74122654  1
+",-154.51912875
+1692,C-170882-2973-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.75687000
+_cell_length_b   4.41751000
+_cell_length_c   6.27448000
+_cell_angle_alpha   83.84126000
+_cell_angle_beta   117.87113000
+_cell_angle_gamma   93.86382000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   115.85964026
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.77414763  0.36457000  0.43975067  1
+  C  C1  1  0.39445150  0.77212314  0.82087257  1
+  C  C2  1  0.64747062  0.16231300  0.56222191  1
+  C  C3  1  0.39441804  0.10342958  0.82136830  1
+  C  C4  1  0.00987143  0.59502226  0.21624598  1
+  C  C5  1  -0.08294078  0.81087033  0.30617592  1
+  C  C6  1  0.64808735  0.83312166  0.56669765  1
+  C  C7  1  0.27164147  0.57140775  0.95040303  1
+  C  C8  1  0.92390926  0.32568223  0.29208908  1
+  C  C9  1  0.27093804  0.24209412  0.95358650  1
+  C  C10  1  0.52129790  0.63360390  0.69350261  1
+  C  C11  1  0.77262871  0.68691013  0.44627507  1
+  C  C12  1  0.99762623  0.07917786  0.22478787  1
+  C  C13  1  1.14900134  1.03939250  1.07890138  1
+  C  C14  1  0.15220115  0.71776614  0.07427956  1
+  C  C15  1  0.52115221  0.30258359  0.69232649  1
+",-154.23375625
+1449,C-189722-5605-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50259000
+_cell_length_b   5.06301000
+_cell_length_c   7.28937000
+_cell_angle_alpha   94.89178000
+_cell_angle_beta   84.22492000
+_cell_angle_gamma   114.48952000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   83.52846172
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.37373388  0.26536609  0.84299072  1
+  C  C1  1  0.74402585  0.95178792  0.59044412  1
+  C  C2  1  -0.10799659  0.51825027  0.31074747  1
+  C  C3  1  -0.03558020  0.11381234  0.41686259  1
+  C  C4  1  0.43961804  0.04753514  0.29259685  1
+  C  C5  1  0.61761802  0.70310622  0.07296795  1
+  C  C6  1  0.64192449  0.78918823  0.88435773  1
+  C  C7  1  0.49046519  0.64535696  0.58894343  1
+  C  C8  1  0.30336944  0.45895335  0.42245018  1
+  C  C9  1  0.34657521  0.35519775  1.05094790  1
+  C  C10  1  0.15492838  0.76787134  0.19227167  1
+  C  C11  1  0.76773035  0.06980848  0.78989761  1
+  C  C12  1  0.73803946  0.28477274  0.15962116  1
+  C  C13  1  0.52895569  0.55531446  0.76132633  1
+",-154.0839692857143
+494,C-80186-3462-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.75362000
+_cell_length_b   6.46589000
+_cell_length_c   4.06323000
+_cell_angle_alpha   113.48719000
+_cell_angle_beta   101.84040000
+_cell_angle_gamma   118.33418000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   87.97184015
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.62755805  0.13031992  0.75381957  1
+  C  C1  1  0.30689972  0.30929668  0.11684050  1
+  C  C2  1  0.45150147  0.79923344  0.09505069  1
+  C  C3  1  0.19279090  0.43377888  0.36265214  1
+  C  C4  1  0.83943283  0.34243579  0.17894121  1
+  C  C5  1  0.66925277  0.43403003  0.36431207  1
+  C  C6  1  0.79181412  0.63967041  0.77490366  1
+  C  C7  1  0.48225585  0.63910327  0.77551996  1
+  C  C8  1  0.74122313  0.00537229  0.50794521  1
+  C  C9  1  1.14203419  0.79892762  0.09542413  1
+  C  C10  1  0.09470780  0.09654226  0.69130927  1
+  C  C11  1  0.26471787  0.00457523  0.50626648  1
+",-154.29029166666666
+1503,C-92140-8673-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45792000
+_cell_length_b   6.33835000
+_cell_length_c   7.07335000
+_cell_angle_alpha   118.03777000
+_cell_angle_beta   76.72956000
+_cell_angle_gamma   97.09270000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   94.65114581
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.73725059  0.62933527  0.57782592  1
+  C  C1  1  0.48342044  0.52873306  0.22135335  1
+  C  C2  1  0.02694374  0.40117898  0.11983061  1
+  C  C3  1  0.33032003  0.66451684  0.47097581  1
+  C  C4  1  0.70406851  0.08476205  0.81452801  1
+  C  C5  1  0.39758681  0.90712131  0.47051254  1
+  C  C6  1  0.59403893  0.38975249  0.57114911  1
+  C  C7  1  0.68360832  0.83030134  0.81508648  1
+  C  C8  1  -0.11564422  0.04913379  0.57740035  1
+  C  C9  1  0.12293708  0.81912729  0.92801066  1
+  C  C10  1  0.49259297  0.79111549  0.22080158  1
+  C  C11  1  1.04046524  0.28253219  0.57135138  1
+  C  C12  1  0.15051659  1.20873806  -0.07261366  1
+  C  C13  1  1.05173147  0.81689014  0.11951804  1
+",-154.20229642857143
+3468,C-141037-8469-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44660000
+_cell_length_b   3.64381000
+_cell_length_c   9.11359000
+_cell_angle_alpha   106.03768000
+_cell_angle_beta   66.26316000
+_cell_angle_gamma   109.59495000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   69.12023988
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46196415  0.97285056  0.91644985  1
+  C  C1  1  0.67422491  0.14972057  0.16704007  1
+  C  C2  1  0.62457931  0.40956427  0.95422373  1
+  C  C3  1  0.15995405  0.92412563  0.10149878  1
+  C  C4  1  1.13914134  0.60692845  0.67481960  1
+  C  C5  1  0.99941863  0.48739546  0.06326643  1
+  C  C6  1  0.47548801  0.28841938  0.34375966  1
+  C  C7  1  0.72057205  0.52940361  0.59446417  1
+  C  C8  1  0.94764281  0.74756851  0.85104252  1
+  C  C9  1  -0.10781137  0.36361566  0.42419701  1
+",-154.290985
+6369,C-13661-7792-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.58098000
+_cell_length_b   4.64230000
+_cell_length_c   5.51531000
+_cell_angle_alpha   78.21958000
+_cell_angle_beta   131.92485000
+_cell_angle_gamma   101.27929000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.97223412
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.60267847  0.19687454  0.15612152  1
+  C  C1  1  0.52168407  0.41075642  0.67886825  1
+  C  C2  1  0.96822784  0.47335603  0.31158703  1
+  C  C3  1  0.60597133  -0.05687982  0.33260558  1
+  C  C4  1  0.88473810  0.94042443  0.65800490  1
+  C  C5  1  0.33919457  0.65738453  0.19291620  1
+  C  C6  1  -0.11353281  0.68693962  0.83444351  1
+  C  C7  1  0.15016903  0.22647615  0.79752471  1
+",-154.16430625
+5910,C-28224-863-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48744000
+_cell_length_b   3.60365000
+_cell_length_c   7.31265000
+_cell_angle_alpha   82.83676000
+_cell_angle_beta   99.80584000
+_cell_angle_gamma   110.20370000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   60.46364281
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64372848  0.79511148  0.30567900  1
+  C  C1  1  0.47618162  0.00070975  0.76653212  1
+  C  C2  1  0.90851007  0.62024327  0.00977160  1
+  C  C3  1  0.88692158  0.23472004  0.35117769  1
+  C  C4  1  0.04612407  0.01478287  0.89196632  1
+  C  C5  1  0.27733679  0.43075009  0.93540803  1
+  C  C6  1  1.01854344  0.63511040  0.21419272  1
+  C  C7  1  0.51344602  0.39256778  0.44355911  1
+  C  C8  1  0.24866168  0.58406305  0.72434367  1
+  C  C9  1  0.61841604  0.39736817  0.64930784  1
+",-154.20226
+3800,C-96694-8817-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42523000
+_cell_length_b   4.21466000
+_cell_length_c   4.86654000
+_cell_angle_alpha   89.87105000
+_cell_angle_beta   60.12963000
+_cell_angle_gamma   89.92283000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.13512917
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.69090874  0.06027097  0.89060830  1
+  C  C1  1  0.10030651  0.65123447  0.48116170  1
+  C  C2  1  0.10373510  0.56377734  0.97783676  1
+  C  C3  1  0.75653464  0.62334740  0.32524184  1
+  C  C4  1  0.75232474  0.71257113  0.82887064  1
+  C  C5  1  0.16143668  0.21605729  -0.08056244  1
+",-154.31018983333334
+6527,C-41273-2006-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47092000
+_cell_length_b   3.36553000
+_cell_length_c   5.96772000
+_cell_angle_alpha   69.37900000
+_cell_angle_beta   101.91056000
+_cell_angle_gamma   68.45786000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.86181222
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.18965425  0.55396464  0.86158353  1
+  C  C1  1  0.53887966  0.73666593  0.74096589  1
+  C  C2  1  0.22033411  0.09593164  0.46743196  1
+  C  C3  1  1.21106092  0.90707662  0.25982826  1
+  C  C4  1  0.50382673  0.19842148  0.13547736  1
+  C  C5  1  0.51272422  0.38763070  0.34311111  1
+",-154.12446083333333
+5637,C-152591-5216-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42508000
+_cell_length_b   4.21971000
+_cell_length_c   4.22331000
+_cell_angle_alpha   91.46800000
+_cell_angle_beta   89.99643000
+_cell_angle_gamma   90.05204000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.20349616
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.75348741  0.85897827  0.10924594  1
+  C  C1  1  0.25348621  0.83458302  0.95260292  1
+  C  C2  1  0.75532119  0.26903886  0.51930765  1
+  C  C3  1  0.75512896  0.92032603  0.45813582  1
+  C  C4  1  0.25540940  0.42555021  0.54442357  1
+  C  C5  1  0.25475313  0.77422520  0.60423630  1
+",-154.30299666666667
+4611,C-56499-9815-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52742000
+_cell_length_b   4.71032000
+_cell_length_c   4.79306000
+_cell_angle_alpha   77.15867000
+_cell_angle_beta   63.21988000
+_cell_angle_gamma   101.77044000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.53636199
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.35242873  0.94150712  0.83508232  1
+  C  C1  1  0.43197082  0.27334976  0.13166648  1
+  C  C2  1  0.46712987  0.50004737  0.24327328  1
+  C  C3  1  1.29673953  0.95146367  0.32406330  1
+  C  C4  1  0.60268245  0.82174838  0.05085149  1
+  C  C5  1  0.54753323  0.83237673  0.53974246  1
+  C  C6  1  0.30942686  0.47409958  0.59649142  1
+  C  C7  1  0.59031911  0.30081659  0.77826044  1
+",-154.0702725
+5490,C-107771-927-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48513000
+_cell_length_b   4.84380000
+_cell_length_c   6.49637000
+_cell_angle_alpha   89.99660000
+_cell_angle_beta   90.00795000
+_cell_angle_gamma   120.86952000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.12192306
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53669764  0.24492157  0.36202663  1
+  C  C1  1  0.53655076  0.24461460  0.60060204  1
+  C  C2  1  0.53666680  0.74472101  0.39900656  1
+  C  C3  1  0.00986995  0.21734745  -0.07952907  1
+  C  C4  1  0.73287022  0.94072277  0.07555263  1
+  C  C5  1  0.00977897  0.71737209  0.07917504  1
+  C  C6  1  0.85918494  0.56745661  0.70298431  1
+  C  C7  1  0.85929986  0.06754218  0.29663057  1
+  C  C8  1  0.88496922  0.09279207  0.69350060  1
+  C  C9  1  0.88496683  0.59288511  0.30612745  1
+  C  C10  1  0.73292623  0.44069247  0.92408795  1
+  C  C11  1  0.53653898  0.74485036  0.63758948  1
+",-154.429
+7390,C-130546-1595-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44813000
+_cell_length_b   5.70664000
+_cell_length_c   5.57999000
+_cell_angle_alpha   117.56687000
+_cell_angle_beta   102.69657000
+_cell_angle_gamma   102.38084000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   62.75014050
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.25446268  0.50821725  0.50880939  1
+  C  C1  1  0.25550961  0.94918229  1.06865544  1
+  C  C2  1  1.09777635  0.07513738  0.62932111  1
+  C  C3  1  0.76143121  0.02381294  0.00377019  1
+  C  C4  1  0.76039396  0.58277908  0.44388009  1
+  C  C5  1  -0.27519886  0.14140964  -0.18226655  1
+  C  C6  1  0.91488666  0.45661543  -0.11724414  1
+  C  C7  1  0.20203958  0.74634734  0.16707126  1
+  C  C8  1  0.28743096  0.39025495  0.69434993  1
+  C  C9  1  0.81032545  0.78541049  0.34532588  1
+",-154.181017
+264,C-47664-5276-59,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43091000
+_cell_length_b   4.20485000
+_cell_length_c   5.88664000
+_cell_angle_alpha   104.70976000
+_cell_angle_beta   101.41257000
+_cell_angle_gamma   90.17262000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.95802380
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.45253682  -0.05666565  -0.11096794  1
+  C  C1  1  1.12361053  0.76875716  0.39356406  1
+  C  C2  1  0.12372120  0.10192450  0.39256034  1
+  C  C3  1  0.62359446  0.26878214  0.39354866  1
+  C  C4  1  0.95237265  0.11011219  -0.11007814  1
+  C  C5  1  0.95257891  0.44336253  0.88915292  1
+  C  C6  1  0.62372143  0.60194454  0.39257917  1
+  C  C7  1  0.45239619  0.61015859  0.89003483  1
+",-154.43614125
+8480,C-152607-7999-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49025000
+_cell_length_b   3.59479000
+_cell_length_c   4.34958000
+_cell_angle_alpha   84.28264000
+_cell_angle_beta   106.65279000
+_cell_angle_gamma   110.32707000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98094050
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.81111137  0.25363634  0.24881774  1
+  C  C1  1  0.62375553  0.25398595  0.87249013  1
+  C  C2  1  0.25396739  0.51371782  0.87268094  1
+  C  C3  1  0.72845860  -0.11685346  0.45448152  1
+  C  C4  1  0.44206676  0.51349972  0.24899528  1
+  C  C5  1  0.33563675  0.88301342  0.66700069  1
+",-154.19280433333333
+7153,C-126159-6870-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47819000
+_cell_length_b   2.47797000
+_cell_length_c   6.77951000
+_cell_angle_alpha   89.97904000
+_cell_angle_beta   111.43087000
+_cell_angle_gamma   120.02975000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.68011883
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.89808012  0.50611958  0.17289148  1
+  C  C1  1  0.78560490  -0.05143922  0.83862363  1
+  C  C2  1  0.33991805  0.22529670  0.75454450  1
+  C  C3  1  0.00460400  0.05760114  0.50360521  1
+  C  C4  1  1.12051545  1.11712181  0.08951275  1
+  C  C5  1  0.22636308  0.66903010  0.42014083  1
+",-154.53554283333332
+3640,C-40097-8776-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.54419000
+_cell_length_b   2.45850000
+_cell_length_c   6.23050000
+_cell_angle_alpha   78.97360000
+_cell_angle_beta   100.20535000
+_cell_angle_gamma   88.45186000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   37.57158796
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.42492266  0.62907192  0.56230416  1
+  C  C1  1  0.17598437  0.86721578  0.08372127  1
+  C  C2  1  0.60988606  0.94983417  0.92303098  1
+  C  C3  1  0.54634828  0.51562259  0.79189193  1
+  C  C4  1  0.36323323  0.18805514  0.44505561  1
+  C  C5  1  0.23994429  0.30081941  0.21519655  1
+",-154.1736005
+9474,C-141018-4458-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47353000
+_cell_length_b   4.23500000
+_cell_length_c   5.45917000
+_cell_angle_alpha   89.98827000
+_cell_angle_beta   89.99863000
+_cell_angle_gamma   90.00412000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.18698560
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.31361277  0.26752050  -0.13859414  1
+  C  C1  1  0.68643253  -0.07166862  0.46872256  1
+  C  C2  1  1.18637302  0.43927914  0.46747396  1
+  C  C3  1  0.68640529  0.79045470  0.20714095  1
+  C  C4  1  0.68669731  0.92788655  0.94561863  1
+  C  C5  1  1.18640336  0.77093158  0.57340771  1
+  C  C6  1  0.68638640  0.26781049  0.55432008  1
+  C  C7  1  0.18667679  0.77067932  0.84068440  1
+  C  C8  1  0.18635815  0.43913396  -0.05282861  1
+  C  C9  1  0.18628262  0.56928898  0.20721737  1
+",-154.358564
+3898,C-106873-5485-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.00736000
+_cell_length_b   4.00903000
+_cell_length_c   4.00791000
+_cell_angle_alpha   105.35742000
+_cell_angle_beta   117.97413000
+_cell_angle_gamma   105.47781000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.71142736
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20207419  0.68803635  0.30577894  1
+  C  C1  1  0.57255245  0.68805634  0.67619775  1
+  C  C2  1  0.70215038  0.98780525  0.10549763  1
+  C  C3  1  0.07263430  -0.01215286  0.47596784  1
+  C  C4  1  -0.12730997  0.28793263  -0.02400802  1
+  C  C5  1  0.37263295  -0.01190139  0.17623222  1
+  C  C6  1  0.50226246  0.28792885  0.60553247  1
+  C  C7  1  0.00221574  -0.01181397  0.80582007  1
+",-154.205035
+613,C-189724-308-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50106000
+_cell_length_b   4.25469000
+_cell_length_c   7.93305000
+_cell_angle_alpha   96.82171000
+_cell_angle_beta   77.33993000
+_cell_angle_gamma   87.40224000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   81.55980996
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87128479  0.07420736  0.98539577  1
+  C  C1  1  -0.02228193  0.55435025  0.80823839  1
+  C  C2  1  0.06583741  0.45247753  0.61509815  1
+  C  C3  1  0.56631632  0.62046100  0.55108423  1
+  C  C4  1  0.30865218  0.13842078  0.54463180  1
+  C  C5  1  0.86866783  0.44005875  0.98184682  1
+  C  C6  1  0.04370331  0.87976767  0.81570233  1
+  C  C7  1  1.15725358  0.13882952  0.26531864  1
+  C  C8  1  0.19139025  0.50982875  0.26518716  1
+  C  C9  1  0.30362661  0.59299513  0.07941968  1
+  C  C10  1  0.30083130  0.96760171  1.08095829  1
+  C  C11  1  0.58133623  1.02908780  0.35822536  1
+  C  C12  1  0.35497361  -0.07143068  0.65205447  1
+  C  C13  1  0.63354641  0.65959282  0.35786702  1
+",-154.1219135714286
+918,C-28236-2280-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42736000
+_cell_length_b   5.85119000
+_cell_length_c   5.46671000
+_cell_angle_alpha   106.24011000
+_cell_angle_beta   85.75002000
+_cell_angle_gamma   114.17866000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   67.93309624
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.73744721  0.97108742  0.28673472  1
+  C  C1  1  0.62735487  0.36059430  0.27232940  1
+  C  C2  1  0.85132679  0.55382493  0.11868377  1
+  C  C3  1  0.32546519  0.49711135  0.94153776  1
+  C  C4  1  0.00362980  0.24237662  0.30280939  1
+  C  C5  1  0.11020725  0.83706416  0.25210514  1
+  C  C6  1  1.06809761  0.21466676  0.80292434  1
+  C  C7  1  0.44048682  0.08046662  0.76812817  1
+  C  C8  1  0.17360092  0.81043943  0.75803076  1
+  C  C9  1  0.54943923  0.69249091  0.79017184  1
+",-154.188123
+2926,C-106837-6296-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48523000
+_cell_length_b   4.08722000
+_cell_length_c   4.67925000
+_cell_angle_alpha   83.31504000
+_cell_angle_beta   105.34444000
+_cell_angle_gamma   90.00802000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.50102775
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.23022747  0.39387605  0.13673355  1
+  C  C1  1  0.84888184  0.86271012  0.36545748  1
+  C  C2  1  0.06088157  0.32581605  0.79555768  1
+  C  C3  1  1.00389979  0.68128618  0.68025174  1
+  C  C4  1  0.73108640  0.62037288  0.13853970  1
+  C  C5  1  0.35020137  0.08747887  0.36781091  1
+  C  C6  1  0.51909874  0.15626551  0.70926642  1
+  C  C7  1  0.57486352  0.80039394  0.82377121  1
+",-154.36937875
+5934,C-136241-2721-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45189000
+_cell_length_b   3.33862000
+_cell_length_c   9.50582000
+_cell_angle_alpha   96.96188000
+_cell_angle_beta   97.27152000
+_cell_angle_gamma   111.84425000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   70.43879950
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.18894108  0.76006985  0.89269978  1
+  C  C1  1  -0.23576713  0.47318606  0.33520696  1
+  C  C2  1  -0.00896210  0.15301276  0.11768834  1
+  C  C3  1  0.28815912  1.07089630  0.77740823  1
+  C  C4  1  0.35694796  0.58523510  0.40575979  1
+  C  C5  1  0.83237412  0.97693612  0.96412086  1
+  C  C6  1  0.53620593  0.79608847  0.55252888  1
+  C  C7  1  0.93292566  0.28850188  0.84798346  1
+  C  C8  1  0.57968444  0.25835136  0.18857879  1
+  C  C9  1  0.12395661  0.89856000  0.62335150  1
+",-154.24801
+4657,C-73621-2756-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.40084000
+_cell_length_b   2.53223000
+_cell_length_c   8.38442000
+_cell_angle_alpha   87.68570000
+_cell_angle_beta   81.74541000
+_cell_angle_gamma   90.05085000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   50.40252363
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.08302059  0.03235048  0.24163912  1
+  C  C1  1  0.47452467  0.50285814  0.45773797  1
+  C  C2  1  1.03550708  0.51892408  0.33817093  1
+  C  C3  1  0.79874163  0.99755412  0.81351950  1
+  C  C4  1  0.71257584  1.02600577  0.98224947  1
+  C  C5  1  0.34162949  0.98524202  0.72937132  1
+  C  C6  1  0.42951297  -0.01033559  0.55399902  1
+  C  C7  1  0.17071503  0.03736918  0.06619658  1
+",-154.07178375
+3205,C-96686-8751-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48236000
+_cell_length_b   3.84389000
+_cell_length_c   4.49116000
+_cell_angle_alpha   90.02834000
+_cell_angle_beta   56.45718000
+_cell_angle_gamma   89.95244000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.71785719
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.80285308  1.06045615  0.22551504  1
+  C  C1  1  0.53540119  0.35496242  0.49308511  1
+  C  C2  1  0.53187753  1.06086766  -0.00335920  1
+  C  C3  1  0.79874936  0.35543437  0.72964198  1
+  C  C4  1  0.53624534  0.76544380  0.49245047  1
+  C  C5  1  0.79937371  0.76588230  0.72914490  1
+",-154.15833766666665
+7815,C-134183-9440-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.63544000
+_cell_length_b   3.62364000
+_cell_length_c   8.45580000
+_cell_angle_alpha   68.82381000
+_cell_angle_beta   67.17535000
+_cell_angle_gamma   63.12471000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   89.20967201
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70937081  0.15541508  0.70618228  1
+  C  C1  1  0.40171001  0.34483560  0.61032992  1
+  C  C2  1  0.20728911  0.15733742  0.20700716  1
+  C  C3  1  -0.09707193  0.65167972  0.45589341  1
+  C  C4  1  0.90034269  0.34564994  0.11065630  1
+  C  C5  1  0.40254636  0.65163379  0.95558147  1
+  C  C6  1  0.21173209  0.84273844  0.36034311  1
+  C  C7  1  0.71273628  -0.15883751  0.85953898  1
+  C  C8  1  1.02048137  0.34428301  0.61032251  1
+  C  C9  1  0.52158081  0.65203816  0.45554819  1
+  C  C10  1  0.02127232  0.65171902  -0.04467340  1
+  C  C11  1  0.51910828  0.34546362  0.11048566  1
+",-154.12929833333334
+9443,C-141037-8469-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47394000
+_cell_length_b   4.47176000
+_cell_length_c   4.92135000
+_cell_angle_alpha   53.53740000
+_cell_angle_beta   59.77004000
+_cell_angle_gamma   56.36600000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.19959821
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.65392597  0.24226861  0.73542001  1
+  C  C1  1  0.17375479  0.44544781  0.51255088  1
+  C  C2  1  0.21891733  0.39913923  1.01334358  1
+  C  C3  1  0.60839623  0.28838043  0.23464264  1
+  C  C4  1  0.76550894  0.85361590  0.51261360  1
+  C  C5  1  0.06203924  0.83407283  0.73528799  1
+",-154.29995383333332
+9583,C-176663-4376-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42593000
+_cell_length_b   5.47304000
+_cell_length_c   3.91534000
+_cell_angle_alpha   125.73876000
+_cell_angle_beta   92.25754000
+_cell_angle_gamma   99.42814000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.02897980
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.96887281  1.02742676  0.96290426  1
+  C  C1  1  -0.14239347  0.80314794  0.51940849  1
+  C  C2  1  0.19060254  0.46943147  0.85261123  1
+  C  C3  1  0.63547975  0.36104660  0.62946215  1
+  C  C4  1  0.52425044  0.13643785  0.18596686  1
+  C  C5  1  0.30238503  0.69455088  0.29620911  1
+",-154.38130583333333
+2891,C-57120-3338-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47402000
+_cell_length_b   4.11786000
+_cell_length_c   4.28052000
+_cell_angle_alpha   89.98313000
+_cell_angle_beta   90.00070000
+_cell_angle_gamma   89.98425000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.60851307
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.51530242  0.58215228  0.25714661  1
+  C  C1  1  0.01530242  0.58215228  0.75714661  1
+  C  C2  1  1.01534597  0.45706730  1.09051794  1
+  C  C3  1  0.01509064  0.95707440  0.75737918  1
+  C  C4  1  0.51502522  0.08215672  0.59074852  1
+  C  C5  1  0.51509064  0.95707440  0.25737918  1
+  C  C6  1  0.51534597  0.45706730  0.59051794  1
+  C  C7  1  1.01502522  0.08215672  0.09074852  1
+",-154.51910625
+2893,C-130536-5861-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48144000
+_cell_length_b   4.21921000
+_cell_length_c   3.68775000
+_cell_angle_alpha   75.04408000
+_cell_angle_beta   70.35576000
+_cell_angle_gamma   90.03051000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.96870567
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.51099469  0.29898565  1.05651327  1
+  C  C1  1  0.93289872  0.42971346  0.21285506  1
+  C  C2  1  -0.03637087  0.79451321  0.14542966  1
+  C  C3  1  0.70873238  0.22314312  0.65905677  1
+  C  C4  1  0.18781820  1.00108593  0.69941006  1
+  C  C5  1  0.38488559  0.92494112  0.30272758  1
+",-154.30956266666666
+2332,C-91032-4468-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.37865000
+_cell_length_b   6.09515000
+_cell_length_c   5.73788000
+_cell_angle_alpha   79.47992000
+_cell_angle_beta   103.64333000
+_cell_angle_gamma   86.05156000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   112.12067555
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.01178180  0.68501602  0.09207851  1
+  C  C1  1  0.24216805  0.94452665  0.88723925  1
+  C  C2  1  0.63941132  0.58299748  0.09712609  1
+  C  C3  1  0.61423793  1.04690873  0.88249604  1
+  C  C4  1  1.04045457  0.22422223  0.32508360  1
+  C  C5  1  0.40598049  0.36884741  0.44336628  1
+  C  C6  1  0.39635289  0.59969558  0.29384496  1
+  C  C7  1  0.82724279  0.85383123  0.52173659  1
+  C  C8  1  0.73283554  0.34942971  0.08792996  1
+  C  C9  1  0.18435611  0.66083911  0.64938314  1
+  C  C10  1  -0.02575838  -0.06904086  1.07854593  1
+  C  C11  1  0.85742884  0.02915609  0.68585283  1
+  C  C12  1  0.52117039  0.28093208  0.89055540  1
+  C  C13  1  0.06802045  0.96837967  0.33027889  1
+  C  C14  1  0.84799818  0.26006343  0.53702674  1
+  C  C15  1  0.21087778  0.40526100  0.65376944  1
+  C  C16  1  0.27896758  0.69794134  0.90165749  1
+  C  C17  1  0.42373057  0.77585509  0.45731767  1
+",-154.07192555555557
+1610,C-41318-6901-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47468000
+_cell_length_b   5.69654000
+_cell_length_c   6.69153000
+_cell_angle_alpha   117.63741000
+_cell_angle_beta   103.02123000
+_cell_angle_gamma   92.33310000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   80.25855715
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20548816  0.90497502  0.56886962  1
+  C  C1  1  0.37619965  0.86138909  0.75571142  1
+  C  C2  1  0.36465405  0.61890884  0.76306210  1
+  C  C3  1  0.56342330  0.00763438  0.18878787  1
+  C  C4  1  0.45841504  0.49781582  0.26867717  1
+  C  C5  1  0.92971798  0.60704967  0.89749461  1
+  C  C6  1  0.21484833  0.35532194  0.53914228  1
+  C  C7  1  0.10270300  0.25741638  0.02689361  1
+  C  C8  1  0.53883557  0.08354447  0.99550220  1
+  C  C9  1  0.62406766  0.31153759  0.39374041  1
+  C  C10  1  0.90062644  0.31465443  0.83008673  1
+  C  C11  1  0.03566351  0.82902820  0.15939147  1
+  C  C12  1  0.28430543  0.19665001  0.66911251  1
+  C  C13  1  1.04166726  0.68858138  0.32095733  1
+",-154.1298657142857
+9756,C-184058-8674-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52341000
+_cell_length_b   4.66534000
+_cell_length_c   4.96834000
+_cell_angle_alpha   83.90176000
+_cell_angle_beta   89.95328000
+_cell_angle_gamma   89.96928000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.15909997
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.97921582  0.75078583  0.84380941  1
+  C  C1  1  0.48043742  0.59291748  0.26383964  1
+  C  C2  1  0.48168113  0.26899266  0.24138405  1
+  C  C3  1  0.97976180  0.92154566  0.56045737  1
+  C  C4  1  -0.02058255  0.64409144  0.42560579  1
+  C  C5  1  0.47956975  0.29402067  0.74778186  1
+  C  C6  1  0.47949088  0.80296529  0.00536176  1
+  C  C7  1  0.48045281  0.10137328  0.51837386  1
+  C  C8  1  0.48025164  0.12680766  0.02404835  1
+  C  C9  1  0.97885031  0.47401553  0.70726779  1
+",-154.24696
+7331,C-145333-1039-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45703000
+_cell_length_b   6.53071000
+_cell_length_c   7.79072000
+_cell_angle_alpha   66.84891000
+_cell_angle_beta   71.59554000
+_cell_angle_gamma   67.85331000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   104.38394670
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.08538345  0.34129322  0.76922531  1
+  C  C1  1  -0.11817568  -0.04039301  0.85588380  1
+  C  C2  1  1.00028214  0.36852345  0.32654108  1
+  C  C3  1  0.59178201  0.76339275  0.34003594  1
+  C  C4  1  0.58680155  0.05603602  0.55424594  1
+  C  C5  1  1.04824260  0.86759363  0.27883708  1
+  C  C6  1  0.04469683  0.00538922  0.64696193  1
+  C  C7  1  0.62090157  0.21739572  0.35750266  1
+  C  C8  1  0.59490948  0.23294112  0.86843540  1
+  C  C9  1  0.88786127  0.12049109  0.18541399  1
+  C  C10  1  -0.44438698  0.60689133  1.03321334  1
+  C  C11  1  0.39062420  0.22892427  0.07432836  1
+  C  C12  1  -0.56632704  0.83171264  -0.06767810  1
+  C  C13  1  1.14498848  0.46463216  0.58420968  1
+  C  C14  1  0.70946390  0.51856071  0.46609749  1
+  C  C15  1  0.11538990  0.47628228  0.10409440  1
+",-154.225940625
+5667,C-126171-2991-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45427000
+_cell_length_b   4.65686000
+_cell_length_c   7.07417000
+_cell_angle_alpha   89.48852000
+_cell_angle_beta   87.33568000
+_cell_angle_gamma   88.59540000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   80.73792314
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64960476  0.20243167  0.84163390  1
+  C  C1  1  0.57638841  0.73068597  0.09119781  1
+  C  C2  1  0.64689831  0.49307256  0.74614558  1
+  C  C3  1  0.67033701  0.42944861  0.19707909  1
+  C  C4  1  0.66886044  0.06666540  0.63848168  1
+  C  C5  1  0.69685630  0.54703619  0.39695956  1
+  C  C6  1  0.68078391  0.35924538  0.55866312  1
+  C  C7  1  0.13610331  0.67075888  0.77384735  1
+  C  C8  1  0.19089238  0.23864784  0.15891470  1
+  C  C9  1  0.33937013  0.94280110  0.25002095  1
+  C  C10  1  0.21157553  0.75390037  0.41531143  1
+  C  C11  1  1.17270458  -0.11127684  0.61051106  1
+  C  C12  1  0.14359914  0.12727823  0.95163701  1
+  C  C13  1  1.10125428  0.80130584  0.97075105  1
+",-154.07316642857143
+7590,C-47640-4572-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44277000
+_cell_length_b   5.97793000
+_cell_length_c   6.30061000
+_cell_angle_alpha   61.84041000
+_cell_angle_beta   78.80825000
+_cell_angle_gamma   78.12410000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   78.87657672
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.43514131  0.01014529  0.91908001  1
+  C  C1  1  0.20561656  0.04683473  0.34204217  1
+  C  C2  1  0.66506974  0.65842239  0.79597152  1
+  C  C3  1  0.58006241  0.55132290  0.07375877  1
+  C  C4  1  1.07145595  0.08741763  0.55820951  1
+  C  C5  1  -0.04140407  0.39385355  0.47406925  1
+  C  C6  1  0.55851928  0.96610972  0.70511096  1
+  C  C7  1  0.76283434  1.03500072  0.23982430  1
+  C  C8  1  0.37728199  0.46687900  0.56348866  1
+  C  C9  1  -0.12148956  0.02189501  1.02104212  1
+  C  C10  1  1.04102560  0.50492525  0.19629335  1
+  C  C11  1  0.24606576  0.58460472  0.70743718  1
+",-154.2184675
+3747,C-13663-1651-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.35552000
+_cell_length_b   4.92073000
+_cell_length_c   4.91419000
+_cell_angle_alpha   114.55843000
+_cell_angle_beta   102.49236000
+_cell_angle_gamma   104.47551000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   66.56747533
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.94994442  0.76003904  0.82893439  1
+  C  C1  1  0.46989485  0.53822732  0.59582772  1
+  C  C2  1  0.22322484  0.55064707  0.82887744  1
+  C  C3  1  0.88413103  0.46147500  0.15107597  1
+  C  C4  1  0.46987444  0.03813556  0.59573987  1
+  C  C5  1  0.36441457  0.18306977  0.38508782  1
+  C  C6  1  0.61067476  0.17095289  0.15125455  1
+  C  C7  1  0.22324257  0.05059898  0.82883556  1
+  C  C8  1  0.36442500  0.68298539  0.38500544  1
+  C  C9  1  0.88409398  0.96157167  0.15119289  1
+  C  C10  1  0.61071510  0.67091091  0.15122701  1
+  C  C11  1  0.94995964  0.25994150  0.82880425  1
+",-154.20328333333333
+2082,C-73615-2489-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48358000
+_cell_length_b   4.72114000
+_cell_length_c   6.27273000
+_cell_angle_alpha   73.41028000
+_cell_angle_beta   101.42077000
+_cell_angle_gamma   105.25863000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.40018769
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.16689390  0.47456441  0.23199350  1
+  C  C1  1  1.44924429  -0.00433545  0.27451465  1
+  C  C2  1  0.69455350  0.04711063  0.71241504  1
+  C  C3  1  -0.11869246  0.38096244  0.75514775  1
+  C  C4  1  0.34613803  0.03010214  0.03363179  1
+  C  C5  1  -0.08683158  0.64631658  0.55237561  1
+  C  C6  1  0.05387916  0.13628938  0.34496545  1
+  C  C7  1  0.62782851  0.55269053  0.07600792  1
+  C  C8  1  0.10268900  0.98101357  0.59465466  1
+  C  C9  1  0.34974266  0.66578815  0.40457374  1
+  C  C10  1  0.44632209  0.36033641  0.90416859  1
+  C  C11  1  0.73976149  0.89075562  0.96210951  1
+",-154.41967916666667
+9234,C-193958-6227-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48131000
+_cell_length_b   3.68892000
+_cell_length_c   4.83679000
+_cell_angle_alpha   111.44934000
+_cell_angle_beta   104.84911000
+_cell_angle_gamma   109.67410000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.97709314
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.94097459  0.54120540  0.75353742  1
+  C  C1  1  0.23121991  0.25345270  0.62265362  1
+  C  C2  1  0.27202174  -0.16198316  0.11827781  1
+  C  C3  1  0.98033606  0.12540593  0.24902812  1
+  C  C4  1  0.25580589  0.59830581  0.32479564  1
+  C  C5  1  -0.04251858  0.78043582  0.54684599  1
+",-154.30970399999998
+5019,C-141024-202-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46153000
+_cell_length_b   4.55323000
+_cell_length_c   7.74137000
+_cell_angle_alpha   87.77949000
+_cell_angle_beta   80.86591000
+_cell_angle_gamma   74.30547000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   82.46980030
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.88553275  0.70802952  0.25396329  1
+  C  C1  1  0.70328649  0.05347839  0.28085973  1
+  C  C2  1  0.10112816  0.15996138  0.37969066  1
+  C  C3  1  0.74035409  0.44662058  0.80633871  1
+  C  C4  1  0.83993153  0.15666236  0.90494585  1
+  C  C5  1  -0.02532693  0.72623839  0.05707368  1
+  C  C6  1  0.45618081  -0.01070674  0.83934793  1
+  C  C7  1  0.51364440  0.06592571  0.64893543  1
+  C  C8  1  0.79270365  0.06581110  0.08756312  1
+  C  C9  1  0.30221320  0.61036693  0.51980185  1
+  C  C10  1  0.55226051  0.69167328  0.93757913  1
+  C  C11  1  -0.09472862  0.51183426  0.41185451  1
+  C  C12  1  0.31037300  0.42385572  0.68835614  1
+  C  C13  1  1.11085254  0.97075024  0.55003866  1
+",-154.07582785714283
+451,C-9630-678-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48859000
+_cell_length_b   4.30632000
+_cell_length_c   5.55782000
+_cell_angle_alpha   130.19914000
+_cell_angle_beta   77.05437000
+_cell_angle_gamma   106.80342000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.49368324
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.41716835  0.15451769  0.50795339  1
+  C  C1  1  0.97909662  1.09183702  0.32049869  1
+  C  C2  1  0.72960778  0.34197286  0.07038865  1
+  C  C3  1  0.22928575  0.84171819  0.57043898  1
+  C  C4  1  0.66748854  0.90466495  0.75787872  1
+  C  C5  1  0.16746957  0.40432794  0.25786500  1
+  C  C6  1  0.47926316  0.59210312  0.82057603  1
+  C  C7  1  0.91723863  0.65470193  1.00802716  1
+",-154.54683
+4056,C-40110-5594-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47526000
+_cell_length_b   4.24775000
+_cell_length_c   4.24927000
+_cell_angle_alpha   128.06032000
+_cell_angle_beta   89.99130000
+_cell_angle_gamma   89.99374000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.17779541
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.01037890  0.17309214  0.63712014  1
+  C  C1  1  0.51000942  0.56163099  0.24856244  1
+  C  C2  1  1.01020450  0.01617539  0.20232980  1
+  C  C3  1  1.01010163  0.58125283  0.04537995  1
+  C  C4  1  0.51038531  0.96977928  0.65672819  1
+  C  C5  1  0.51018054  0.12667388  0.09151458  1
+",-154.28540016666668
+758,C-34611-1398-68,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48720000
+_cell_length_b   5.55983000
+_cell_length_c   7.03157000
+_cell_angle_alpha   90.00449000
+_cell_angle_beta   90.00401000
+_cell_angle_gamma   116.58936000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   86.95155190
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.00083943  0.50877639  0.81443662  1
+  C  C1  1  0.75073102  0.75926722  1.06451435  1
+  C  C2  1  0.75091862  0.75942737  0.56454217  1
+  C  C3  1  0.25071611  0.75926582  -0.06097988  1
+  C  C4  1  0.00112486  0.00989248  0.68908478  1
+  C  C5  1  0.25077660  0.25920599  0.06428973  1
+  C  C6  1  1.00101761  0.50890085  0.31440404  1
+  C  C7  1  -0.24863340  0.25949007  0.43911108  1
+  C  C8  1  0.00091659  0.00977489  0.18910880  1
+  C  C9  1  0.50108930  1.00990183  0.31444302  1
+  C  C10  1  0.75076232  0.25921173  0.93907067  1
+  C  C11  1  0.50100164  0.50894640  0.68912809  1
+  C  C12  1  0.50083046  0.50881369  0.18906608  1
+  C  C13  1  0.50094792  0.00976454  0.81439121  1
+  C  C14  1  0.25137690  0.25947701  0.56433242  1
+  C  C15  1  0.25089272  0.75942622  0.43904803  1
+",-154.544731875
+4937,C-13946-920-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.80037000
+_cell_length_b   4.81376000
+_cell_length_c   3.62571000
+_cell_angle_alpha   112.14097000
+_cell_angle_beta   90.47523000
+_cell_angle_gamma   98.25732000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.69823724
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.27723654  0.90402636  0.83735401  1
+  C  C1  1  0.27577696  0.59613090  0.80168904  1
+  C  C2  1  0.27636177  0.40470376  0.39672953  1
+  C  C3  1  0.27589323  0.59629519  0.18345563  1
+  C  C4  1  0.27668290  0.09564741  0.24227613  1
+  C  C5  1  0.27748460  0.90430237  0.45593185  1
+",-154.11821899999998
+7701,C-28222-3619-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.54818000
+_cell_length_b   2.44063000
+_cell_length_c   7.61044000
+_cell_angle_alpha   71.98715000
+_cell_angle_beta   116.78836000
+_cell_angle_gamma   89.08769000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.50212342
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.30385013  1.11226421  0.47649954  1
+  C  C1  1  0.79983663  0.94921231  0.13895846  1
+  C  C2  1  0.15931509  0.05354724  0.03513244  1
+  C  C3  1  -0.17314441  0.28504718  0.80532985  1
+  C  C4  1  0.65499003  0.89073052  0.69767761  1
+  C  C5  1  1.13207543  0.71797864  0.36879110  1
+",-154.07185216666667
+9220,C-57140-5474-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43152000
+_cell_length_b   4.20623000
+_cell_length_c   5.71575000
+_cell_angle_alpha   96.10774000
+_cell_angle_beta   79.21077000
+_cell_angle_gamma   89.83010000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.08298626
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40328008  0.88625214  0.26231311  1
+  C  C1  1  0.90308773  1.05341073  0.26409628  1
+  C  C2  1  -0.09670958  0.38625270  0.26233527  1
+  C  C3  1  0.71426582  0.80682037  0.76278097  1
+  C  C4  1  0.21425548  0.30681980  0.76275881  1
+  C  C5  1  0.40311951  0.55340770  0.26407136  1
+  C  C6  1  0.21445817  0.63966177  0.76099780  1
+  C  C7  1  0.71442639  0.13966480  0.76102272  1
+",-154.44723625
+6611,C-137393-2973-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.53239000
+_cell_length_b   4.40946000
+_cell_length_c   10.91078000
+_cell_angle_alpha   91.56891000
+_cell_angle_beta   83.15899000
+_cell_angle_gamma   91.22637000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C20
+_cell_volume   120.90197090
+_cell_formula_units_Z   20
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.57054177  0.49717357  0.19769400  1
+  C  C1  1  0.24196654  0.80413947  0.90866946  1
+  C  C2  1  0.16611435  0.57649754  1.00464021  1
+  C  C3  1  1.17686425  1.06005755  -0.00648358  1
+  C  C4  1  1.13864710  0.10671582  0.65632714  1
+  C  C5  1  0.51992667  0.00817872  0.30376712  1
+  C  C6  1  0.79156096  0.73012316  0.83725664  1
+  C  C7  1  0.51577155  0.68062693  0.30450861  1
+  C  C8  1  0.44498042  0.18816780  0.41793150  1
+  C  C9  1  0.52481422  0.61703400  0.65098604  1
+  C  C10  1  0.57772869  0.17731218  0.19532875  1
+  C  C11  1  0.98693468  0.78415249  0.70480368  1
+  C  C12  1  0.70668455  0.37419057  0.83838789  1
+  C  C13  1  0.46876893  0.69920943  0.52206320  1
+  C  C14  1  0.47958259  0.51320540  0.41730884  1
+  C  C15  1  -0.36221403  0.00949794  0.07392240  1
+  C  C16  1  0.34043180  1.01300051  0.52366988  1
+  C  C17  1  0.18587644  0.31898228  0.91714075  1
+  C  C18  1  0.63095738  0.64861645  0.07870821  1
+  C  C19  1  0.62925247  0.28918099  0.69729335  1
+",-154.10927099999998
+4907,C-80144-1745-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.54967000
+_cell_length_b   3.65184000
+_cell_length_c   5.54622000
+_cell_angle_alpha   94.64689000
+_cell_angle_beta   76.63246000
+_cell_angle_gamma   110.43294000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.08054198
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79727599  0.59079554  0.79106199  1
+  C  C1  1  0.64201683  0.03305657  0.54209991  1
+  C  C2  1  -0.23531577  0.77253161  1.03918195  1
+  C  C3  1  0.39442814  0.03333154  0.03934468  1
+  C  C4  1  0.49419369  0.40421327  0.21082125  1
+  C  C5  1  0.60855402  0.21324074  0.79103541  1
+  C  C6  1  1.01208930  0.77211906  0.54233285  1
+  C  C7  1  0.91406892  0.40402397  0.37016105  1
+",-154.1841675
+3438,C-41312-2882-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.53202000
+_cell_length_b   2.45706000
+_cell_length_c   6.86201000
+_cell_angle_alpha   69.62264000
+_cell_angle_beta   97.88753000
+_cell_angle_gamma   88.44194000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.51115673
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.86760592  0.72387521  0.79168564  1
+  C  C1  1  0.22354697  0.06046332  0.45717588  1
+  C  C2  1  1.11360085  0.29234930  0.22643787  1
+  C  C3  1  0.76437991  0.95542089  0.56097197  1
+  C  C4  1  0.92591400  0.11890434  0.89833322  1
+  C  C5  1  0.05115284  0.89740843  0.12001911  1
+",-154.08159133333334
+7194,C-126167-1633-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.82425000
+_cell_length_b   3.72492000
+_cell_length_c   3.64057000
+_cell_angle_alpha   106.26070000
+_cell_angle_beta   112.31943000
+_cell_angle_gamma   117.56500000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.60199584
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.60960683  0.68685867  1.09975968  1
+  C  C1  1  0.41815334  0.68797108  0.69434027  1
+  C  C2  1  0.91832992  0.68826081  0.75498315  1
+  C  C3  1  0.60935266  0.68514621  0.47853440  1
+  C  C4  1  0.91782557  0.68670605  0.13373917  1
+  C  C5  1  0.10945617  -0.31436013  0.53912683  1
+",-154.13573266666666
+5243,C-126183-8981-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.98518000
+_cell_length_b   4.62387000
+_cell_length_c   4.76167000
+_cell_angle_alpha   100.90871000
+_cell_angle_beta   73.90167000
+_cell_angle_gamma   108.70066000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   79.36497521
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.62321381  0.71943332  1.07199692  1
+  C  C1  1  0.70581614  0.19731524  0.45205071  1
+  C  C2  1  0.55704647  0.00511927  0.70644348  1
+  C  C3  1  -0.11320465  0.66831485  0.21038072  1
+  C  C4  1  0.53962670  1.01153867  0.20235734  1
+  C  C5  1  0.03152170  0.42376878  0.95210427  1
+  C  C6  1  0.22742361  0.49476778  0.61758385  1
+  C  C7  1  0.09637260  0.25589689  0.38527565  1
+  C  C8  1  0.32316291  0.39331148  0.09099485  1
+  C  C9  1  0.76394312  0.76422843  0.74690074  1
+  C  C10  1  0.17410084  0.81772198  0.62963353  1
+  C  C11  1  0.16133393  0.93425075  0.34857313  1
+  C  C12  1  0.63132944  0.51177255  0.51940212  1
+  C  C13  1  0.61133487  0.20940582  0.97318829  1
+",-154.07468428571428
+1885,C-176656-6648-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48144000
+_cell_length_b   4.21993000
+_cell_length_c   3.68719000
+_cell_angle_alpha   104.91167000
+_cell_angle_beta   109.63934000
+_cell_angle_gamma   89.94545000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98417761
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40212946  0.07716433  0.23657794  1
+  C  C1  1  0.62679510  0.28362648  0.68251178  1
+  C  C2  1  0.20519497  0.15276615  0.83902115  1
+  C  C3  1  0.66135613  0.64859617  0.75062734  1
+  C  C4  1  0.08290643  0.77919114  0.59349743  1
+  C  C5  1  0.88243091  0.85532612  1.19629626  1
+",-154.310563
+9358,C-126159-6870-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47226000
+_cell_length_b   3.68146000
+_cell_length_c   8.11336000
+_cell_angle_alpha   66.22896000
+_cell_angle_beta   89.90353000
+_cell_angle_gamma   89.91854000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   67.57917990
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63988549  0.51955627  0.40319619  1
+  C  C1  1  1.13986630  0.70360131  0.32138638  1
+  C  C2  1  0.14058501  0.61658924  0.80473683  1
+  C  C3  1  0.13977342  0.03978165  0.16941513  1
+  C  C4  1  0.14038156  0.20727664  0.80769781  1
+  C  C5  1  0.14025322  1.04175033  0.65860519  1
+  C  C6  1  0.63999743  0.18204523  0.06612669  1
+  C  C7  1  0.64007172  1.01658711  0.91703322  1
+  C  C8  1  0.64011613  0.60732968  0.91998372  1
+  C  C9  1  0.64035201  0.18370414  0.55531094  1
+",-154.19737600000002
+4571,C-136219-6599-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44928000
+_cell_length_b   4.54351000
+_cell_length_c   3.96345000
+_cell_angle_alpha   86.67544000
+_cell_angle_beta   90.01352000
+_cell_angle_gamma   105.63407000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.39782073
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.03475157  0.74837273  0.25744228  1
+  C  C1  1  0.87899634  0.44019141  0.12066397  1
+  C  C2  1  0.28509285  0.25124632  0.64075894  1
+  C  C3  1  0.35132561  0.38393697  0.93352545  1
+  C  C4  1  0.75562360  0.19241313  0.45600564  1
+  C  C5  1  0.60243053  0.88374044  0.32288132  1
+",-154.2646795
+2983,C-136214-3679-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.72819000
+_cell_length_b   3.72736000
+_cell_length_c   4.30150000
+_cell_angle_alpha   54.72131000
+_cell_angle_beta   54.72157000
+_cell_angle_gamma   70.53288000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.83603105
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46604743  0.61296364  0.01589527  1
+  C  C1  1  0.21578783  0.86295524  0.26604031  1
+  C  C2  1  0.96592400  0.11295781  0.01606393  1
+  C  C3  1  0.21566293  0.86288809  0.76617814  1
+  C  C4  1  -0.03408659  0.61295727  0.76603012  1
+  C  C5  1  0.46606230  0.11298374  0.26591543  1
+",-154.08037433333334
+3319,C-13651-5621-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48628000
+_cell_length_b   2.53213000
+_cell_length_c   7.89219000
+_cell_angle_alpha   98.58898000
+_cell_angle_beta   99.08003000
+_cell_angle_gamma   89.94664000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.50004597
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64503429  0.57789989  0.98116693  1
+  C  C1  1  0.56103869  0.47942546  0.81004785  1
+  C  C2  1  -0.04518732  0.87466475  0.59849483  1
+  C  C3  1  0.25415934  0.18491269  0.20033313  1
+  C  C4  1  0.00769617  0.42353172  0.70311167  1
+  C  C5  1  0.81297469  0.24029988  0.31744186  1
+  C  C6  1  0.86390053  0.78836566  0.42040987  1
+  C  C7  1  0.19698962  0.63182484  0.08542127  1
+",-154.15573375
+4825,C-102899-3014-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47287000
+_cell_length_b   4.27341000
+_cell_length_c   8.90597000
+_cell_angle_alpha   75.76717000
+_cell_angle_beta   73.87812000
+_cell_angle_gamma   89.99686000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   87.40263404
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.61274197  0.70090963  0.45184715  1
+  C  C1  1  -0.03108511  0.72550609  0.94019967  1
+  C  C2  1  1.24474952  0.76108417  0.18793421  1
+  C  C3  1  0.79587117  0.63287322  0.12162972  1
+  C  C4  1  1.00527237  0.09037181  0.87830561  1
+  C  C5  1  0.19500508  0.60692650  0.36951857  1
+  C  C6  1  0.66963572  0.27045140  0.18811188  1
+  C  C7  1  0.52892755  0.58695294  0.88111026  1
+  C  C8  1  0.35275039  0.24245653  0.36930998  1
+  C  C9  1  0.44119742  0.22219334  -0.05746367  1
+  C  C10  1  0.72551403  0.04013427  0.63288452  1
+  C  C11  1  0.71848519  0.67855538  0.69976860  1
+  C  C12  1  0.30008546  0.54985735  0.63352385  1
+  C  C13  1  0.24351135  1.12678007  0.12977164  1
+  C  C14  1  0.18458048  0.18446642  0.69110710  1
+  C  C15  1  -0.22938879  1.06544878  0.45153002  1
+",-154.357685
+3744,C-41312-2882-51,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43382000
+_cell_length_b   4.88124000
+_cell_length_c   5.54369000
+_cell_angle_alpha   124.62502000
+_cell_angle_beta   90.06196000
+_cell_angle_gamma   119.89825000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.08973743
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.21447125  0.55541645  0.82519226  1
+  C  C1  1  0.21626460  0.55732848  0.23931695  1
+  C  C2  1  0.27933114  0.12011663  0.31350884  1
+  C  C3  1  0.57299196  0.41403313  0.25447839  1
+  C  C4  1  0.57201909  0.41316841  0.66673930  1
+  C  C5  1  0.50884126  0.84973049  0.17868087  1
+",-154.25576283333334
+10032,C-107756-3646-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48451000
+_cell_length_b   3.82420000
+_cell_length_c   5.78576000
+_cell_angle_alpha   89.88373000
+_cell_angle_beta   64.51137000
+_cell_angle_gamma   71.03498000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.31238692
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.45321616  0.51856647  0.39926981  1
+  C  C1  1  0.71286755  0.11550021  0.34199473  1
+  C  C2  1  0.74050077  0.61282642  0.56424246  1
+  C  C3  1  0.69755151  0.59258679  0.11956121  1
+  C  C4  1  0.42593968  0.02093608  0.17695580  1
+  C  C5  1  -0.24650399  0.26308941  0.72711844  1
+  C  C6  1  0.47073188  0.04027424  0.62123534  1
+  C  C7  1  0.41447354  0.37046299  1.01376342  1
+",-154.2231575
+9909,C-57109-5472-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48448000
+_cell_length_b   5.84235000
+_cell_length_c   4.67834000
+_cell_angle_alpha   43.96908000
+_cell_angle_beta   105.40820000
+_cell_angle_gamma   102.28238000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.42781902
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.50324103  0.79077720  0.20206481  1
+  C  C1  1  0.28899539  0.25485029  0.30890281  1
+  C  C2  1  0.17624443  0.49704566  0.83971243  1
+  C  C3  1  0.78967668  0.02897141  0.53661375  1
+  C  C4  1  0.96002741  0.96064720  0.94610742  1
+  C  C5  1  1.01953088  0.31641279  0.70600469  1
+  C  C6  1  -0.32535623  0.72290802  0.61144124  1
+  C  C7  1  0.44715762  0.43501254  0.44297294  1
+",-154.36522375
+7615,C-152605-7685-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42538000
+_cell_length_b   4.21166000
+_cell_length_c   4.21103000
+_cell_angle_alpha   89.43616000
+_cell_angle_beta   90.02415000
+_cell_angle_gamma   89.97907000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.01305940
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.28089161  1.06793497  0.40715593  1
+  C  C1  1  0.78043911  0.15611700  0.91032663  1
+  C  C2  1  0.78070442  0.21763488  0.25809724  1
+  C  C3  1  0.78116789  0.56511745  0.31766658  1
+  C  C4  1  0.28112430  0.72069264  0.34740063  1
+  C  C5  1  0.28034056  0.12774706  0.75505479  1
+",-154.3061565
+6525,C-41290-3170-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.60876000
+_cell_length_b   3.67720000
+_cell_length_c   4.58534000
+_cell_angle_alpha   66.36283000
+_cell_angle_beta   77.00707000
+_cell_angle_gamma   90.02636000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.06202007
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.74047776  0.08084021  0.88375314  1
+  C  C1  1  0.55317137  0.41919681  0.20618991  1
+  C  C2  1  -0.25998918  0.70560995  0.88428672  1
+  C  C3  1  0.55275713  1.04457366  0.20577671  1
+  C  C4  1  0.85540610  0.51040910  0.65100945  1
+  C  C5  1  0.43559192  0.61637877  0.43832166  1
+",-154.08080683333333
+8114,C-189705-3285-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43686000
+_cell_length_b   4.89119000
+_cell_length_c   6.54076000
+_cell_angle_alpha   79.24320000
+_cell_angle_beta   79.23218000
+_cell_angle_gamma   60.06966000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   65.97247808
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.49601433  0.45195671  0.20813641  1
+  C  C1  1  0.39356403  0.88778768  0.53208090  1
+  C  C2  1  0.20522864  0.40442453  0.88368684  1
+  C  C3  1  0.53033379  0.95921438  0.13267676  1
+  C  C4  1  0.74048704  0.53386091  0.54906103  1
+  C  C5  1  0.42739991  0.39485879  0.45456970  1
+  C  C6  1  0.18315403  0.31236888  0.11426668  1
+  C  C7  1  0.18370427  0.79998674  0.14357931  1
+  C  C8  1  0.74103169  0.04734540  0.51907684  1
+  C  C9  1  0.72060038  0.44079779  0.78016232  1
+",-154.28071
+19,C-40140-2962-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.27361000
+_cell_length_b   3.26402000
+_cell_length_c   3.63072000
+_cell_angle_alpha   75.56247000
+_cell_angle_beta   75.50717000
+_cell_angle_gamma   80.87850000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.18237598
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.61206043  0.55510757  0.23063221  1
+  C  C1  1  0.88032555  0.50069949  0.84899588  1
+  C  C2  1  0.46480899  0.12946831  0.46753926  1
+  C  C3  1  0.25177966  0.91598058  0.23091072  1
+  C  C4  1  0.82620696  0.76873989  0.46707335  1
+  C  C5  1  0.19829341  1.18412736  0.84933680  1
+",-154.1957955
+5282,C-136212-1087-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48184000
+_cell_length_b   3.74033000
+_cell_length_c   5.36984000
+_cell_angle_alpha   134.23774000
+_cell_angle_beta   90.00186000
+_cell_angle_gamma   90.00063000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.71343989
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.47595752  0.27790612  0.11126042  1
+  C  C1  1  -0.02410861  0.06933670  0.40576227  1
+  C  C2  1  0.47581801  0.71504713  0.81608819  1
+  C  C3  1  0.97573531  0.47763756  0.81537510  1
+  C  C4  1  0.97596104  0.50661622  0.11046482  1
+  C  C5  1  0.47584843  0.30661768  0.40655549  1
+",-154.15882166666668
+2861,C-172941-6659-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46129000
+_cell_length_b   3.35543000
+_cell_length_c   4.48626000
+_cell_angle_alpha   111.91502000
+_cell_angle_beta   84.66378000
+_cell_angle_gamma   104.44266000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   33.28700515
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20550672  0.33414689  0.11136919  1
+  C  C1  1  -0.08567327  -0.08020934  0.55605010  1
+  C  C2  1  0.62423229  1.06072605  0.11144325  1
+  C  C3  1  0.41407202  0.81401831  0.34538777  1
+  C  C4  1  0.12435015  0.40013963  0.78925255  1
+  C  C5  1  0.70559399  0.67354316  0.78940764  1
+",-154.20311833333332
+7183,C-72732-3061-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.68968000
+_cell_length_b   2.47894000
+_cell_length_c   6.27762000
+_cell_angle_alpha   78.61388000
+_cell_angle_beta   128.87234000
+_cell_angle_gamma   70.36161000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.96990993
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.73556666  0.58675900  -0.11828492  1
+  C  C1  1  0.32662043  0.53898549  0.38585823  1
+  C  C2  1  0.64887236  0.41512402  0.31051236  1
+  C  C3  1  0.30071470  0.98636443  0.51686105  1
+  C  C4  1  0.38751311  0.15716779  0.08803285  1
+  C  C5  1  0.70981254  0.03419337  0.01262593  1
+",-154.31292066666666
+8677,C-176685-9184-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.26988000
+_cell_length_b   3.62922000
+_cell_length_c   4.23507000
+_cell_angle_alpha   131.56080000
+_cell_angle_beta   84.74649000
+_cell_angle_gamma   104.48759000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.21737602
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.25361964  0.03637187  0.90649838  1
+  C  C1  1  0.04056072  0.48595364  0.11915414  1
+  C  C2  1  0.61393146  0.39635977  0.26731774  1
+  C  C3  1  0.40229628  0.84643282  0.48027398  1
+  C  C4  1  -0.01512397  0.60034596  0.85195865  1
+  C  C5  1  0.66869746  0.28268724  0.53466070  1
+",-154.19851583333335
+5927,C-41304-5896-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.01785000
+_cell_length_b   3.32930000
+_cell_length_c   6.14407000
+_cell_angle_alpha   100.82237000
+_cell_angle_beta   81.22437000
+_cell_angle_gamma   135.36920000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.58116713
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.26028811  0.55932546  0.31170148  1
+  C  C1  1  0.59521765  1.22510778  0.64537622  1
+  C  C2  1  0.37142916  0.44922235  0.08932240  1
+  C  C3  1  -0.07247654  -0.10749567  -0.02146138  1
+  C  C4  1  0.03879825  0.78210949  0.75619141  1
+  C  C5  1  0.70389738  0.11623810  0.42258817  1
+",-154.43269066666667
+4179,C-90821-8000-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.11664000
+_cell_length_b   3.51299000
+_cell_length_c   5.32020000
+_cell_angle_alpha   117.18451000
+_cell_angle_beta   60.27780000
+_cell_angle_gamma   101.42066000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   59.39598260
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.24127326  0.78412952  0.50650340  1
+  C  C1  1  0.40824456  0.61726588  0.17346521  1
+  C  C2  1  0.74090819  0.78430077  1.00670944  1
+  C  C3  1  0.24091171  0.28432538  1.00673708  1
+  C  C4  1  -0.09179997  1.11730274  0.17343940  1
+  C  C5  1  0.74130826  0.28405993  0.50645915  1
+  C  C6  1  0.40842573  0.11734541  0.67324032  1
+  C  C7  1  0.90847587  0.61724458  0.67320131  1
+",-154.43512375
+6415,C-113068-6749-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48171000
+_cell_length_b   4.82746000
+_cell_length_c   6.99795000
+_cell_angle_alpha   99.32781000
+_cell_angle_beta   79.78938000
+_cell_angle_gamma   59.03460000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.48864750
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.34034630  0.69002231  0.25871512  1
+  C  C1  1  0.32004200  0.20168210  0.27605271  1
+  C  C2  1  0.30116885  0.38358432  0.94989280  1
+  C  C3  1  0.66725187  0.63158070  0.72572852  1
+  C  C4  1  0.55064626  0.82588225  0.56929920  1
+  C  C5  1  0.92464587  0.06256574  0.34616296  1
+  C  C6  1  0.56195405  0.57922015  0.03687297  1
+  C  C7  1  0.39390237  0.40433010  0.72591933  1
+  C  C8  1  0.90590380  0.58092839  0.34548273  1
+  C  C9  1  0.57801303  1.07284663  1.01818427  1
+  C  C10  1  0.82302158  0.05357413  0.56948032  1
+  C  C11  1  0.32212121  0.86387157  -0.05130495  1
+",-154.39104583333332
+9082,C-40138-885-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.10377000
+_cell_length_b   2.42945000
+_cell_length_c   5.80368000
+_cell_angle_alpha   80.97956000
+_cell_angle_beta   93.27799000
+_cell_angle_gamma   84.13727000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.87559155
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.73898957  0.39060159  0.48148158  1
+  C  C1  1  0.62965394  -0.05274059  0.36938017  1
+  C  C2  1  0.40568899  1.05726793  0.14812934  1
+  C  C3  1  0.29632250  0.61393381  0.03604207  1
+  C  C4  1  -0.03704548  0.28059307  0.70273241  1
+  C  C5  1  0.07232101  0.72392719  0.81481969  1
+",-154.450482
+5584,C-148242-4178-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45206000
+_cell_length_b   5.43999000
+_cell_length_c   5.44030000
+_cell_angle_alpha   83.58058000
+_cell_angle_beta   90.00120000
+_cell_angle_gamma   90.03507000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   72.11413485
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.68226684  0.49785348  0.50345217  1
+  C  C1  1  0.68231124  0.63389827  0.24856122  1
+  C  C2  1  0.18155142  0.25439150  0.82095351  1
+  C  C3  1  0.18241196  0.70304446  0.85400180  1
+  C  C4  1  0.68170659  0.21794321  0.47118374  1
+  C  C5  1  0.18154435  0.27812676  0.09099221  1
+  C  C6  1  0.68252147  0.89785266  0.15090030  1
+  C  C7  1  0.18229933  0.51496855  0.66585752  1
+  C  C8  1  0.68169074  0.14828811  0.22063238  1
+  C  C9  1  0.18209257  0.54808352  0.11458375  1
+  C  C10  1  0.68153149  0.12045637  0.73511575  1
+  C  C11  1  0.68253770  0.86560032  0.87122997  1
+",-154.12980916666666
+7890,C-142798-9552-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45692000
+_cell_length_b   3.66319000
+_cell_length_c   6.47564000
+_cell_angle_alpha   107.00478000
+_cell_angle_beta   79.04554000
+_cell_angle_gamma   109.58558000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.23466328
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.78657100  -0.23461344  0.27098501  1
+  C  C1  1  0.05729944  0.88067291  0.84214474  1
+  C  C2  1  0.84094961  0.24857660  0.64523495  1
+  C  C3  1  0.06395038  0.64686946  0.59479656  1
+  C  C4  1  0.28380702  0.27974538  0.79160050  1
+  C  C5  1  0.68858480  0.80764214  0.50802128  1
+  C  C6  1  0.33593126  0.75848453  0.16551484  1
+  C  C7  1  0.43480249  0.72045183  -0.07113068  1
+",-154.2870375
+3158,C-79899-8009-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.56789000
+_cell_length_b   4.82244000
+_cell_length_c   8.13017000
+_cell_angle_alpha   98.63675000
+_cell_angle_beta   71.18867000
+_cell_angle_gamma   111.24181000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   123.33067824
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.33619406  0.81649961  0.60440908  1
+  C  C1  1  0.25936667  0.58939873  0.72156147  1
+  C  C2  1  0.49308635  0.18566888  0.29751737  1
+  C  C3  1  0.41016135  0.71280312  0.43730118  1
+  C  C4  1  0.79555656  0.50563269  0.84764983  1
+  C  C5  1  0.54910562  0.69458661  0.83709069  1
+  C  C6  1  0.57286199  0.18234921  0.82970823  1
+  C  C7  1  0.41307743  0.39701330  0.43751676  1
+  C  C8  1  0.61665772  0.25973132  0.11204043  1
+  C  C9  1  0.84877349  1.01085138  0.82727543  1
+  C  C10  1  0.29355583  0.08179242  0.01129746  1
+  C  C11  1  0.26344087  0.74724786  0.01808815  1
+  C  C12  1  0.87305501  0.06345411  1.02080177  1
+  C  C13  1  0.47958269  0.89353558  0.29846022  1
+  C  C14  1  0.29610195  1.09015203  0.70032049  1
+  C  C15  1  0.57360577  0.78046460  0.11543763  1
+  C  C16  1  0.81039581  0.56478696  0.04250901  1
+  C  C17  1  0.33877303  0.34085690  0.60563930  1
+",-154.15867111111112
+2436,C-41300-4225-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42971000
+_cell_length_b   2.42961000
+_cell_length_c   8.69908000
+_cell_angle_alpha   85.85481000
+_cell_angle_beta   99.12458000
+_cell_angle_gamma   59.99284000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.21129508
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71579144  1.05717947  0.37007215  1
+  C  C1  1  0.04972667  0.39075839  0.36961035  1
+  C  C2  1  0.85132435  0.68498572  0.70378677  1
+  C  C3  1  0.12115564  0.89530206  0.03880838  1
+  C  C4  1  0.51853860  0.35068652  0.70392875  1
+  C  C5  1  0.78890120  0.56164754  0.03919059  1
+",-154.45674216666666
+7120,C-92116-7433-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.70065000
+_cell_length_b   4.82230000
+_cell_length_c   4.18325000
+_cell_angle_alpha   76.69013000
+_cell_angle_beta   59.46493000
+_cell_angle_gamma   99.08673000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.13841856
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.05098205  0.55184779  0.42246703  1
+  C  C1  1  0.45183438  0.74217861  1.01881192  1
+  C  C2  1  0.66678482  0.55107655  0.80604171  1
+  C  C3  1  1.00738204  1.24260624  0.45958799  1
+  C  C4  1  0.60666330  0.05219328  0.86326103  1
+  C  C5  1  0.39209621  0.24342123  0.07603853  1
+",-154.12482216666666
+9187,C-148230-2113-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43881000
+_cell_length_b   6.18985000
+_cell_length_c   5.82043000
+_cell_angle_alpha   57.33670000
+_cell_angle_beta   77.87193000
+_cell_angle_gamma   78.60618000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   71.93923590
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.67049018  0.30427113  -0.00495983  1
+  C  C1  1  0.00287915  0.24679795  0.38407833  1
+  C  C2  1  0.09178916  0.38013583  0.07634668  1
+  C  C3  1  0.45908397  0.78408178  0.93517334  1
+  C  C4  1  0.46322183  0.19182204  0.51708902  1
+  C  C5  1  0.37272737  0.06742110  0.82366201  1
+  C  C6  1  1.00028985  0.66123429  -0.02430931  1
+  C  C7  1  0.79418148  0.14897648  -0.10088843  1
+",-154.13175875
+7380,C-53838-1497-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.31069000
+_cell_length_b   3.39876000
+_cell_length_c   5.33626000
+_cell_angle_alpha   98.89240000
+_cell_angle_beta   81.62575000
+_cell_angle_gamma   87.40981000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.54968996
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.13783115  0.19233963  0.20777857  1
+  C  C1  1  0.02936500  0.26479657  0.94554170  1
+  C  C2  1  0.88985118  0.76245636  0.53417555  1
+  C  C3  1  0.76308554  0.06940186  0.38269690  1
+  C  C4  1  0.55687055  0.45124217  0.53294880  1
+  C  C5  1  0.47280769  0.85895743  0.21435875  1
+  C  C6  1  0.34106906  0.52109682  0.80753878  1
+  C  C7  1  -0.01712605  0.85221578  0.80766988  1
+  C  C8  1  0.26440405  0.56421267  0.36415315  1
+  C  C9  1  0.67600422  0.62635830  0.96237633  1
+",-154.30735199999998
+6866,C-72726-1363-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43865000
+_cell_length_b   4.23277000
+_cell_length_c   6.52647000
+_cell_angle_alpha   90.33628000
+_cell_angle_beta   100.77841000
+_cell_angle_gamma   89.99834000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   66.17812319
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.03805053  0.76145232  0.57726827  1
+  C  C1  1  0.15748271  0.15099613  0.82371071  1
+  C  C2  1  0.82763823  0.64889424  0.14823933  1
+  C  C3  1  0.15188736  0.80116180  0.80784476  1
+  C  C4  1  0.69917988  0.64763890  0.90026501  1
+  C  C5  1  0.86576916  0.31038890  0.21424942  1
+  C  C6  1  0.66247483  0.30869541  0.83381648  1
+  C  C7  1  0.48598221  0.76191501  0.47329283  1
+  C  C8  1  0.37460352  0.80312180  0.24215348  1
+  C  C9  1  0.37244456  0.15323498  0.22868341  1
+",-154.258026
+9326,C-184074-4085-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48464000
+_cell_length_b   4.77639000
+_cell_length_c   5.57879000
+_cell_angle_alpha   77.33669000
+_cell_angle_beta   63.53412000
+_cell_angle_gamma   74.85940000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.80464391
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.91744581  0.77447248  0.22228610  1
+  C  C1  1  0.73357015  0.90821509  0.83833815  1
+  C  C2  1  0.67024262  0.69144907  0.51156645  1
+  C  C3  1  0.41578209  0.95077832  0.13520568  1
+  C  C4  1  0.85394008  0.55788515  0.89596420  1
+  C  C5  1  0.17157823  0.51530724  0.59911149  1
+  C  C6  1  0.20853494  0.50426236  0.06791628  1
+  C  C7  1  1.13680508  0.23141933  0.27425834  1
+  C  C8  1  0.37868179  -0.03772638  0.66624507  1
+  C  C9  1  0.44948670  0.23433214  0.46058895  1
+",-154.37007599999998
+8601,C-80199-6032-61,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47155000
+_cell_length_b   4.17053000
+_cell_length_c   6.64904000
+_cell_angle_alpha   96.25159000
+_cell_angle_beta   90.10750000
+_cell_angle_gamma   91.29457000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   68.11053231
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.51042258  0.28234241  0.64060595  1
+  C  C1  1  1.15257233  0.21117525  0.95112802  1
+  C  C2  1  0.84076169  0.76184506  0.52984823  1
+  C  C3  1  0.67358549  0.88754490  0.15839216  1
+  C  C4  1  1.01279871  0.40726698  0.54435732  1
+  C  C5  1  0.20564838  0.87720876  0.84567179  1
+  C  C6  1  0.15768614  0.41458908  0.31583749  1
+  C  C7  1  0.68863506  0.63878894  0.30796948  1
+  C  C8  1  0.17015052  0.11238730  0.16661681  1
+  C  C9  1  0.68746547  0.72993426  0.92942320  1
+  C  C10  1  0.63839392  0.37281299  0.87887735  1
+  C  C11  1  0.35065681  0.92006076  0.62509250  1
+",-154.16610083333333
+6324,C-28228-7733-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47773000
+_cell_length_b   2.47765000
+_cell_length_c   6.31072000
+_cell_angle_alpha   78.67938000
+_cell_angle_beta   78.66947000
+_cell_angle_gamma   59.98524000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.67210379
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.39996224  0.47382515  0.74180505  1
+  C  C1  1  -0.04667194  1.02910220  0.07706160  1
+  C  C2  1  1.09507153  0.16827939  0.65881430  1
+  C  C3  1  0.87097367  -0.05464605  0.32822980  1
+  C  C4  1  0.31476284  0.39028345  0.99282330  1
+  C  C5  1  0.17713506  0.25070316  0.41172775  1
+",-154.52688083333334
+8613,C-157701-8688-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51238000
+_cell_length_b   4.19088000
+_cell_length_c   4.19305000
+_cell_angle_alpha   58.70282000
+_cell_angle_beta   72.25311000
+_cell_angle_gamma   72.24882000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.34210614
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.22657176  0.13186599  0.51515700  1
+  C  C1  1  0.22658586  0.46261671  0.18427805  1
+  C  C2  1  0.03623939  0.80690140  0.22802851  1
+  C  C3  1  0.42183196  0.41868850  0.84000838  1
+  C  C4  1  1.03621065  0.17552367  0.85934654  1
+  C  C5  1  0.42186088  0.78740812  0.47115592  1
+",-154.22916383333333
+920,C-193950-5354-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48087000
+_cell_length_b   3.68887000
+_cell_length_c   4.21808000
+_cell_angle_alpha   75.23171000
+_cell_angle_beta   89.94894000
+_cell_angle_gamma   70.36868000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.00475437
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.16743356  0.88067454  0.67345507  1
+  C  C1  1  0.70904426  0.79571502  0.17719417  1
+  C  C2  1  -0.09253033  0.39794551  0.10162579  1
+  C  C3  1  0.38857356  0.43573517  0.87954518  1
+  C  C4  1  0.58915720  0.03747106  0.80446580  1
+  C  C5  1  0.13040515  0.95259650  0.30813149  1
+",-154.3099125
+3514,C-148275-4529-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   5.27435000
+_cell_length_b   4.26117000
+_cell_length_c   2.53903000
+_cell_angle_alpha   89.97605000
+_cell_angle_beta   76.44215000
+_cell_angle_gamma   66.16682000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   50.45757058
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.31817188  0.81422841  0.11822559  1
+  C  C1  1  0.31809949  0.13828935  0.11821712  1
+  C  C2  1  0.88249829  0.38027851  0.83494388  1
+  C  C3  1  0.56303187  0.51506749  0.99275865  1
+  C  C4  1  0.88253248  0.00802056  0.83502777  1
+  C  C5  1  0.56305238  0.19245629  -0.00710242  1
+  C  C6  1  0.03019452  0.43802191  0.26206930  1
+  C  C7  1  0.03020620  0.80246838  1.26224661  1
+",-154.10498625
+8086,C-145335-4867-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46675000
+_cell_length_b   5.68570000
+_cell_length_c   5.68682000
+_cell_angle_alpha   120.00993000
+_cell_angle_beta   90.01212000
+_cell_angle_gamma   90.00233000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   69.06622369
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.81524082  0.31333868  0.44506295  1
+  C  C1  1  1.31502578  -0.01969133  0.51701549  1
+  C  C2  1  0.31519443  0.22639254  0.27173174  1
+  C  C3  1  -0.18469673  0.79036812  -0.07741633  1
+  C  C4  1  0.81538067  0.63168490  0.60440800  1
+  C  C5  1  0.31538208  -0.03626101  0.00964699  1
+  C  C6  1  0.31485650  0.71752412  0.25485712  1
+  C  C7  1  0.81473900  0.63089284  0.08158684  1
+  C  C8  1  0.31525610  0.71819869  0.51755477  1
+  C  C9  1  0.31484945  0.22578219  0.00897218  1
+  C  C10  1  -0.18525263  0.31241535  0.92217510  1
+  C  C11  1  0.81508011  0.15365560  0.60385074  1
+",-154.225555
+4121,C-57111-4456-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42652000
+_cell_length_b   4.15033000
+_cell_length_c   6.51113000
+_cell_angle_alpha   67.79648000
+_cell_angle_beta   79.10401000
+_cell_angle_gamma   89.91736000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   59.43887640
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17426589  0.55229992  0.57183845  1
+  C  C1  1  1.14714022  0.17687810  0.61412966  1
+  C  C2  1  0.68843741  0.72430170  0.54269547  1
+  C  C3  1  0.37327410  0.48058855  0.15774692  1
+  C  C4  1  -0.17718918  0.34030428  0.25947499  1
+  C  C5  1  1.02494923  0.93054321  0.85580974  1
+  C  C6  1  0.47414323  0.78802185  0.95647068  1
+  C  C7  1  0.70486619  0.09901380  0.50124919  1
+",-154.257105
+4137,C-47650-9988-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48742000
+_cell_length_b   5.74900000
+_cell_length_c   6.86493000
+_cell_angle_alpha   96.64966000
+_cell_angle_beta   71.67372000
+_cell_angle_gamma   90.47471000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   92.52258090
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.48391697  0.68985463  1.18201377  1
+  C  C1  1  0.53354285  -0.09053181  0.60465235  1
+  C  C2  1  0.19009098  0.34001317  0.05820036  1
+  C  C3  1  1.08491590  1.05454692  0.55605907  1
+  C  C4  1  0.29794599  0.64188978  0.85582268  1
+  C  C5  1  0.62081494  0.63134717  0.50582425  1
+  C  C6  1  0.47806636  0.46057569  0.68057194  1
+  C  C7  1  0.72185524  -0.00776792  0.95083533  1
+  C  C8  1  0.77840291  0.24569905  0.93808832  1
+  C  C9  1  0.10785405  0.59131696  0.06278478  1
+  C  C10  1  0.48766742  0.93986416  0.17186634  1
+  C  C11  1  0.23082192  0.57426354  0.37693676  1
+  C  C12  1  0.26405646  0.10972015  0.33613560  1
+  C  C13  1  0.18759957  0.32482170  0.27898454  1
+  C  C14  1  -0.03498737  0.29953414  0.70281804  1
+  C  C15  1  0.32032501  0.88592148  0.83561908  1
+",-154.11877
+1593,C-73639-7493-53,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44894000
+_cell_length_b   6.82897000
+_cell_length_c   8.86916000
+_cell_angle_alpha   54.60194000
+_cell_angle_beta   73.88827000
+_cell_angle_gamma   79.62090000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   116.12251757
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40258282  0.71785639  0.54982946  1
+  C  C1  1  0.44529588  0.90251183  -0.08129406  1
+  C  C2  1  0.02060142  0.27746141  1.15819648  1
+  C  C3  1  0.36180875  -0.00237878  0.45603256  1
+  C  C4  1  0.60152616  0.00264760  0.71432723  1
+  C  C5  1  0.87350455  0.86337257  1.01023006  1
+  C  C6  1  0.91269221  0.11157711  0.34816989  1
+  C  C7  1  -0.28330473  0.77659669  0.20440455  1
+  C  C8  1  1.03275051  0.37895685  0.59068967  1
+  C  C9  1  0.14531599  0.73777807  0.29572992  1
+  C  C10  1  0.55674844  0.26393219  0.62498788  1
+  C  C11  1  1.19162510  -0.07337926  0.66291782  1
+  C  C12  1  0.23471889  0.64693308  0.75658942  1
+  C  C13  1  0.68578798  0.53223506  0.86402878  1
+  C  C14  1  0.58114854  0.36450964  1.05370965  1
+  C  C15  1  0.99135909  0.64069954  0.49944149  1
+",-154.26708125
+4303,C-9606-4988-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48510000
+_cell_length_b   4.68190000
+_cell_length_c   4.08612000
+_cell_angle_alpha   96.67274000
+_cell_angle_beta   90.00954000
+_cell_angle_gamma   74.58770000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.49838543
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70497607  0.67569455  0.66239279  1
+  C  C1  1  0.76243594  0.56048001  0.30657129  1
+  C  C2  1  0.43517698  0.21721437  0.60025270  1
+  C  C3  1  0.21881876  0.64621229  0.13585971  1
+  C  C4  1  0.04776248  0.98714833  0.06855076  1
+  C  C5  1  0.54683443  0.98924077  0.84181319  1
+  C  C6  1  0.27809633  0.53072619  0.78025530  1
+  C  C7  1  -0.06602379  0.21960209  0.37439306  1
+",-154.37097375
+628,C-73615-2489-55,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48435000
+_cell_length_b   3.82321000
+_cell_length_c   5.78594000
+_cell_angle_alpha   89.99396000
+_cell_angle_beta   115.49084000
+_cell_angle_gamma   71.04181000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.28092443
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55221701  0.72122266  0.56667251  1
+  C  C1  1  0.27082327  0.49852019  0.67312747  1
+  C  C2  1  0.59758546  0.74085166  1.12205930  1
+  C  C3  1  0.61052056  0.39149890  0.95949873  1
+  C  C4  1  0.28297278  0.14905787  0.51059260  1
+  C  C5  1  0.30947218  0.64666517  0.28710595  1
+  C  C6  1  0.32767520  0.16933995  1.06576217  1
+  C  C7  1  0.57013414  0.24313981  0.34537376  1
+",-154.2202075
+7723,C-101135-8572-66,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47972000
+_cell_length_b   6.13672000
+_cell_length_c   8.44476000
+_cell_angle_alpha   68.02675000
+_cell_angle_beta   76.56602000
+_cell_angle_gamma   68.81960000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   110.41826681
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.49186954  0.89755637  0.27417277  1
+  C  C1  1  0.47253365  0.46824585  0.90646429  1
+  C  C2  1  1.10448297  0.33009509  0.86840924  1
+  C  C3  1  -0.15864634  0.88963197  -0.04052298  1
+  C  C4  1  0.28173116  -0.02941383  0.43691184  1
+  C  C5  1  0.75678946  -0.09194712  0.53727026  1
+  C  C6  1  0.16311195  0.76752063  0.80840916  1
+  C  C7  1  0.78386189  0.38839379  0.59453950  1
+  C  C8  1  0.86294222  0.64134536  0.10249269  1
+  C  C9  1  0.86502297  0.43804960  0.40868791  1
+  C  C10  1  1.18633346  1.03998234  0.98152709  1
+  C  C11  1  0.48536858  0.49611023  0.07926643  1
+  C  C12  1  0.24656810  0.36219341  0.67989453  1
+  C  C13  1  0.69101527  0.82823894  0.70705283  1
+  C  C14  1  0.10898257  0.24098717  0.33252385  1
+  C  C15  1  0.67434894  0.26190139  0.21920723  1
+  C  C16  1  0.71187477  0.64749217  0.28106275  1
+  C  C17  1  0.96804534  0.02615105  0.17434783  1
+",-154.12216999999998
+1309,C-90863-258-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42774000
+_cell_length_b   6.02811000
+_cell_length_c   5.71094000
+_cell_angle_alpha   41.66378000
+_cell_angle_beta   77.54088000
+_cell_angle_gamma   78.27273000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   54.13650390
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.11932294  0.12278403  0.53016378  1
+  C  C1  1  0.79087346  0.36155822  -0.05197170  1
+  C  C2  1  0.09406080  0.49125209  0.21186458  1
+  C  C3  1  0.33476393  0.20231631  1.01961690  1
+  C  C4  1  0.96008870  0.71721553  0.25227000  1
+  C  C5  1  0.63309089  0.95519870  0.66819597  1
+  C  C6  1  0.65751990  0.58758403  -0.01182773  1
+  C  C7  1  0.41656527  -0.12337230  0.18003801  1
+",-154.1752975
+4258,C-189742-1338-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48531000
+_cell_length_b   5.69768000
+_cell_length_c   5.12733000
+_cell_angle_alpha   110.85860000
+_cell_angle_beta   89.95598000
+_cell_angle_gamma   115.88437000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   59.99855906
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17533187  0.90272520  0.29179732  1
+  C  C1  1  0.39752591  0.62681237  0.83672004  1
+  C  C2  1  0.66735710  0.89501125  0.10467458  1
+  C  C3  1  0.08396088  0.31298460  0.41900213  1
+  C  C4  1  0.48559847  0.21503294  0.51649503  1
+  C  C5  1  0.93199947  0.65961480  0.37845247  1
+  C  C6  1  0.39430837  0.62281851  0.52983133  1
+  C  C7  1  0.62552927  0.35402482  0.07240223  1
+  C  C8  1  0.71137542  0.44034563  0.82911168  1
+  C  C9  1  0.97377363  0.20259129  0.10886089  1
+",-154.144838
+6731,C-57142-7457-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.10889000
+_cell_length_b   5.17100000
+_cell_length_c   3.32472000
+_cell_angle_alpha   82.50147000
+_cell_angle_beta   102.87024000
+_cell_angle_gamma   120.96663000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   59.03953890
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.35102698  0.75915433  0.95062886  1
+  C  C1  1  1.03548733  0.44914788  -0.05391298  1
+  C  C2  1  0.72002159  0.89514375  0.18263666  1
+  C  C3  1  -0.15142617  0.73388722  0.47230366  1
+  C  C4  1  0.03464527  0.20547281  0.18691558  1
+  C  C5  1  0.35300250  0.21091923  0.49847197  1
+  C  C6  1  0.71858267  0.44374350  0.63295855  1
+  C  C7  1  0.22336583  -0.07975692  0.65765038  1
+",-154.2021475
+7478,C-76016-983-55,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.39843000
+_cell_length_b   3.25864000
+_cell_length_c   4.66550000
+_cell_angle_alpha   110.10791000
+_cell_angle_beta   89.99733000
+_cell_angle_gamma   89.99867000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.51769305
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.14203754  0.77966729  0.13003882  1
+  C  C1  1  0.47160286  0.13384333  0.14174482  1
+  C  C2  1  0.47163027  0.14042911  0.79766333  1
+  C  C3  1  0.14229801  0.49321718  0.80892075  1
+  C  C4  1  0.85539484  0.14063704  0.29768018  1
+  C  C5  1  0.18477356  0.49343287  0.30890260  1
+  C  C6  1  0.85548077  1.13371265  0.64177340  1
+  C  C7  1  0.18506455  0.77946013  0.63004399  1
+",-154.139915
+2299,C-92111-7590-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43191000
+_cell_length_b   3.95964000
+_cell_length_c   4.68163000
+_cell_angle_alpha   84.29499000
+_cell_angle_beta   105.55702000
+_cell_angle_gamma   89.69127000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.19081461
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.66501838  0.61608245  0.65047685  1
+  C  C1  1  -0.00081823  0.28066296  0.31842763  1
+  C  C2  1  0.88562191  0.06288927  0.09376722  1
+  C  C3  1  0.33125604  0.95011456  0.98326574  1
+  C  C4  1  0.21952625  -0.27196715  0.76135253  1
+  C  C5  1  0.55366856  0.39260082  0.42941222  1
+",-154.4616835
+4540,C-130516-3871-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.54904000
+_cell_length_b   2.43780000
+_cell_length_c   6.91334000
+_cell_angle_alpha   70.12394000
+_cell_angle_beta   99.99125000
+_cell_angle_gamma   87.66755000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.55689206
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.44418671  0.21429083  0.02652462  1
+  C  C1  1  0.60910316  0.38812590  0.35609022  1
+  C  C2  1  0.55516410  -0.00521258  0.24825649  1
+  C  C3  1  0.39193340  0.82050902  -0.08114765  1
+  C  C4  1  0.72436229  0.15831355  0.58550564  1
+  C  C5  1  0.27782754  0.05119677  0.68949678  1
+",-154.07366316666665
+1130,C-107758-6639-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.69562000
+_cell_length_b   4.68937000
+_cell_length_c   4.52646000
+_cell_angle_alpha   85.34958000
+_cell_angle_beta   105.09404000
+_cell_angle_gamma   74.25352000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.45696549
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.02722316  0.16550604  0.49120185  1
+  C  C1  1  0.36903525  0.88641559  -0.02584846  1
+  C  C2  1  0.77342796  0.31176647  0.16784345  1
+  C  C3  1  -0.05295175  0.64820229  0.52071290  1
+  C  C4  1  0.67318671  0.64497869  0.20137278  1
+  C  C5  1  0.26815657  0.21961436  1.00775917  1
+  C  C6  1  0.09709586  0.88182908  0.65451534  1
+  C  C7  1  1.07107625  0.36411878  0.68383337  1
+",-154.07555
+6457,C-142757-9743-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.42055000
+_cell_length_b   4.80269000
+_cell_length_c   3.42617000
+_cell_angle_alpha   108.68859000
+_cell_angle_beta   91.03819000
+_cell_angle_gamma   108.64322000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   50.06153228
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.75531510  0.08635819  -0.02573751  1
+  C  C1  1  0.93462656  0.73135970  0.50538632  1
+  C  C2  1  0.61058911  0.73133307  0.82935611  1
+  C  C3  1  0.25518850  0.58627932  0.47434558  1
+  C  C4  1  0.11072072  0.23127584  0.32924996  1
+  C  C5  1  0.08023758  0.08638590  0.64940937  1
+  C  C6  1  0.43475165  0.23143149  1.00528631  1
+  C  C7  1  0.58012328  0.58644738  0.14951486  1
+",-154.1128075
+761,C-172943-9308-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48766000
+_cell_length_b   2.48728000
+_cell_length_c   6.09128000
+_cell_angle_alpha   89.99021000
+_cell_angle_beta   89.99485000
+_cell_angle_gamma   60.00163000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.64089230
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.04441202  0.85158008  0.52156834  1
+  C  C1  1  0.71107869  0.51824674  0.18823501  1
+  C  C2  1  0.37791585  0.18489986  0.60510459  1
+  C  C3  1  0.71124918  0.51823319  -0.06156207  1
+  C  C4  1  0.37774535  0.18491341  0.85490167  1
+  C  C5  1  0.04458251  -0.14843348  0.27177126  1
+",-154.54631716666668
+3324,C-41276-8743-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47765000
+_cell_length_b   2.47837000
+_cell_length_c   6.31089000
+_cell_angle_alpha   89.99184000
+_cell_angle_beta   101.33657000
+_cell_angle_gamma   120.03429000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.67318658
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36019530  -0.04283104  -0.10004019  1
+  C  C1  1  -0.08688229  0.73311473  0.23123300  1
+  C  C2  1  0.30210940  0.42842927  0.31459767  1
+  C  C3  1  0.19258111  0.87550586  0.64900020  1
+  C  C4  1  0.46998569  0.51421288  0.56546515  1
+  C  C5  1  0.74904029  0.65075850  0.98360087  1
+",-154.525705
+3461,C-130518-7047-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44630000
+_cell_length_b   4.56651000
+_cell_length_c   6.24455000
+_cell_angle_alpha   87.90663000
+_cell_angle_beta   78.64242000
+_cell_angle_gamma   105.53154000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   65.59983329
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.85320832  0.43595275  0.64919470  1
+  C  C1  1  0.04482669  1.01558042  0.83828387  1
+  C  C2  1  0.43115426  0.16572700  0.22542704  1
+  C  C3  1  0.63633569  0.68703670  0.33482953  1
+  C  C4  1  0.63870718  0.48476742  0.12295499  1
+  C  C5  1  0.24699270  0.34896375  0.77213108  1
+  C  C6  1  1.03202922  0.60013007  0.45681484  1
+  C  C7  1  0.24204422  0.55049020  0.98254132  1
+  C  C8  1  0.45376927  0.86967338  0.88037564  1
+  C  C9  1  0.83937685  0.02059561  0.26955598  1
+",-154.231707
+5724,C-106857-1903-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47364000
+_cell_length_b   4.80276000
+_cell_length_c   4.80293000
+_cell_angle_alpha   52.93145000
+_cell_angle_beta   75.07918000
+_cell_angle_gamma   75.07178000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.60431773
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.24857053  0.65477766  0.26177949  1
+  C  C1  1  1.18628304  0.05117341  0.99120502  1
+  C  C2  1  -0.25142947  0.15477766  0.76177949  1
+  C  C3  1  0.99865461  0.23814561  0.17840875  1
+  C  C4  1  0.68628304  0.55117341  0.49120502  1
+  C  C5  1  0.49865461  0.73814561  0.67840875  1
+  C  C6  1  0.43619896  0.46780546  0.07457576  1
+  C  C7  1  -0.06380104  0.96780546  0.57457576  1
+",-154.519375
+9771,C-170902-8935-55,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43107000
+_cell_length_b   4.20474000
+_cell_length_c   6.14843000
+_cell_angle_alpha   65.73367000
+_cell_angle_beta   87.95762000
+_cell_angle_gamma   89.93635000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.25358125
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.72265117  0.63818159  0.61499503  1
+  C  C1  1  0.80351829  0.63099708  0.11566052  1
+  C  C2  1  0.80344638  -0.03700508  0.11698405  1
+  C  C3  1  0.22257926  0.47017943  0.61631856  1
+  C  C4  1  0.22265117  0.13818159  0.61499503  1
+  C  C5  1  0.30344638  0.46299492  0.11698405  1
+  C  C6  1  0.72257926  -0.02982057  0.61631856  1
+  C  C7  1  0.30351829  1.13099708  0.11566052  1
+",-154.4546375
+8998,C-9632-1856-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48447000
+_cell_length_b   4.08577000
+_cell_length_c   4.67890000
+_cell_angle_alpha   96.66507000
+_cell_angle_beta   105.39543000
+_cell_angle_gamma   90.00701000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.45787711
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.05715621  1.13191964  0.95644082  1
+  C  C1  1  0.90045541  -0.04821143  0.64250126  1
+  C  C2  1  0.84432582  0.59586056  0.52665737  1
+  C  C3  1  0.32866777  0.07061214  0.49811596  1
+  C  C4  1  0.55614191  0.35878289  0.95398573  1
+  C  C5  1  0.67485061  0.66498103  0.18628093  1
+  C  C6  1  0.38632698  0.42604087  0.61243862  1
+  C  C7  1  0.17367170  0.88991730  1.18424782  1
+",-154.36568875
+9215,C-96696-5300-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48763000
+_cell_length_b   3.51630000
+_cell_length_c   4.30545000
+_cell_angle_alpha   65.90522000
+_cell_angle_beta   73.17821000
+_cell_angle_gamma   90.00482000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.60578828
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.59014665  0.73445188  0.02253553  1
+  C  C1  1  0.25681332  0.40111855  0.68920220  1
+  C  C2  1  0.75677895  0.65062812  0.68944410  1
+  C  C3  1  0.42344561  0.31729479  0.35611077  1
+  C  C4  1  1.09011228  -0.01603855  0.02277743  1
+  C  C5  1  -0.07652001  0.06778521  0.35586887  1
+",-154.54412833333333
+7942,C-76008-2415-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48570000
+_cell_length_b   5.30056000
+_cell_length_c   4.06393000
+_cell_angle_alpha   104.08461000
+_cell_angle_beta   90.06435000
+_cell_angle_gamma   117.76133000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.54647957
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.32784888  0.86875441  0.74058651  1
+  C  C1  1  0.10393090  0.64468426  0.94261198  1
+  C  C2  1  0.59917012  0.63969564  0.16820659  1
+  C  C3  1  0.79445420  0.33682958  0.71091702  1
+  C  C4  1  0.63521409  0.17703469  0.97483569  1
+  C  C5  1  0.24989007  0.29228271  0.17632776  1
+  C  C6  1  0.18056029  0.22261859  0.50952903  1
+  C  C7  1  -0.16680704  0.87420313  0.51644272  1
+",-154.3606025
+4831,C-176683-1873-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.22181000
+_cell_length_b   3.64291000
+_cell_length_c   4.26956000
+_cell_angle_alpha   63.08212000
+_cell_angle_beta   101.27342000
+_cell_angle_gamma   91.90540000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.73195628
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.06869359  0.81920620  0.73848980  1
+  C  C1  1  0.76301247  0.47364785  0.43064485  1
+  C  C2  1  0.26108975  0.41330224  0.93141620  1
+  C  C3  1  0.57099971  0.26016847  0.23720944  1
+  C  C4  1  0.76335463  0.85424975  0.43006197  1
+  C  C5  1  0.06900275  0.19965669  0.73812775  1
+",-154.14322983333332
+1161,C-113050-8539-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.70239000
+_cell_length_b   4.45988000
+_cell_length_c   4.28218000
+_cell_angle_alpha   68.71119000
+_cell_angle_beta   97.12985000
+_cell_angle_gamma   61.19894000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   53.72212476
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71029116  0.76744424  0.34210087  1
+  C  C1  1  0.57277062  0.48910029  0.42072270  1
+  C  C2  1  0.17425980  0.78917948  0.75992840  1
+  C  C3  1  0.36280344  0.14383768  1.17678480  1
+  C  C4  1  0.11935894  0.75734957  0.42312640  1
+  C  C5  1  0.90037765  0.12143447  0.75896323  1
+  C  C6  1  0.95456092  0.15308599  0.09582301  1
+  C  C7  1  0.50125019  0.42160638  0.09812389  1
+",-154.08737625
+7343,C-172947-5402-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.68983000
+_cell_length_b   2.48186000
+_cell_length_c   4.84698000
+_cell_angle_alpha   104.85416000
+_cell_angle_beta   68.40515000
+_cell_angle_gamma   70.34760000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.01382387
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.17164763  1.18945765  1.12059552  1
+  C  C1  1  0.48544241  0.21166563  0.82325019  1
+  C  C2  1  0.30172985  0.91443664  0.04550887  1
+  C  C3  1  0.95895572  0.93756725  0.74788525  1
+  C  C4  1  0.24693765  0.22758925  0.61677700  1
+  C  C5  1  0.54067480  0.89808898  0.25166737  1
+",-154.31155049999998
+7759,C-40128-4097-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42575000
+_cell_length_b   4.21814000
+_cell_length_c   5.96349000
+_cell_angle_alpha   135.02559000
+_cell_angle_beta   90.13220000
+_cell_angle_gamma   89.92705000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.12779553
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.14272237  -0.16961235  1.05356395  1
+  C  C1  1  0.14250021  1.23797725  0.40156463  1
+  C  C2  1  0.64256748  0.64591399  0.89775046  1
+  C  C3  1  0.14280433  0.64615408  0.46198591  1
+  C  C4  1  0.64306536  0.23794764  0.54983439  1
+  C  C5  1  0.64287225  0.83006838  0.48981535  1
+",-154.31029883333335
+7997,C-41318-6901-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.22849000
+_cell_length_b   2.46910000
+_cell_length_c   5.19132000
+_cell_angle_alpha   89.99833000
+_cell_angle_beta   89.86603000
+_cell_angle_gamma   112.45388000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   38.24498590
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.09033785  0.92954200  0.38902067  1
+  C  C1  1  0.08837034  0.42837763  0.98031153  1
+  C  C2  1  0.45043593  0.60993360  0.76111129  1
+  C  C3  1  0.72710585  0.24755133  0.76126689  1
+  C  C4  1  0.08857406  0.92848358  0.13302520  1
+  C  C5  1  0.09032407  0.42953876  0.54171382  1
+",-154.25794249999998
+2789,C-34606-3915-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.79072000
+_cell_length_b   2.98210000
+_cell_length_c   4.41410000
+_cell_angle_alpha   112.87889000
+_cell_angle_beta   95.49291000
+_cell_angle_gamma   73.17960000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   55.60467639
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17189648  0.54670894  0.72456840  1
+  C  C1  1  0.94541245  0.63771483  0.22394965  1
+  C  C2  1  0.94834664  0.50677736  0.87308368  1
+  C  C3  1  0.68846360  0.39466782  0.71136709  1
+  C  C4  1  0.43331624  1.03424194  0.21127684  1
+  C  C5  1  0.68732792  0.01898596  0.38716851  1
+  C  C6  1  0.17499500  0.41675554  0.37371153  1
+  C  C7  1  0.43251518  0.65534051  -0.11239940  1
+",-154.11262625
+8997,C-113050-8539-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48431000
+_cell_length_b   4.08914000
+_cell_length_c   4.67476000
+_cell_angle_alpha   96.68910000
+_cell_angle_beta   74.58322000
+_cell_angle_gamma   89.99211000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.44502502
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.19751526  0.88758949  0.46998003  1
+  C  C1  1  0.92758954  0.82612695  0.01115291  1
+  C  C2  1  0.58118614  0.42033117  0.69845478  1
+  C  C3  1  0.86817252  0.18164245  0.12610802  1
+  C  C4  1  0.69827590  0.11420125  0.46800213  1
+  C  C5  1  0.35569512  0.70810342  0.15508755  1
+  C  C6  1  0.41009461  0.35237401  0.04021685  1
+  C  C7  1  0.08269361  0.64513657  0.69624463  1
+",-154.3652125
+1652,C-80168-1847-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46826000
+_cell_length_b   4.26004000
+_cell_length_c   6.53308000
+_cell_angle_alpha   103.03863000
+_cell_angle_beta   79.13240000
+_cell_angle_gamma   89.99909000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   65.65824527
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.13704126  0.66273099  0.99573366  1
+  C  C1  1  0.27439812  0.01264932  0.75572111  1
+  C  C2  1  0.85877429  0.52032465  0.75520080  1
+  C  C3  1  0.45961102  0.19993777  0.10495703  1
+  C  C4  1  0.06084028  0.70840811  0.34593083  1
+  C  C5  1  0.82650256  0.15701963  0.67622212  1
+  C  C6  1  0.50811032  0.57369518  0.43124754  1
+  C  C7  1  0.30694705  0.56554727  0.10516525  1
+  C  C8  1  0.38927458  0.65482009  0.66956624  1
+  C  C9  1  0.47708565  0.21658826  0.34517866  1
+  C  C10  1  1.01516372  0.02833814  -0.00451524  1
+  C  C11  1  0.95179526  0.07127819  0.42397391  1
+",-154.29989
+360,C-13937-9715-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42434000
+_cell_length_b   4.84717000
+_cell_length_c   4.20094000
+_cell_angle_alpha   92.06587000
+_cell_angle_beta   89.99214000
+_cell_angle_gamma   120.05028000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.69363294
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.13693467  0.91040830  0.96844388  1
+  C  C1  1  0.72843611  0.50464088  0.37479397  1
+  C  C2  1  0.72866032  0.00378284  0.46790532  1
+  C  C3  1  0.67007981  -0.05734357  0.81425166  1
+  C  C4  1  0.07633607  0.85125064  0.31506013  1
+  C  C5  1  0.07408251  0.35062400  0.40896413  1
+",-154.28811199999998
+2369,C-13691-2934-59,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49423000
+_cell_length_b   3.42074000
+_cell_length_c   7.20663000
+_cell_angle_alpha   61.77737000
+_cell_angle_beta   80.00348000
+_cell_angle_gamma   68.59959000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   50.44247600
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71738232  0.98260078  0.49990234  1
+  C  C1  1  -0.09537824  0.21046122  0.89432165  1
+  C  C2  1  0.12909692  0.81805414  0.83944305  1
+  C  C3  1  0.90704927  0.76328727  0.33916756  1
+  C  C4  1  0.31980087  0.04271501  0.23368803  1
+  C  C5  1  0.31736642  0.27868084  0.99980927  1
+  C  C6  1  0.13099447  0.26122209  0.39453425  1
+  C  C7  1  0.71623497  0.74986634  0.73375625  1
+",-154.08711125
+2374,C-170888-2365-60,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47589000
+_cell_length_b   4.18359000
+_cell_length_c   4.79151000
+_cell_angle_alpha   64.12831000
+_cell_angle_beta   89.99780000
+_cell_angle_gamma   89.99359000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   44.65664105
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.16945188  1.11502925  0.42375414  1
+  C  C1  1  0.66956938  0.50139151  0.91155273  1
+  C  C2  1  0.66938326  0.69200175  0.26946797  1
+  C  C3  1  1.16921562  0.07837716  0.75763222  1
+  C  C4  1  0.66923696  0.87156279  0.91221925  1
+  C  C5  1  0.16939009  0.74432278  0.42469446  1
+  C  C6  1  0.66944330  0.32221695  0.26861324  1
+  C  C7  1  0.16946381  0.44801252  0.75785639  1
+",-154.40108125
+5289,C-134219-5441-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51614000
+_cell_length_b   5.05449000
+_cell_length_c   3.94114000
+_cell_angle_alpha   88.23298000
+_cell_angle_beta   99.88726000
+_cell_angle_gamma   110.90966000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.10111524
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.02899531  0.32799068  0.05304093  1
+  C  C1  1  -0.07370495  0.04394216  0.23778952  1
+  C  C2  1  0.90370131  0.54113083  0.52322864  1
+  C  C3  1  0.24888430  0.80120617  0.72675297  1
+  C  C4  1  0.81134137  0.29887723  0.68265457  1
+  C  C5  1  0.78801726  0.79612518  0.96799113  1
+  C  C6  1  0.68555760  0.51220748  0.15349898  1
+  C  C7  1  0.46549140  0.03882786  0.47884216  1
+",-154.128595
+1174,C-13913-1160-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50922000
+_cell_length_b   5.57203000
+_cell_length_c   4.67509000
+_cell_angle_alpha   84.38590000
+_cell_angle_beta   90.01136000
+_cell_angle_gamma   63.24013000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.01208588
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.18504010  0.20923287  0.12099710  1
+  C  C1  1  0.64280380  0.25102250  0.93977860  1
+  C  C2  1  0.44287176  0.95295405  0.61165610  1
+  C  C3  1  0.78038424  0.11522513  0.66434526  1
+  C  C4  1  0.36232111  0.53279180  0.76879393  1
+  C  C5  1  0.70132576  0.69466789  0.82071542  1
+  C  C6  1  0.45893923  0.93518431  0.28911551  1
+  C  C7  1  -0.04392146  0.43895371  0.31182990  1
+  C  C8  1  0.49785044  0.39670976  0.49291055  1
+  C  C9  1  0.68204951  0.71411546  0.14388074  1
+",-154.239245
+9501,C-90800-1393-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42864000
+_cell_length_b   5.20533000
+_cell_length_c   5.86008000
+_cell_angle_alpha   53.70889000
+_cell_angle_beta   89.59277000
+_cell_angle_gamma   89.77441000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   59.71038204
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.31745092  0.46883754  0.25536368  1
+  C  C1  1  -0.18263389  0.96899277  0.00543964  1
+  C  C2  1  0.81762700  0.96899234  0.50537454  1
+  C  C3  1  0.81751551  0.63529091  0.17222465  1
+  C  C4  1  0.81770952  0.63528035  0.67216778  1
+  C  C5  1  0.31759562  0.46884615  0.75530038  1
+  C  C6  1  0.31738803  0.13544101  0.92191718  1
+  C  C7  1  0.31761068  0.13545495  0.42189305  1
+",-154.41119875
+2851,C-113056-5626-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.28993000
+_cell_length_b   3.28464000
+_cell_length_c   4.79903000
+_cell_angle_alpha   107.28650000
+_cell_angle_beta   73.06255000
+_cell_angle_gamma   81.88903000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.87424019
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.19003500  0.37155179  0.23302653  1
+  C  C1  1  0.82964070  0.23221821  0.73298358  1
+  C  C2  1  0.82960727  0.73206884  0.23300640  1
+  C  C3  1  0.46827594  0.05173665  0.91352117  1
+  C  C4  1  0.82939925  0.69173052  0.91355703  1
+  C  C5  1  0.19003406  0.87168041  0.73302853  1
+  C  C6  1  0.46826499  0.55156496  0.41355818  1
+  C  C7  1  0.82943739  1.19154632  0.41353998  1
+",-154.33352875
+2086,C-142767-8046-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43026000
+_cell_length_b   4.67909000
+_cell_length_c   8.72607000
+_cell_angle_alpha   111.68069000
+_cell_angle_beta   96.77727000
+_cell_angle_gamma   105.94672000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   85.94243434
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.48650711  0.24898228  0.96337757  1
+  C  C1  1  0.15328013  0.24898310  0.29668668  1
+  C  C2  1  0.54277066  0.08281117  0.24015324  1
+  C  C3  1  0.82021670  0.24906501  0.62992292  1
+  C  C4  1  -0.29055862  0.58251982  0.07430328  1
+  C  C5  1  1.20973797  1.08289801  0.57337353  1
+  C  C6  1  0.37643461  0.58257513  0.40756634  1
+  C  C7  1  -0.12393315  0.08284114  0.90680616  1
+  C  C8  1  0.65321873  0.74914656  0.79619092  1
+  C  C9  1  0.04307847  0.58261407  0.74085731  1
+  C  C10  1  0.31959806  0.74906259  0.12961792  1
+  C  C11  1  0.98663863  0.74914971  0.46285435  1
+",-154.44205916666667
+9600,C-152581-906-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46018000
+_cell_length_b   4.15719000
+_cell_length_c   6.11189000
+_cell_angle_alpha   81.18022000
+_cell_angle_beta   65.72296000
+_cell_angle_gamma   87.65907000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.29030838
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.05607971  0.95643618  0.78161504  1
+  C  C1  1  0.00346085  0.30259906  0.65602588  1
+  C  C2  1  0.79882090  -0.01962683  0.41368788  1
+  C  C3  1  0.18294476  0.82546200  0.17826628  1
+  C  C4  1  0.39523710  0.45571948  0.74621039  1
+  C  C5  1  0.81528602  -0.02330076  0.04330334  1
+  C  C6  1  0.34137823  0.45442544  0.16425238  1
+  C  C7  1  0.53322581  0.81229180  0.67980069  1
+  C  C8  1  0.25040367  0.21429677  0.40352965  1
+  C  C9  1  0.98540105  0.35472037  0.02716839  1
+",-154.113198
+8873,C-130505-1819-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43110000
+_cell_length_b   3.60567000
+_cell_length_c   5.86398000
+_cell_angle_alpha   98.47408000
+_cell_angle_beta   83.74924000
+_cell_angle_gamma   120.76725000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.65128538
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.18758370  0.07888274  0.12302577  1
+  C  C1  1  0.52088013  0.74551085  0.78970600  1
+  C  C2  1  0.07484189  0.85594247  0.90199294  1
+  C  C3  1  -0.25848533  0.18927979  0.23532365  1
+  C  C4  1  0.85420734  0.41217353  0.45637529  1
+  C  C5  1  0.40813832  0.52257058  0.56867317  1
+",-154.45865733333332
+5220,C-126157-7089-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.07756000
+_cell_length_b   2.42983000
+_cell_length_c   5.88374000
+_cell_angle_alpha   101.29663000
+_cell_angle_beta   85.53736000
+_cell_angle_gamma   88.71635000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.98317963
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.68499886  0.30882763  0.03676049  1
+  C  C1  1  0.24094614  0.53188441  0.48187468  1
+  C  C2  1  0.57433979  0.86521454  0.14855783  1
+  C  C3  1  0.35153845  -0.02452063  0.37005087  1
+  C  C4  1  0.90772705  0.19856592  0.81525733  1
+  C  C5  1  0.01830580  0.64215723  0.70342690  1
+",-154.46006916666667
+8390,C-76028-1827-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47570000
+_cell_length_b   4.79262000
+_cell_length_c   4.18403000
+_cell_angle_alpha   64.10911000
+_cell_angle_beta   90.00130000
+_cell_angle_gamma   90.00095000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   44.66099443
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.05761641  0.71790152  0.31542142  1
+  C  C1  1  0.05770608  0.05167894  0.27855238  1
+  C  C2  1  0.05789174  0.05174445  0.64830479  1
+  C  C3  1  1.05771595  0.71837579  0.94516870  1
+  C  C4  1  0.55763467  0.56282809  0.52269423  1
+  C  C5  1  0.55769349  0.20614934  1.07175525  1
+  C  C6  1  0.55791290  0.20602894  0.70130324  1
+  C  C7  1  0.55762396  0.56321783  0.89271339  1
+",-154.406525
+6440,C-170900-9651-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48368000
+_cell_length_b   5.01010000
+_cell_length_c   4.05185000
+_cell_angle_alpha   113.92391000
+_cell_angle_beta   101.02240000
+_cell_angle_gamma   85.48819000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.23713347
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.31588687  0.58839929  0.05501399  1
+  C  C1  1  0.45121849  0.30453668  0.10268862  1
+  C  C2  1  -0.04811476  1.11277206  1.00714117  1
+  C  C3  1  0.76416398  0.58839698  0.82421070  1
+  C  C4  1  1.13016271  0.11262194  0.39637105  1
+  C  C5  1  0.62952002  0.30437313  0.49195867  1
+  C  C6  1  0.26504506  0.82878849  0.44403147  1
+  C  C7  1  0.81669803  0.82880992  0.67492522  1
+",-154.06855125
+6665,C-73663-9884-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.53754000
+_cell_length_b   4.26006000
+_cell_length_c   5.28454000
+_cell_angle_alpha   113.76439000
+_cell_angle_beta   103.98540000
+_cell_angle_gamma   90.03727000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   50.42266009
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71124551  0.84930900  0.81205947  1
+  C  C1  1  0.44649096  0.23934769  0.27958391  1
+  C  C2  1  0.44655200  0.56208449  0.27964261  1
+  C  C3  1  0.71150271  0.48476927  0.81204537  1
+  C  C4  1  0.56721726  0.18530508  0.52465537  1
+  C  C5  1  0.28710766  0.05491207  -0.04013633  1
+  C  C6  1  0.28723226  0.42728662  0.95994642  1
+  C  C7  1  0.56725834  0.86126407  0.52469908  1
+",-154.10348
+9682,C-34663-3579-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43189000
+_cell_length_b   5.41439000
+_cell_length_c   8.46414000
+_cell_angle_alpha   131.22217000
+_cell_angle_beta   98.12290000
+_cell_angle_gamma   90.02413000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   82.32917417
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.91056925  0.29468257  0.60504780  1
+  C  C1  1  0.60448376  0.41763170  0.98642638  1
+  C  C2  1  0.35921835  0.16012827  0.50128468  1
+  C  C3  1  0.53394472  0.04278601  0.83796185  1
+  C  C4  1  0.02418331  0.62185621  0.82600188  1
+  C  C5  1  0.69989199  0.96988364  0.18763570  1
+  C  C6  1  0.72103987  0.28700537  0.24088635  1
+  C  C7  1  0.02309201  -0.10603275  0.81535911  1
+  C  C8  1  0.21818380  0.40345370  0.23406619  1
+  C  C9  1  0.23857087  0.91624005  0.26585545  1
+  C  C10  1  0.17510406  0.54468929  0.13291452  1
+  C  C11  1  0.58162502  0.65521135  0.94388758  1
+",-154.20364833333335
+7782,C-57165-511-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.31283000
+_cell_length_b   3.29240000
+_cell_length_c   5.22330000
+_cell_angle_alpha   64.40042000
+_cell_angle_beta   94.95949000
+_cell_angle_gamma   79.74066000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.69285753
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.81927865  0.33045707  0.29782840  1
+  C  C1  1  0.04168256  0.40384373  0.75670604  1
+  C  C2  1  0.27415708  0.03357362  0.01264252  1
+  C  C3  1  0.71594392  0.73099543  0.75696976  1
+  C  C4  1  0.49821923  1.10818430  0.47144194  1
+  C  C5  1  0.18179911  0.96701543  0.29764619  1
+  C  C6  1  0.59993114  0.70659920  1.01255182  1
+  C  C7  1  0.13551421  0.47169512  0.47158923  1
+",-154.22154
+822,C-193911-8410-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.25291000
+_cell_length_b   3.28417000
+_cell_length_c   3.63203000
+_cell_angle_alpha   75.41679000
+_cell_angle_beta   75.61491000
+_cell_angle_gamma   80.90152000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.18444310
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70885009  0.60468542  0.45046493  1
+  C  C1  1  0.34708634  -0.03339506  0.44970729  1
+  C  C2  1  0.76517688  0.33941947  0.83165069  1
+  C  C3  1  0.13574569  0.75411551  0.21172235  1
+  C  C4  1  0.49612204  0.39315626  0.21254412  1
+  C  C5  1  0.08114707  0.02175400  0.83074131  1
+",-154.19557583333332
+3277,C-130561-7361-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47333000
+_cell_length_b   4.91679000
+_cell_length_c   4.64543000
+_cell_angle_alpha   85.38642000
+_cell_angle_beta   86.17191000
+_cell_angle_gamma   81.94006000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   55.66489704
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.10125369  0.97332746  0.97913425  1
+  C  C1  1  0.67877272  0.38770033  0.80350503  1
+  C  C2  1  0.67927119  0.64369091  0.31736196  1
+  C  C3  1  0.56199696  0.88340304  0.51630850  1
+  C  C4  1  0.14058910  0.55445741  0.85455801  1
+  C  C5  1  1.06649038  0.84083222  0.69621669  1
+  C  C6  1  0.56306221  0.14022504  1.03021881  1
+  C  C7  1  0.42501459  0.18402940  0.36389190  1
+  C  C8  1  -0.18368098  0.34332054  0.46997037  1
+  C  C9  1  0.17480173  0.68640285  0.13759508  1
+",-154.177402
+1301,C-28234-2764-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43719000
+_cell_length_b   4.22917000
+_cell_length_c   6.53217000
+_cell_angle_alpha   95.25495000
+_cell_angle_beta   79.20859000
+_cell_angle_gamma   89.99418000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   65.85006608
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.14948900  0.75590541  0.24197688  1
+  C  C1  1  0.32455235  0.11258738  0.87772458  1
+  C  C2  1  0.81285750  0.62539135  0.90948707  1
+  C  C3  1  0.81782377  0.27187374  0.89222043  1
+  C  C4  1  0.52776788  0.35970230  0.50451648  1
+  C  C5  1  0.48962581  0.70755994  0.56836242  1
+  C  C6  1  0.36202661  0.76533865  0.81387221  1
+  C  C7  1  0.03499619  0.20042362  0.48845863  1
+  C  C8  1  0.03806096  -0.15247884  0.47253647  1
+  C  C9  1  0.70061973  0.71889805  0.13928911  1
+",-154.27671800000002
+981,C-57122-6468-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.31572000
+_cell_length_b   4.68581000
+_cell_length_c   5.94173000
+_cell_angle_alpha   59.12351000
+_cell_angle_beta   80.09809000
+_cell_angle_gamma   69.55143000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   74.23647149
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.20580938  0.58237386  0.26176572  1
+  C  C1  1  0.41379902  0.44135532  0.84464542  1
+  C  C2  1  0.57821996  0.96115242  0.60738535  1
+  C  C3  1  0.09923112  0.54522323  0.02395568  1
+  C  C4  1  0.41124624  0.09823993  0.90883421  1
+  C  C5  1  0.94703091  0.23221353  0.18667488  1
+  C  C6  1  1.19577025  -0.05037889  0.16263251  1
+  C  C7  1  0.60040234  0.63510310  0.62064933  1
+  C  C8  1  0.14646856  0.10648311  0.70932779  1
+  C  C9  1  0.83282317  0.90003537  0.83266387  1
+  C  C10  1  -0.35260646  0.29402081  0.37851322  1
+  C  C11  1  -0.11116329  0.44000622  0.48487693  1
+",-154.095025
+8179,C-134169-158-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42948000
+_cell_length_b   3.25767000
+_cell_length_c   10.54019000
+_cell_angle_alpha   85.45220000
+_cell_angle_beta   88.67131000
+_cell_angle_gamma   101.73184000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   81.35388175
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.00448437  -0.08755057  0.73421387  1
+  C  C1  1  0.71780276  1.04428708  0.32784476  1
+  C  C2  1  0.03862006  0.25063041  0.11221693  1
+  C  C3  1  0.54465454  0.14710586  0.91556375  1
+  C  C4  1  0.24183659  0.58450129  0.19617324  1
+  C  C5  1  1.05189785  0.21152652  0.97720332  1
+  C  C6  1  0.46601686  0.70923868  0.54857018  1
+  C  C7  1  0.27322832  0.33287146  0.32932391  1
+  C  C8  1  0.47633572  0.66563493  0.41398793  1
+  C  C9  1  0.51824229  -0.00535134  0.79308692  1
+  C  C10  1  0.97339799  0.77035817  0.61068368  1
+  C  C11  1  0.79643214  0.87111321  0.19750882  1
+",-154.08710666666667
+4927,C-76014-6220-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42912000
+_cell_length_b   4.15366000
+_cell_length_c   6.30573000
+_cell_angle_alpha   77.95773000
+_cell_angle_beta   78.95933000
+_cell_angle_gamma   90.00085000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   61.01844961
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.02015552  1.07705568  0.32788644  1
+  C  C1  1  0.11934433  0.72745446  0.04847439  1
+  C  C2  1  0.42875889  0.11487245  0.42990003  1
+  C  C3  1  0.77257204  0.23349898  0.74384124  1
+  C  C4  1  0.32452381  0.20254003  0.64005973  1
+  C  C5  1  1.09970694  0.06437341  0.08979703  1
+  C  C6  1  0.65227641  0.24320430  -0.01765870  1
+  C  C7  1  0.63252241  0.58010848  1.02272593  1
+",-154.27654125
+7816,C-184054-4402-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45325000
+_cell_length_b   3.40717000
+_cell_length_c   5.79571000
+_cell_angle_alpha   105.24503000
+_cell_angle_beta   77.83772000
+_cell_angle_gamma   68.77589000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.97208783
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.26977809  0.38484357  0.08666056  1
+  C  C1  1  1.01973437  0.60697731  0.36271497  1
+  C  C2  1  0.62202301  0.86967279  0.89522548  1
+  C  C3  1  -0.20604638  0.46494799  0.95637389  1
+  C  C4  1  0.39582469  0.72789577  0.48897798  1
+  C  C5  1  1.14600312  -0.05000462  0.76503483  1
+",-154.11961216666666
+6888,C-189694-8518-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.53752000
+_cell_length_b   4.47068000
+_cell_length_c   4.28714000
+_cell_angle_alpha   116.36794000
+_cell_angle_beta   88.66301000
+_cell_angle_gamma   107.19620000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.56843076
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.92422859  -0.02652419  0.70098074  1
+  C  C1  1  0.52706642  1.04955242  0.24701469  1
+  C  C2  1  1.10072321  0.45683843  0.14187066  1
+  C  C3  1  0.34745033  0.25719544  0.86198415  1
+  C  C4  1  0.14591969  0.42718750  0.47338680  1
+  C  C5  1  0.67971486  0.17378034  -0.01898962  1
+  C  C6  1  0.49771426  0.38112988  0.59570133  1
+  C  C7  1  0.10363747  0.78239146  0.11761681  1
+  C  C8  1  0.87816783  0.00304187  0.36975730  1
+  C  C9  1  0.92049724  0.64787525  0.72513323  1
+",-154.160456
+8308,C-157721-7325-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48403000
+_cell_length_b   3.92430000
+_cell_length_c   6.39699000
+_cell_angle_alpha   79.48693000
+_cell_angle_beta   78.77469000
+_cell_angle_gamma   71.57742000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.53862865
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.72371183  0.76727750  0.60302086  1
+  C  C1  1  0.74078618  0.96435982  0.37179028  1
+  C  C2  1  0.53522564  0.33180613  0.41872805  1
+  C  C3  1  0.33006837  -0.08676344  0.24561322  1
+  C  C4  1  0.53871944  0.54395708  0.20023119  1
+  C  C5  1  0.12275683  0.51296098  0.06294046  1
+  C  C6  1  0.34850393  0.10905038  0.01510389  1
+  C  C7  1  -0.02045065  0.93261645  0.92736425  1
+  C  C8  1  -0.04907558  0.36372967  0.55517129  1
+  C  C9  1  1.09358791  -0.05859067  0.69103031  1
+",-154.232264
+3140,C-113064-8679-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43320000
+_cell_length_b   3.13215000
+_cell_length_c   8.44057000
+_cell_angle_alpha   101.49269000
+_cell_angle_beta   81.99370000
+_cell_angle_gamma   112.48781000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.10230908
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.78134500  0.56368172  0.94007385  1
+  C  C1  1  0.28160350  0.64933540  1.02330533  1
+  C  C2  1  0.28200645  1.31461736  0.68973638  1
+  C  C3  1  0.78735019  0.07484257  0.43902857  1
+  C  C4  1  0.78118726  0.39768347  0.77313363  1
+  C  C5  1  0.28619518  0.15754477  0.52255522  1
+  C  C6  1  0.28526858  0.82151470  0.18949868  1
+  C  C7  1  0.78562015  0.90731791  0.27278283  1
+",-154.46382625
+304,C-96676-423-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.26705000
+_cell_length_b   3.27614000
+_cell_length_c   4.23550000
+_cell_angle_alpha   95.24638000
+_cell_angle_beta   123.96501000
+_cell_angle_gamma   99.13541000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.21264900
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55982125  0.76331703  0.87425827  1
+  C  C1  1  0.19822349  0.40221493  0.87345960  1
+  C  C2  1  0.76143942  0.13529902  0.49215872  1
+  C  C3  1  1.00952661  0.54874506  0.11116384  1
+  C  C4  1  0.44643686  0.81712160  0.49268882  1
+  C  C5  1  0.64761497  0.18863456  0.11058825  1
+",-154.19851266666666
+2990,C-145323-1843-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.30844000
+_cell_length_b   2.46606000
+_cell_length_c   6.67447000
+_cell_angle_alpha   104.07000000
+_cell_angle_beta   106.36958000
+_cell_angle_gamma   76.22739000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.83267194
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.00487257  0.55281869  1.10020679  1
+  C  C1  1  0.66583715  0.37216667  0.88692140  1
+  C  C2  1  0.77419337  0.41208995  0.38865164  1
+  C  C3  1  0.70828450  0.84865183  0.26003968  1
+  C  C4  1  0.95539221  0.07841517  0.72780277  1
+  C  C5  1  0.26861908  0.97765810  0.10067580  1
+  C  C6  1  0.89092122  0.51493013  0.59908528  1
+  C  C7  1  0.39408664  0.94747896  0.88697264  1
+",-154.18083625
+2967,C-136221-5891-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.59279000
+_cell_length_b   2.49085000
+_cell_length_c   4.35374000
+_cell_angle_alpha   106.60966000
+_cell_angle_beta   84.31136000
+_cell_angle_gamma   110.29579000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.01829496
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.48877057  0.48487231  0.69070949  1
+  C  C1  1  0.11965645  0.59251372  0.27265113  1
+  C  C2  1  0.85983605  -0.03794081  0.27267965  1
+  C  C3  1  0.48896189  -0.12084186  0.47851076  1
+  C  C4  1  0.85982233  0.77423773  0.89675982  1
+  C  C5  1  0.11927343  0.40321581  0.89660186  1
+",-154.19727616666668
+1366,C-134185-1570-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44876000
+_cell_length_b   3.36956000
+_cell_length_c   7.57160000
+_cell_angle_alpha   94.17875000
+_cell_angle_beta   99.31894000
+_cell_angle_gamma   111.31409000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.84113390
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.09054891  0.40708686  0.81983461  1
+  C  C1  1  0.76458629  0.46947016  0.10806779  1
+  C  C2  1  0.44368946  0.20410727  0.72872507  1
+  C  C3  1  0.41090406  0.47990739  0.39131845  1
+  C  C4  1  0.21611894  0.46427442  1.01611700  1
+  C  C5  1  0.18815959  0.74255140  0.67998618  1
+  C  C6  1  0.86380202  0.47610333  0.29971746  1
+  C  C7  1  0.53997913  0.53945705  0.58801784  1
+",-154.19618625
+3759,C-176689-6597-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.93188000
+_cell_length_b   4.37858000
+_cell_length_c   5.29671000
+_cell_angle_alpha   111.08930000
+_cell_angle_beta   103.98667000
+_cell_angle_gamma   109.59863000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   73.02223733
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.37906686  0.31144177  -0.00555348  1
+  C  C1  1  0.12630202  0.18276508  0.11958220  1
+  C  C2  1  0.63341222  0.69207265  0.11967768  1
+  C  C3  1  0.63089555  0.17563380  0.60299257  1
+  C  C4  1  0.37747986  0.04678492  0.72762816  1
+  C  C5  1  -0.27517167  0.02648581  0.35994933  1
+  C  C6  1  0.03126324  0.33178488  0.36184177  1
+  C  C7  1  0.88088414  0.80052828  0.98399807  1
+  C  C8  1  0.12378385  0.66619616  0.60291843  1
+  C  C9  1  0.87609024  0.55771673  0.73836488  1
+",-154.202517
+1205,C-34649-5321-57,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48811000
+_cell_length_b   4.30488000
+_cell_length_c   4.30536000
+_cell_angle_alpha   80.41888000
+_cell_angle_beta   73.20267000
+_cell_angle_gamma   89.98616000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.47540093
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.24762402  0.14827195  0.77606678  1
+  C  C1  1  0.68575297  -0.03903534  0.90103932  1
+  C  C2  1  0.93581668  0.71095218  0.40104454  1
+  C  C3  1  -0.00245414  0.39825969  0.27607087  1
+  C  C4  1  0.43560318  0.21095528  0.40104030  1
+  C  C5  1  0.49768773  0.89825947  0.27607201  1
+  C  C6  1  0.18589484  0.46096444  0.90104046  1
+  C  C7  1  0.74783752  0.64826885  0.77607103  1
+",-154.544885
+5420,C-142755-3271-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45308000
+_cell_length_b   6.70735000
+_cell_length_c   6.46897000
+_cell_angle_alpha   101.72135000
+_cell_angle_beta   79.79549000
+_cell_angle_gamma   105.08492000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   99.75405854
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.29195019  0.88720131  1.10372548  1
+  C  C1  1  0.61263593  0.85382572  0.41861539  1
+  C  C2  1  0.35486327  0.60008937  0.60513484  1
+  C  C3  1  0.75942785  0.53444186  0.69649349  1
+  C  C4  1  0.63304306  0.56998224  0.92488978  1
+  C  C5  1  0.20320841  0.94571959  0.33520514  1
+  C  C6  1  0.53323868  0.85472767  0.65587287  1
+  C  C7  1  0.80980337  0.25472896  0.90843246  1
+  C  C8  1  1.01450382  0.48007607  0.01447763  1
+  C  C9  1  0.29167711  0.17927622  0.34324655  1
+  C  C10  1  0.23989549  0.15571162  0.85727646  1
+  C  C11  1  0.48053497  0.60890387  0.36663162  1
+  C  C12  1  0.85572499  0.28307457  0.32800628  1
+  C  C13  1  -0.03731030  0.49944041  0.26338053  1
+  C  C14  1  1.03834220  -0.07073716  0.77658896  1
+  C  C15  1  -0.18624225  0.83670758  -0.01062539  1
+",-154.080445
+6366,C-145389-5770-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.81257000
+_cell_length_b   4.21100000
+_cell_length_c   4.85449000
+_cell_angle_alpha   90.06658000
+_cell_angle_beta   52.26969000
+_cell_angle_gamma   73.46201000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.48865738
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.45234805  0.70637501  0.29572995  1
+  C  C1  1  0.45653453  0.03865353  0.79365546  1
+  C  C2  1  0.45654736  0.53865582  0.54367125  1
+  C  C3  1  0.45247153  1.20636111  0.54567119  1
+  C  C4  1  0.45661812  1.03865456  0.29363821  1
+  C  C5  1  0.45665801  0.53863963  1.04359670  1
+  C  C6  1  0.45238793  0.20636009  0.04568844  1
+  C  C7  1  0.45245870  0.70635882  0.79565540  1
+",-154.44868625
+9419,C-126183-8981-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48200000
+_cell_length_b   3.68955000
+_cell_length_c   4.21993000
+_cell_angle_alpha   75.18145000
+_cell_angle_beta   89.95284000
+_cell_angle_gamma   109.66510000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.01905513
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.29845037  0.05965844  0.46223559  1
+  C  C1  1  -0.02472440  0.41746377  0.76038421  1
+  C  C2  1  1.10102210  0.66166470  0.38702330  1
+  C  C3  1  0.77854927  1.02061896  0.68413020  1
+  C  C4  1  0.55401775  0.57486660  0.89090892  1
+  C  C5  1  0.52294881  0.50551544  0.25588068  1
+",-154.31381266666668
+7744,C-53822-9555-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.30327000
+_cell_length_b   4.30325000
+_cell_length_c   4.76782000
+_cell_angle_alpha   90.00296000
+_cell_angle_beta   89.96871000
+_cell_angle_gamma   99.13616000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   87.17062592
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.66812770  0.74474554  0.20536991  1
+  C  C1  1  1.00813068  0.19907414  0.47702816  1
+  C  C2  1  0.14121012  0.55094989  0.45382444  1
+  C  C3  1  0.00469881  0.68685654  0.70496062  1
+  C  C4  1  1.00598130  0.68607529  0.20504556  1
+  C  C5  1  0.47908780  0.95285093  0.70519858  1
+  C  C6  1  0.14104163  0.55096248  0.95624086  1
+  C  C7  1  0.73838971  0.21261946  0.70521788  1
+  C  C8  1  0.49212885  0.68399828  0.47718599  1
+  C  C9  1  0.49201441  0.68392748  0.93416923  1
+  C  C10  1  0.66515176  0.53634796  0.70524913  1
+  C  C11  1  0.00797964  0.19900275  -0.06579343  1
+  C  C12  1  0.94544510  1.02314240  0.20535536  1
+  C  C13  1  0.15466599  1.02584405  0.70528291  1
+",-154.1946507142857
+8721,C-170906-4496-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48067000
+_cell_length_b   2.48100000
+_cell_length_c   8.17897000
+_cell_angle_alpha   90.01209000
+_cell_angle_beta   89.99754000
+_cell_angle_gamma   59.97838000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.58432598
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.01932700  0.11917753  0.16260073  1
+  C  C1  1  1.01902112  0.11923820  -0.02337866  1
+  C  C2  1  1.01901611  0.11933953  0.66256282  1
+  C  C3  1  0.68574814  0.78584678  0.91394503  1
+  C  C4  1  0.35258859  0.45258905  0.22510086  1
+  C  C5  1  0.68573282  0.78594992  0.72506583  1
+  C  C6  1  0.01916416  0.11933269  0.47659489  1
+  C  C7  1  0.35246294  0.45270299  0.41395311  1
+",-154.53729375
+685,C-134195-9130-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48336000
+_cell_length_b   5.22928000
+_cell_length_c   3.82506000
+_cell_angle_alpha   80.84624000
+_cell_angle_beta   71.05546000
+_cell_angle_gamma   89.95421000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.31517482
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.75051835  1.01224893  0.79551937  1
+  C  C1  1  -0.21090152  0.73283360  0.72300342  1
+  C  C2  1  0.12393125  0.33862375  0.05000870  1
+  C  C3  1  0.00219800  0.78720540  0.29476992  1
+  C  C4  1  0.54870767  0.95219404  0.19960044  1
+  C  C5  1  1.17846764  0.62557784  0.94525300  1
+  C  C6  1  0.51287636  0.23149828  0.27234372  1
+  C  C7  1  0.29720815  0.17716736  0.70046615  1
+",-154.2214675
+3539,C-75999-4861-53,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.43461000
+_cell_length_b   4.85804000
+_cell_length_c   5.49036000
+_cell_angle_alpha   52.55511000
+_cell_angle_beta   68.92379000
+_cell_angle_gamma   82.40011000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.40355232
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70066622  1.04368445  0.75555142  1
+  C  C1  1  0.95583716  0.60401768  0.61089220  1
+  C  C2  1  -0.03983270  0.83977372  -0.03117383  1
+  C  C3  1  0.33969813  0.84693583  0.30898818  1
+  C  C4  1  0.62539571  0.60451539  0.28000583  1
+  C  C5  1  0.55704927  0.09904574  0.30610010  1
+  C  C6  1  0.25049754  0.03854583  -0.01493968  1
+  C  C7  1  0.63008755  0.84054380  0.63782568  1
+  C  C8  1  1.02821774  0.34511318  -0.05759250  1
+  C  C9  1  0.33433043  0.40525802  0.26397041  1
+  C  C10  1  0.88334825  0.40056138  0.49380327  1
+  C  C11  1  0.24600419  0.59717898  -0.06050447  1
+",-154.23373333333333
+6338,C-73651-4102-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44884000
+_cell_length_b   3.37013000
+_cell_length_c   7.57203000
+_cell_angle_alpha   79.02882000
+_cell_angle_beta   80.65698000
+_cell_angle_gamma   68.66694000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.84857717
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.25563745  0.53743315  0.88131424  1
+  C  C1  1  -0.12876859  0.59645939  0.59301332  1
+  C  C2  1  -0.04023523  0.61169340  0.40095508  1
+  C  C3  1  0.80957048  0.33705461  -0.02713177  1
+  C  C4  1  1.01760307  -0.12453426  1.02072539  1
+  C  C5  1  0.32798802  0.59056650  0.68494784  1
+  C  C6  1  0.57107289  0.67531471  0.11277961  1
+  C  C7  1  0.50137781  0.61985020  0.30919100  1
+",-154.19320125
+2595,C-170896-9077-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.14240000
+_cell_length_b   3.41953000
+_cell_length_c   5.01348000
+_cell_angle_alpha   111.52750000
+_cell_angle_beta   89.97530000
+_cell_angle_gamma   127.31050000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   50.12269899
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20713973  0.49390750  0.70606567  1
+  C  C1  1  0.08760724  -0.16123569  0.79258656  1
+  C  C2  1  0.87941571  0.83876389  0.04265083  1
+  C  C3  1  0.41533126  0.49390791  0.95600140  1
+  C  C4  1  0.87941571  0.83876389  0.54265083  1
+  C  C5  1  0.08760724  0.83876431  0.29258656  1
+  C  C6  1  0.20713973  0.49390750  0.20606567  1
+  C  C7  1  0.41533126  0.49390791  0.45600140  1
+",-154.1249725
+5462,C-80205-231-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.24986000
+_cell_length_b   2.99579000
+_cell_length_c   4.79877000
+_cell_angle_alpha   72.80571000
+_cell_angle_beta   84.35186000
+_cell_angle_gamma   73.66396000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.00182169
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.69282595  0.20599913  -0.11234805  1
+  C  C1  1  0.19289591  0.06585710  0.14349933  1
+  C  C2  1  0.70460021  0.79554919  0.40108598  1
+  C  C3  1  0.86781438  1.01389078  0.14292286  1
+  C  C4  1  0.36782408  0.15298938  0.88660721  1
+  C  C5  1  0.20600453  0.20645388  0.62474598  1
+  C  C6  1  0.85620334  0.42369910  0.62874224  1
+  C  C7  1  0.35505500  1.01704045  0.40372634  1
+",-154.12511
+5033,C-13925-8845-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.51666000
+_cell_length_b   3.31955000
+_cell_length_c   3.51803000
+_cell_angle_alpha   90.01510000
+_cell_angle_beta   120.03006000
+_cell_angle_gamma   89.99146000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.55560901
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36852438  0.05335595  0.40589825  1
+  C  C1  1  0.59997710  0.88803646  0.17369314  1
+  C  C2  1  0.67312742  0.38803867  0.70994406  1
+  C  C3  1  -0.09484065  0.22058062  0.17382747  1
+  C  C4  1  0.90458421  0.55338065  0.47789112  1
+  C  C5  1  0.36793084  0.72062044  0.70976677  1
+",-154.41090533333332
+1038,C-106885-2076-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43262000
+_cell_length_b   4.22719000
+_cell_length_c   4.81579000
+_cell_angle_alpha   82.25586000
+_cell_angle_beta   104.59209000
+_cell_angle_gamma   106.70691000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.79724761
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.95850812  0.19852219  0.72806607  1
+  C  C1  1  0.59080098  0.67109622  0.51681408  1
+  C  C2  1  0.20329718  0.14566068  0.26903355  1
+  C  C3  1  0.12770762  0.56338463  0.69990177  1
+  C  C4  1  0.74010711  1.03795373  0.45226326  1
+  C  C5  1  0.37252542  0.51060661  0.24083058  1
+  C  C6  1  0.35546590  0.73655124  0.98139685  1
+  C  C7  1  0.97511196  0.97249309  0.98723715  1
+",-154.227915
+4431,C-72754-2980-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.04013000
+_cell_length_b   2.43003000
+_cell_length_c   6.51042000
+_cell_angle_alpha   90.21657000
+_cell_angle_beta   105.34413000
+_cell_angle_gamma   113.16204000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.32667313
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.12672056  0.06003147  0.05585448  1
+  C  C1  1  0.79153116  0.39251772  0.72307425  1
+  C  C2  1  1.24078395  0.61699555  0.16727942  1
+  C  C3  1  0.90775580  0.95051473  0.83346069  1
+  C  C4  1  0.57190199  0.28255558  0.50077517  1
+  C  C5  1  0.45690723  0.72500434  0.38983359  1
+",-154.432782
+1131,C-90835-6350-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47523000
+_cell_length_b   4.16088000
+_cell_length_c   6.89259000
+_cell_angle_alpha   107.60686000
+_cell_angle_beta   100.34104000
+_cell_angle_gamma   89.99915000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   66.45156550
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20371632  0.68690973  1.00020390  1
+  C  C1  1  0.54104013  0.52587652  0.67466435  1
+  C  C2  1  0.75936769  0.24265140  0.11077912  1
+  C  C3  1  0.86939231  0.22659786  0.33267555  1
+  C  C4  1  0.09267451  0.07833151  0.77841668  1
+  C  C5  1  1.20388404  0.06259257  1.00035599  1
+  C  C6  1  0.42096996  0.40847752  0.43613091  1
+  C  C7  1  0.54056117  0.89675527  0.67498952  1
+  C  C8  1  0.42097881  0.77906047  0.43634322  1
+  C  C9  1  -0.13061573  0.85788572  0.33297136  1
+  C  C10  1  0.75918383  0.61812691  0.11095196  1
+  C  C11  1  0.09352036  0.44739502  0.77818125  1
+",-154.44166416666667
+5179,C-150739-4923-53,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.29926000
+_cell_length_b   5.38125000
+_cell_length_c   6.52769000
+_cell_angle_alpha   106.99012000
+_cell_angle_beta   84.35469000
+_cell_angle_gamma   76.93753000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   106.27275513
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.59783515  0.24247521  0.21372154  1
+  C  C1  1  0.73800650  0.91378941  0.66543234  1
+  C  C2  1  0.80515064  0.45779170  0.30182003  1
+  C  C3  1  0.53010526  0.16143262  0.61048100  1
+  C  C4  1  0.38042360  0.16302682  0.39127569  1
+  C  C5  1  0.15043854  0.51521768  0.96848091  1
+  C  C6  1  0.11405060  0.26976415  0.79106486  1
+  C  C7  1  0.37726081  0.79807426  0.72720966  1
+  C  C8  1  1.01012634  1.03058977  0.84433830  1
+  C  C9  1  0.77460464  0.37348206  0.68042877  1
+  C  C10  1  0.88185335  0.00197474  1.05645629  1
+  C  C11  1  0.00133825  0.42269658  0.49254566  1
+  C  C12  1  0.49549155  0.61905413  0.85592383  1
+  C  C13  1  0.14204732  0.69084111  0.54497535  1
+  C  C14  1  0.21567075  0.45358036  0.17100816  1
+  C  C15  1  0.35096669  0.89378653  0.23883888  1
+  C  C16  1  0.36273806  0.67050682  0.32793278  1
+  C  C17  1  0.72166165  0.75678546  1.03274216  1
+",-154.07163111111112
+6295,C-193954-5904-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42560000
+_cell_length_b   4.21645000
+_cell_length_c   4.21638000
+_cell_angle_alpha   90.18903000
+_cell_angle_beta   89.94467000
+_cell_angle_gamma   90.02035000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.12243640
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.10055721  -0.12197795  0.65138352  1
+  C  C1  1  0.10046666  0.47063281  0.24221666  1
+  C  C2  1  1.10040241  0.81823366  0.30349810  1
+  C  C3  1  0.60041959  0.90480333  0.80744721  1
+  C  C4  1  0.60052834  0.31449740  0.21534246  1
+  C  C5  1  0.60054109  0.96657804  0.15512624  1
+",-154.30753966666666
+7911,C-47636-5638-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49033000
+_cell_length_b   4.28235000
+_cell_length_c   6.56619000
+_cell_angle_alpha   98.24904000
+_cell_angle_beta   100.85742000
+_cell_angle_gamma   87.78680000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   68.05501949
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.33199908  0.14007344  0.46825023  1
+  C  C1  1  0.66822911  0.74240252  0.69268717  1
+  C  C2  1  0.14396159  0.26917529  0.80707713  1
+  C  C3  1  0.31407133  0.81013711  0.01592508  1
+  C  C4  1  0.68557834  0.64372344  0.45570479  1
+  C  C5  1  0.58289176  0.11213764  0.69853679  1
+  C  C6  1  0.89303474  0.83075809  0.14923297  1
+  C  C7  1  0.79658583  0.19633996  0.15680437  1
+  C  C8  1  0.14104504  0.79418462  0.37398195  1
+  C  C9  1  0.78818048  0.29949559  0.38949488  1
+  C  C10  1  0.20779654  0.62964708  0.80094127  1
+  C  C11  1  1.24492027  0.17698501  1.02260138  1
+",-154.08298416666665
+402,C-130262-6085-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48408000
+_cell_length_b   7.40709000
+_cell_length_c   8.29759000
+_cell_angle_alpha   72.32988000
+_cell_angle_beta   96.81063000
+_cell_angle_gamma   78.90235000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C24
+_cell_volume   140.16908995
+_cell_formula_units_Z   24
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55078927  0.73315210  0.99995663  1
+  C  C1  1  0.52170033  0.58009719  0.76276418  1
+  C  C2  1  -0.00674626  0.36661789  0.43395405  1
+  C  C3  1  0.96237344  0.48087546  0.55283555  1
+  C  C4  1  -0.15855831  0.89160032  0.74692807  1
+  C  C5  1  0.10604952  -0.01952339  0.45452869  1
+  C  C6  1  0.13666840  0.65850219  0.10575359  1
+  C  C7  1  0.12145557  0.80591987  0.23518193  1
+  C  C8  1  0.61802368  1.01182704  0.55649468  1
+  C  C9  1  -0.13657330  0.35896619  0.26376824  1
+  C  C10  1  0.20286299  0.28274918  0.69353546  1
+  C  C11  1  0.75705219  0.23672325  0.80126835  1
+  C  C12  1  0.44496468  0.75848156  0.80868887  1
+  C  C13  1  0.27938128  0.33565258  0.02445806  1
+  C  C14  1  0.96992084  0.14319937  0.27753529  1
+  C  C15  1  0.21253948  0.78582743  0.42714227  1
+  C  C16  1  0.52516687  0.93003424  0.15735984  1
+  C  C17  1  0.71525155  0.37397255  0.90818102  1
+  C  C18  1  0.27924853  0.44277934  0.16136178  1
+  C  C19  1  0.44003697  0.94279937  0.97716475  1
+  C  C20  1  0.86004852  0.01844137  0.87587978  1
+  C  C21  1  0.43964656  0.12773505  0.17722583  1
+  C  C22  1  0.31827214  0.20512624  0.55546718  1
+  C  C23  1  0.40716655  0.59501070  0.57168800  1
+",-154.09567208333334
+2922,C-73637-6506-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.55625000
+_cell_length_b   5.66192000
+_cell_length_c   4.60935000
+_cell_angle_alpha   119.43865000
+_cell_angle_beta   106.32447000
+_cell_angle_gamma   103.25712000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   50.07806225
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.03452644  0.74448058  0.13901806  1
+  C  C1  1  0.39825198  1.10674312  0.50529588  1
+  C  C2  1  0.33778728  0.78927253  0.70277263  1
+  C  C3  1  -0.00645932  0.28063439  0.52240912  1
+  C  C4  1  1.05521063  0.59853385  0.32573927  1
+  C  C5  1  0.54640344  0.08025297  0.82755326  1
+  C  C6  1  0.84582085  0.30749682  0.20057027  1
+  C  C7  1  0.35761620  0.64280956  0.88896410  1
+",-154.15611
+1647,C-106875-7579-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47298000
+_cell_length_b   3.28765000
+_cell_length_c   6.57188000
+_cell_angle_alpha   81.85131000
+_cell_angle_beta   112.14347000
+_cell_angle_gamma   112.13444000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.84304299
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.35113774  0.92267832  0.93324600  1
+  C  C1  1  0.98959182  0.56183112  0.75309529  1
+  C  C2  1  -0.01011695  0.20139579  0.93311598  1
+  C  C3  1  -0.01008729  0.20127309  0.43312172  1
+  C  C4  1  -0.01039209  0.56170798  0.25311103  1
+  C  C5  1  0.35110147  0.56197030  1.11378320  1
+  C  C6  1  0.35116082  0.92256954  0.43323580  1
+  C  C7  1  0.35106408  0.56196216  0.61377208  1
+",-154.3272975
+572,C-134219-5441-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45632000
+_cell_length_b   3.66401000
+_cell_length_c   6.45358000
+_cell_angle_alpha   105.47351000
+_cell_angle_beta   101.00555000
+_cell_angle_gamma   70.45005000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.41848870
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.83848803  0.46973200  0.52785213  1
+  C  C1  1  0.82530167  0.25042539  0.28303126  1
+  C  C2  1  0.20056320  0.41413916  0.19597008  1
+  C  C3  1  0.61344977  0.87145636  0.47866771  1
+  C  C4  1  1.10582039  0.36724300  0.95872980  1
+  C  C5  1  0.46351740  0.30594754  0.61504271  1
+  C  C6  1  0.05085221  0.84866886  0.33219391  1
+  C  C7  1  0.55909964  0.35252219  0.85238711  1
+",-154.28573875
+5466,C-80164-8806-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47359000
+_cell_length_b   4.80347000
+_cell_length_c   6.43390000
+_cell_angle_alpha   69.45822000
+_cell_angle_beta   67.39421000
+_cell_angle_gamma   75.09142000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   65.42008360
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.60685527  0.72590147  -0.00914105  1
+  C  C1  1  -0.28179590  0.94765170  0.26898282  1
+  C  C2  1  0.80020459  0.86379919  0.72726870  1
+  C  C3  1  0.27278867  0.05909314  0.65791585  1
+  C  C4  1  0.94027105  0.39248612  0.32453340  1
+  C  C5  1  1.05035587  0.61426654  0.60276825  1
+  C  C6  1  0.38408166  0.28103424  0.93569576  1
+  C  C7  1  0.35835714  -0.02476315  0.11558229  1
+  C  C8  1  1.02394536  0.30843221  0.78264943  1
+  C  C9  1  -0.30925294  0.64181039  0.44941482  1
+  C  C10  1  0.46808217  0.19715046  0.39366670  1
+  C  C11  1  1.13433947  0.53057409  0.06023614  1
+",-154.52400333333333
+1271,C-126147-4024-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.31837000
+_cell_length_b   3.51539000
+_cell_length_c   3.51863000
+_cell_angle_alpha   59.99091000
+_cell_angle_beta   89.99821000
+_cell_angle_gamma   90.00071000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.54371080
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40787007  0.56581127  0.68957621  1
+  C  C1  1  0.24058210  0.02938248  0.45757375  1
+  C  C2  1  0.74064904  0.56623699  0.99336709  1
+  C  C3  1  0.90783592  1.02997865  0.76132184  1
+  C  C4  1  0.07536292  0.26105341  -0.00634774  1
+  C  C5  1  0.57528944  0.33436108  0.45751115  1
+",-154.4101015
+9625,C-28258-8310-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42999000
+_cell_length_b   2.42997000
+_cell_length_c   8.73604000
+_cell_angle_alpha   83.26414000
+_cell_angle_beta   74.39164000
+_cell_angle_gamma   59.97250000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.00491589
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.34126102  0.94916302  0.24068972  1
+  C  C1  1  0.30423092  0.55936808  0.90938016  1
+  C  C2  1  0.61295319  0.60928885  0.57427862  1
+  C  C3  1  0.94720742  -0.05715325  0.57356939  1
+  C  C4  1  0.97034773  0.22616280  -0.08985062  1
+  C  C5  1  0.67543891  0.28232591  0.23993073  1
+",-154.45506466666666
+567,C-170378-1288-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.58328000
+_cell_length_b   5.49166000
+_cell_length_c   3.64632000
+_cell_angle_alpha   109.50265000
+_cell_angle_beta   89.52578000
+_cell_angle_gamma   118.45098000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.15618353
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.03538510  0.48484983  0.39669176  1
+  C  C1  1  0.34419361  0.79561789  0.55321652  1
+  C  C2  1  -0.15465759  0.29388998  0.60869105  1
+  C  C3  1  0.53457684  0.98602651  -0.04377648  1
+  C  C4  1  0.53492165  -0.01374641  0.34091906  1
+  C  C5  1  0.84550628  0.29437178  0.99349509  1
+",-154.082509
+2204,C-148225-7911-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.53312000
+_cell_length_b   3.76688000
+_cell_length_c   5.05310000
+_cell_angle_alpha   89.93804000
+_cell_angle_beta   89.92684000
+_cell_angle_gamma   89.78471000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.21606572
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.22141176  0.13183575  0.25315037  1
+  C  C1  1  0.71872099  0.62705875  0.41250748  1
+  C  C2  1  0.72090536  0.42916771  0.87333498  1
+  C  C3  1  0.71855905  0.75227508  0.68932417  1
+  C  C4  1  0.72012106  0.23834831  0.41281187  1
+  C  C5  1  0.21999791  0.73360108  0.25255775  1
+  C  C6  1  0.72024481  1.10846330  0.68904640  1
+  C  C7  1  0.22112495  0.42992233  0.04381377  1
+",-154.1247325
+3928,C-145302-9438-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47921000
+_cell_length_b   4.95457000
+_cell_length_c   6.31404000
+_cell_angle_alpha   78.68072000
+_cell_angle_beta   89.98559000
+_cell_angle_gamma   59.96377000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   65.39649279
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.05931147  0.28365477  0.33172661  1
+  C  C1  1  0.75429532  0.58934223  0.41546993  1
+  C  C2  1  0.20017296  0.64422148  0.75030250  1
+  C  C3  1  0.97653865  0.36561752  0.08427544  1
+  C  C4  1  0.83898245  0.50579431  0.66645802  1
+  C  C5  1  0.05932023  0.78363173  0.33172133  1
+  C  C6  1  0.75429824  1.08936125  0.41546954  1
+  C  C7  1  0.83900987  0.00581201  0.66647136  1
+  C  C8  1  0.28258544  0.55996948  1.00111609  1
+  C  C9  1  -0.02342347  0.86559531  0.08426890  1
+  C  C10  1  0.20023184  0.14421328  0.75034760  1
+  C  C11  1  0.28262070  0.05996543  1.00115698  1
+",-154.53566583333333
+20,C-134193-3339-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.28292000
+_cell_length_b   3.30967000
+_cell_length_c   4.82553000
+_cell_angle_alpha   102.44676000
+_cell_angle_beta   102.43304000
+_cell_angle_gamma   79.86147000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.53413692
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.12240623  0.06880529  0.86206249  1
+  C  C1  1  0.59013823  0.84270950  0.40309934  1
+  C  C2  1  0.16910925  0.38934952  0.68844762  1
+  C  C3  1  0.80617360  0.75216557  0.68848363  1
+  C  C4  1  0.26315675  0.16900060  0.40319271  1
+  C  C5  1  0.48510437  0.70578016  0.86237618  1
+  C  C6  1  0.70560132  0.61147197  0.14753929  1
+  C  C7  1  0.03200035  0.28457998  0.14745594  1
+",-154.21400625
+1579,C-170910-1502-67,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48450000
+_cell_length_b   3.82380000
+_cell_length_c   5.78147000
+_cell_angle_alpha   89.96988000
+_cell_angle_beta   115.44482000
+_cell_angle_gamma   108.96103000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.28017458
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.51027429  0.17103862  0.07653550  1
+  C  C1  1  1.25087894  0.76780937  0.01839198  1
+  C  C2  1  0.22169922  0.26515337  0.24159333  1
+  C  C3  1  0.20956315  0.91547475  0.40409848  1
+  C  C4  1  0.53891957  0.67323032  0.85320278  1
+  C  C5  1  0.49137948  0.69251624  0.29786419  1
+  C  C6  1  0.26868318  0.24498915  0.79651320  1
+  C  C7  1  0.55062556  0.02251958  0.69038135  1
+",-154.22099625
+6437,C-177276-5156-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48457000
+_cell_length_b   4.08751000
+_cell_length_c   4.67675000
+_cell_angle_alpha   96.70348000
+_cell_angle_beta   74.54540000
+_cell_angle_gamma   90.00197000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.44142029
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.72435263  0.12962177  0.66799675  1
+  C  C1  1  0.26888928  0.29977415  0.58166483  1
+  C  C2  1  -0.05810691  0.59278919  0.23771179  1
+  C  C3  1  0.21087595  0.65573312  0.69657459  1
+  C  C4  1  0.44082999  0.36798471  0.24004930  1
+  C  C5  1  1.05155141  0.83519858  0.01153077  1
+  C  C6  1  0.55236094  0.06181304  0.00967590  1
+  C  C7  1  0.78343571  0.77409853  0.55265087  1
+",-154.36726125
+9089,C-53838-1497-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48334000
+_cell_length_b   3.73903000
+_cell_length_c   5.91262000
+_cell_angle_alpha   129.20454000
+_cell_angle_beta   114.85757000
+_cell_angle_gamma   89.98442000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.74429620
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.11937922  0.35633838  0.50137009  1
+  C  C1  1  0.70952041  0.94650902  0.09190200  1
+  C  C2  1  0.61973787  0.11981719  0.50167082  1
+  C  C3  1  0.91474662  0.14785984  0.79710445  1
+  C  C4  1  0.41440841  0.91823358  0.79682752  1
+  C  C5  1  0.20995116  0.70997169  1.09223742  1
+",-154.16154466666669
+5800,C-72720-4972-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46759000
+_cell_length_b   5.45081000
+_cell_length_c   6.48662000
+_cell_angle_alpha   112.47950000
+_cell_angle_beta   79.03294000
+_cell_angle_gamma   103.09172000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   78.00031250
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.09686069  0.44115400  0.43649886  1
+  C  C1  1  0.16383249  0.36973843  0.97931456  1
+  C  C2  1  0.25444177  0.16163373  0.23081628  1
+  C  C3  1  0.67072376  0.87633644  0.63946893  1
+  C  C4  1  0.73238666  0.74847918  0.26839859  1
+  C  C5  1  0.93060622  0.42424176  0.66822274  1
+  C  C6  1  0.27139928  -0.06834254  0.32912387  1
+  C  C7  1  0.32215666  0.29274917  0.71971251  1
+  C  C8  1  -0.02677128  0.69024919  0.86769077  1
+  C  C9  1  0.24608826  0.00786842  0.58831620  1
+  C  C10  1  0.81877960  0.13914583  0.07719908  1
+  C  C11  1  0.74902533  0.55295511  0.03989445  1
+  C  C12  1  0.64823410  0.61010888  0.43976177  1
+  C  C13  1  0.58698227  0.85933160  0.87076771  1
+",-154.1446214285714
+5516,C-136219-6599-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45042000
+_cell_length_b   4.38706000
+_cell_length_c   5.68341000
+_cell_angle_alpha   97.55623000
+_cell_angle_beta   90.03228000
+_cell_angle_gamma   106.25579000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.10067533
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.61868388  0.73095356  0.43434165  1
+  C  C1  1  0.43206789  0.35719566  0.39329073  1
+  C  C2  1  0.86962014  0.23420372  0.24750284  1
+  C  C3  1  -0.07280320  0.34437869  0.76640515  1
+  C  C4  1  0.18123937  0.85419511  0.58063740  1
+  C  C5  1  0.36218783  0.21527281  0.62760814  1
+  C  C6  1  1.12365792  0.74412215  0.06109126  1
+  C  C7  1  1.10443523  0.70032550  0.79534210  1
+  C  C8  1  0.68909269  0.87325828  0.19999170  1
+  C  C9  1  0.94703516  0.38814371  0.03230093  1
+",-154.142304
+4439,C-28224-863-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48134000
+_cell_length_b   4.84497000
+_cell_length_c   3.69047000
+_cell_angle_alpha   122.65602000
+_cell_angle_beta   109.72739000
+_cell_angle_gamma   75.01177000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99717616
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.35064566  0.74120773  0.86536999  1
+  C  C1  1  0.77233544  0.61034718  0.57786264  1
+  C  C2  1  0.22489739  0.11424436  -0.00545019  1
+  C  C3  1  0.80338817  0.24526361  0.28231742  1
+  C  C4  1  0.54789970  0.81701081  0.33881741  1
+  C  C5  1  0.02797524  1.03883899  0.52167292  1
+",-154.31108383333333
+1126,C-172928-8845-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45820000
+_cell_length_b   3.39475000
+_cell_length_c   5.93810000
+_cell_angle_alpha   117.03899000
+_cell_angle_beta   78.22851000
+_cell_angle_gamma   110.98269000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.15954258
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36877314  0.45619499  0.78993196  1
+  C  C1  1  0.76940818  0.38343696  0.91763112  1
+  C  C2  1  0.60032513  0.85132194  0.72424380  1
+  C  C3  1  0.73205518  0.59571027  0.19356309  1
+  C  C4  1  0.19819284  -0.07746400  0.59629347  1
+  C  C5  1  0.22258542  0.70409743  0.32032705  1
+",-154.14448766666666
+2772,C-92130-9945-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47838000
+_cell_length_b   2.47783000
+_cell_length_c   6.31131000
+_cell_angle_alpha   101.28275000
+_cell_angle_beta   89.99623000
+_cell_angle_gamma   59.98708000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.69265499
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.03488516  0.44967282  0.04263702  1
+  C  C1  1  0.10881655  0.16902352  0.62404246  1
+  C  C2  1  0.65983482  0.05993702  -0.04112861  1
+  C  C3  1  0.19144121  0.00255366  0.37311941  1
+  C  C4  1  0.88463586  0.61437669  0.29010458  1
+  C  C5  1  0.74688441  0.89105969  0.70779985  1
+",-154.52877516666666
+5293,C-90804-2418-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48756000
+_cell_length_b   4.30418000
+_cell_length_c   6.57757000
+_cell_angle_alpha   70.88147000
+_cell_angle_beta   100.89201000
+_cell_angle_gamma   89.99139000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   65.19600747
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.15675217  0.90200481  0.80002688  1
+  C  C1  1  0.28259170  0.77702404  0.05035589  1
+  C  C2  1  0.49038749  0.90190970  0.46698891  1
+  C  C3  1  0.65655137  0.40199113  0.79990554  1
+  C  C4  1  0.82374139  0.90186044  0.13396934  1
+  C  C5  1  0.61585912  0.77687224  0.71685299  1
+  C  C6  1  0.44945347  0.27667685  0.38393842  1
+  C  C7  1  0.99016724  0.40193777  0.46681503  1
+  C  C8  1  0.32355475  0.40185672  0.13382932  1
+  C  C9  1  0.94962968  0.77666951  0.38408964  1
+  C  C10  1  0.78241845  0.27700599  0.05023997  1
+  C  C11  1  1.11565719  0.27688959  0.71669247  1
+",-154.54624166666667
+4768,C-136206-8828-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.80297000
+_cell_length_b   2.46219000
+_cell_length_c   7.44689000
+_cell_angle_alpha   99.52012000
+_cell_angle_beta   93.34778000
+_cell_angle_gamma   108.86927000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   64.60447371
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63492397  0.62986950  0.70257516  1
+  C  C1  1  0.70276099  0.76642996  0.90375353  1
+  C  C2  1  0.60887011  0.07080824  0.61093926  1
+  C  C3  1  -0.09342989  1.06110226  0.29424861  1
+  C  C4  1  0.42248881  0.23990509  0.13487899  1
+  C  C5  1  0.91583623  0.41057959  0.98081106  1
+  C  C6  1  0.32942460  0.29314456  0.33225827  1
+  C  C7  1  -0.17730562  0.46159764  0.17782519  1
+  C  C8  1  0.54229356  -0.06150424  0.40923484  1
+  C  C9  1  0.33843204  0.63951431  0.01800699  1
+",-154.209857
+372,C-130544-211-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49059000
+_cell_length_b   4.65635000
+_cell_length_c   5.94866000
+_cell_angle_alpha   76.99251000
+_cell_angle_beta   77.84746000
+_cell_angle_gamma   57.71006000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.47976287
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.23065163  0.63502189  0.57070205  1
+  C  C1  1  0.22011222  0.42578497  0.01087912  1
+  C  C2  1  -0.04023161  0.19142396  1.00065516  1
+  C  C3  1  0.92052017  0.49121984  0.47925733  1
+  C  C4  1  0.28618598  0.96648996  0.79880467  1
+  C  C5  1  0.89486723  0.65042106  0.21240243  1
+  C  C6  1  0.26300684  0.12456035  0.53161535  1
+  C  C7  1  0.01893263  0.72728532  0.81113456  1
+  C  C8  1  0.16244485  0.88939601  0.20032377  1
+  C  C9  1  0.95196016  -0.01927936  0.44096265  1
+",-154.33327400000002
+2190,C-170894-4901-61,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42594000
+_cell_length_b   4.14539000
+_cell_length_c   6.33865000
+_cell_angle_alpha   110.69460000
+_cell_angle_beta   79.03637000
+_cell_angle_gamma   89.92248000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.37971705
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.47375090  0.17680153  0.94472140  1
+  C  C1  1  0.14832024  0.79383409  0.59963397  1
+  C  C2  1  0.69112220  0.24781446  0.52347808  1
+  C  C3  1  0.17586040  0.41943341  0.55503533  1
+  C  C4  1  0.37471546  0.48751336  0.14049461  1
+  C  C5  1  0.82570991  0.63177803  0.23961178  1
+  C  C6  1  0.02437465  0.03339659  0.84460573  1
+  C  C7  1  0.70655844  0.87485622  0.48307860  1
+",-154.24039625
+7274,C-172939-8068-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47277000
+_cell_length_b   4.62266000
+_cell_length_c   6.07075000
+_cell_angle_alpha   98.44807000
+_cell_angle_beta   118.34404000
+_cell_angle_gamma   100.39598000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.86260159
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.82035656  0.61041647  0.61667810  1
+  C  C1  1  0.83573526  0.33598861  0.72559760  1
+  C  C2  1  0.39688786  1.02483507  0.52626264  1
+  C  C3  1  0.47762438  0.58235030  0.31870494  1
+  C  C4  1  0.66195672  0.93668363  0.35895335  1
+  C  C5  1  0.53810780  0.31995813  0.88964720  1
+  C  C6  1  0.47283428  0.80393629  0.70072024  1
+  C  C7  1  0.73620800  0.02043818  -0.03769461  1
+  C  C8  1  0.46739072  0.07227278  0.13531216  1
+  C  C9  1  0.77159012  0.42585863  0.18732618  1
+",-154.127936
+5469,C-170364-9439-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46896000
+_cell_length_b   3.23318000
+_cell_length_c   5.16182000
+_cell_angle_alpha   86.37814000
+_cell_angle_beta   89.97541000
+_cell_angle_gamma   67.65475000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   38.02209345
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.13237654  0.82094646  0.79286673  1
+  C  C1  1  0.17392309  0.20867050  0.41909268  1
+  C  C2  1  0.19907009  0.15794257  0.16527388  1
+  C  C3  1  0.70007053  0.15592576  1.01218587  1
+  C  C4  1  0.67321377  0.20976077  0.57223762  1
+  C  C5  1  0.50543487  0.54409924  0.78958732  1
+",-154.2369025
+9849,C-134191-3585-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42913000
+_cell_length_b   4.16724000
+_cell_length_c   6.14134000
+_cell_angle_alpha   69.63593000
+_cell_angle_beta   78.59739000
+_cell_angle_gamma   89.97751000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.97307740
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.31304821  0.66728775  0.45685729  1
+  C  C1  1  0.95297993  0.47609514  0.17723451  1
+  C  C2  1  0.10825374  0.16879191  0.87953088  1
+  C  C3  1  0.76630858  0.72106894  0.55298033  1
+  C  C4  1  0.40456878  0.52976559  0.27348607  1
+  C  C5  1  0.64008364  0.70183553  0.80584191  1
+  C  C6  1  0.62171308  0.02808642  0.85055096  1
+  C  C7  1  0.08125454  0.49466862  0.92462863  1
+",-154.2281175
+884,C-40132-5024-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51241000
+_cell_length_b   4.62630000
+_cell_length_c   5.71384000
+_cell_angle_alpha   62.92044000
+_cell_angle_beta   85.86181000
+_cell_angle_gamma   81.53713000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.48752121
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.37194639  0.78780903  -0.01612626  1
+  C  C1  1  0.45168229  0.76314858  0.51229250  1
+  C  C2  1  -0.01364157  0.37242146  0.92336901  1
+  C  C3  1  -0.10454740  0.65732149  0.15596223  1
+  C  C4  1  0.44576052  0.59480968  0.81747239  1
+  C  C5  1  1.21128133  0.27711233  0.56615895  1
+  C  C6  1  1.19257784  0.13427734  0.82357306  1
+  C  C7  1  0.41060000  0.14068741  0.37831036  1
+  C  C8  1  -0.01487679  0.63283608  0.42842009  1
+  C  C9  1  0.92338569  0.29476711  0.21034078  1
+",-154.12753700000002
+9972,C-176673-628-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.27665000
+_cell_length_b   4.24163000
+_cell_length_c   3.63104000
+_cell_angle_alpha   89.91944000
+_cell_angle_beta   75.45686000
+_cell_angle_gamma   49.48725000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.22975910
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63935127  0.08728776  0.87433550  1
+  C  C1  1  0.21418660  0.29949814  0.63778893  1
+  C  C2  1  0.63943133  0.72589881  0.87471107  1
+  C  C3  1  0.42742518  0.67094099  0.25644825  1
+  C  C4  1  0.21440260  0.93826729  0.63822309  1
+  C  C5  1  0.42619073  0.35484651  0.25599306  1
+",-154.2004315
+8252,C-130544-211-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.56450000
+_cell_length_b   2.47932000
+_cell_length_c   5.72790000
+_cell_angle_alpha   77.54220000
+_cell_angle_beta   89.26885000
+_cell_angle_gamma   89.95429000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.55877452
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.45189911  -0.02527426  0.87945035  1
+  C  C1  1  0.95822413  0.62856012  0.57443494  1
+  C  C2  1  0.95823910  1.05595513  0.71871404  1
+  C  C3  1  0.94354330  0.31750120  0.19431439  1
+  C  C4  1  0.44794096  0.39735410  0.03386229  1
+  C  C5  1  0.94495001  0.74531940  0.33931100  1
+",-154.28791583333333
+7373,C-193924-4401-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.27142000
+_cell_length_b   3.27220000
+_cell_length_c   3.63342000
+_cell_angle_alpha   75.45369000
+_cell_angle_beta   75.44305000
+_cell_angle_gamma   80.81692000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.24581251
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.93731871  0.17915081  0.94278102  1
+  C  C1  1  0.57693737  0.54075991  0.94313584  1
+  C  C2  1  0.36303598  0.32974487  0.70585489  1
+  C  C3  1  0.30850606  0.59597574  0.32423257  1
+  C  C4  1  0.72429077  0.96794977  0.70568339  1
+  C  C5  1  -0.00904970  -0.08767030  0.32421159  1
+",-154.20129483333332
+1893,C-126175-5026-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42919000
+_cell_length_b   3.98094000
+_cell_length_c   5.70115000
+_cell_angle_alpha   52.97735000
+_cell_angle_beta   100.13655000
+_cell_angle_gamma   88.52614000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.71814668
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55158696  0.68359543  -0.00047602  1
+  C  C1  1  0.33062896  0.57336645  0.55734296  1
+  C  C2  1  -0.00308593  0.90687396  0.89069965  1
+  C  C3  1  0.66328225  0.23956114  0.22317395  1
+  C  C4  1  0.21858984  1.01734964  0.33351367  1
+  C  C5  1  0.88569572  0.35078347  0.66710759  1
+",-154.446965
+384,C-28230-7089-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46416000
+_cell_length_b   3.32599000
+_cell_length_c   6.03414000
+_cell_angle_alpha   120.54044000
+_cell_angle_beta   100.37929000
+_cell_angle_gamma   69.80472000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.97437182
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63965930  0.69412049  0.96893561  1
+  C  C1  1  0.16746412  0.51516354  0.84632212  1
+  C  C2  1  0.79375627  0.86335131  0.44805850  1
+  C  C3  1  0.20971341  0.15955404  0.57298343  1
+  C  C4  1  0.01924407  0.34222222  0.36720831  1
+  C  C5  1  0.60282854  1.04650121  0.24252103  1
+",-154.117094
+4687,C-41264-888-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46167000
+_cell_length_b   3.39595000
+_cell_length_c   6.06289000
+_cell_angle_alpha   109.96305000
+_cell_angle_beta   101.69910000
+_cell_angle_gamma   111.29554000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.18011411
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.09190727  0.20421831  0.40864442  1
+  C  C1  1  0.46424967  0.75229517  0.60418185  1
+  C  C2  1  0.31751076  1.05893366  1.00644881  1
+  C  C3  1  0.93440924  0.81781726  0.47800377  1
+  C  C4  1  0.56035745  0.26870556  0.28188447  1
+  C  C5  1  0.70617072  -0.03837546  -0.12020591  1
+",-154.16216466666663
+2837,C-102922-4323-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45863000
+_cell_length_b   4.54564000
+_cell_length_c   7.79590000
+_cell_angle_alpha   100.35980000
+_cell_angle_beta   118.23305000
+_cell_angle_gamma   105.64718000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   68.89359374
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.88123134  0.22286394  0.24867500  1
+  C  C1  1  0.41409016  0.91400350  0.03935632  1
+  C  C2  1  -0.00967814  0.55891499  0.20895373  1
+  C  C3  1  0.16000638  -0.09966156  0.54091836  1
+  C  C4  1  0.43342080  0.85813583  0.40409214  1
+  C  C5  1  0.54269100  0.25569717  0.67824621  1
+  C  C6  1  0.74259878  -0.05167249  0.91359112  1
+  C  C7  1  0.00070308  0.39015656  0.60586027  1
+  C  C8  1  -0.12358299  0.27858089  0.89349694  1
+  C  C9  1  0.30982139  0.58113097  0.08125116  1
+  C  C10  1  0.54524814  0.19162151  0.36853916  1
+  C  C11  1  0.29716327  0.73558328  0.68777349  1
+",-154.25069416666665
+188,C-72744-8833-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46452000
+_cell_length_b   3.38025000
+_cell_length_c   6.32351000
+_cell_angle_alpha   114.29511000
+_cell_angle_beta   101.44469000
+_cell_angle_gamma   111.14500000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.88411907
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.88661925  0.20449420  0.91832002  1
+  C  C1  1  1.20015330  0.55262321  0.19333416  1
+  C  C2  1  0.93002459  0.68885008  0.51808718  1
+  C  C3  1  0.23998221  0.03594423  -0.20705443  1
+  C  C4  1  0.21420677  0.38225358  0.39255099  1
+  C  C5  1  0.91577238  0.85940840  0.31866249  1
+",-154.16237916666668
+5670,C-92140-8673-51,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43054000
+_cell_length_b   3.41586000
+_cell_length_c   5.90350000
+_cell_angle_alpha   97.59648000
+_cell_angle_beta   87.61280000
+_cell_angle_gamma   115.28277000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.92326270
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.44200694  0.58552988  0.22720759  1
+  C  C1  1  -0.00294395  0.69689054  0.33926317  1
+  C  C2  1  0.77521233  0.25218707  0.89387671  1
+  C  C3  1  0.33044899  0.36355132  1.00592807  1
+  C  C4  1  0.66385066  1.03023335  0.67259405  1
+  C  C5  1  1.10861400  0.91886910  0.56054269  1
+",-154.462729
+3626,C-40142-1323-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46734000
+_cell_length_b   3.36272000
+_cell_length_c   5.75110000
+_cell_angle_alpha   96.73934000
+_cell_angle_beta   115.19773000
+_cell_angle_gamma   68.84273000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.22852671
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.65777792  0.17384099  0.58232768  1
+  C  C1  1  0.19687809  0.34620413  0.70712589  1
+  C  C2  1  0.82902662  0.03822983  0.18563463  1
+  C  C3  1  0.42433420  0.09346192  0.30856509  1
+  C  C4  1  0.59482329  -0.04062521  0.91174279  1
+  C  C5  1  0.05572737  0.78700193  0.78672132  1
+",-154.14058633333337
+9806,C-130505-1819-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48292000
+_cell_length_b   3.74814000
+_cell_length_c   3.84067000
+_cell_angle_alpha   90.03903000
+_cell_angle_beta   89.98924000
+_cell_angle_gamma   89.99559000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.74254021
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.60219888  0.81140957  0.25122901  1
+  C  C1  1  0.10218366  0.04001011  0.25086636  1
+  C  C2  1  0.60217999  0.54342962  -0.04323965  1
+  C  C3  1  0.60210377  0.54385280  0.54570881  1
+  C  C4  1  0.10227877  0.30756688  0.95638657  1
+  C  C5  1  1.10220254  0.30799006  0.54533502  1
+",-154.15865866666667
+641,C-53832-8784-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44197000
+_cell_length_b   7.13598000
+_cell_length_c   5.24597000
+_cell_angle_alpha   89.46769000
+_cell_angle_beta   89.93582000
+_cell_angle_gamma   109.93125000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   85.93530539
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55505297  0.28281338  0.03484458  1
+  C  C1  1  0.85723063  0.08280603  0.38906257  1
+  C  C2  1  0.92784787  0.15345984  0.65738885  1
+  C  C3  1  0.62530253  0.85292077  0.95245363  1
+  C  C4  1  0.33739024  0.56151285  0.83452887  1
+  C  C5  1  0.15526063  0.88234108  1.07678682  1
+  C  C6  1  0.03984498  0.76573661  0.53105893  1
+  C  C7  1  0.23909450  0.46893661  0.34693589  1
+  C  C8  1  0.52976101  0.75514596  0.69888771  1
+  C  C9  1  0.22624130  0.95261187  0.34537462  1
+  C  C10  1  0.45691326  0.18234840  0.78201266  1
+  C  C11  1  1.04184730  0.26975211  0.20381729  1
+  C  C12  1  0.75170288  0.47897340  0.90460460  1
+  C  C13  1  0.83781250  0.56547360  0.39081670  1
+",-154.18884714285716
+320,C-170378-1288-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.64714000
+_cell_length_b   2.44644000
+_cell_length_c   8.95492000
+_cell_angle_alpha   114.18580000
+_cell_angle_beta   103.56808000
+_cell_angle_gamma   70.37593000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   68.21439152
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.80998416  0.68230110  0.12456845  1
+  C  C1  1  0.96169631  0.51723590  0.73157176  1
+  C  C2  1  0.67708324  0.48112276  0.94687425  1
+  C  C3  1  0.08558316  1.41138907  0.37044764  1
+  C  C4  1  0.17411294  -0.01452492  0.44935906  1
+  C  C5  1  0.52943657  0.67488266  0.69246958  1
+  C  C6  1  0.02722643  0.14912303  0.84176601  1
+  C  C7  1  0.45947309  -0.00900389  0.88082314  1
+  C  C8  1  0.31122104  0.18526824  0.62664695  1
+  C  C9  1  0.89676596  0.25769815  0.20374735  1
+",-154.285483
+1043,C-130548-3221-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.99430000
+_cell_length_b   2.42866000
+_cell_length_c   8.12864000
+_cell_angle_alpha   112.20051000
+_cell_angle_beta   117.13955000
+_cell_angle_gamma   100.75398000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.83947312
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.06419944  0.58220126  0.43740780  1
+  C  C1  1  0.84180660  1.24938776  0.21542154  1
+  C  C2  1  0.73061084  0.58192591  0.10416732  1
+  C  C3  1  0.39885035  0.58260331  0.77075120  1
+  C  C4  1  0.50997043  0.24994712  0.88222256  1
+  C  C5  1  0.17548322  0.24967134  0.54873928  1
+",-154.429763
+2015,C-136210-9760-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.37677000
+_cell_length_b   2.46771000
+_cell_length_c   5.23217000
+_cell_angle_alpha   89.97909000
+_cell_angle_beta   90.50247000
+_cell_angle_gamma   111.38481000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.59565560
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.30566037  0.91298092  -0.08285756  1
+  C  C1  1  0.18455039  0.35593104  0.31633976  1
+  C  C2  1  0.00819831  -0.23187305  0.44156522  1
+  C  C3  1  0.25713916  0.38896134  1.04167772  1
+  C  C4  1  0.56289630  0.54376042  0.51823653  1
+  C  C5  1  0.38517117  0.95476654  0.64320234  1
+",-154.151305
+5603,C-53828-4519-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42376000
+_cell_length_b   4.19802000
+_cell_length_c   4.85776000
+_cell_angle_alpha   90.81879000
+_cell_angle_beta   119.85029000
+_cell_angle_gamma   89.90957000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.86480027
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.73332151  0.75313563  0.94065610  1
+  C  C1  1  0.26488481  0.59783339  -0.02830875  1
+  C  C2  1  0.67500275  0.10087267  0.88101235  1
+  C  C3  1  0.32746112  0.16206673  0.53366094  1
+  C  C4  1  0.67171406  0.18862457  0.37817953  1
+  C  C5  1  0.32439316  0.25011130  0.03115542  1
+",-154.2871525
+8632,C-170916-5949-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.69530000
+_cell_length_b   4.30129000
+_cell_length_c   4.78554000
+_cell_angle_alpha   116.36042000
+_cell_angle_beta   104.79708000
+_cell_angle_gamma   54.04323000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   55.16711862
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.07454307  0.33869592  0.40690790  1
+  C  C1  1  0.93234098  0.35248340  1.09344018  1
+  C  C2  1  0.82489811  0.80575751  0.62066178  1
+  C  C3  1  0.82566814  0.27692207  0.56468719  1
+  C  C4  1  0.71795096  0.73034839  0.09259195  1
+  C  C5  1  0.07173491  1.02412338  0.77883396  1
+  C  C6  1  0.57650674  0.74354887  0.77832438  1
+  C  C7  1  0.57906139  0.05841936  0.40631116  1
+",-154.09219125
+4747,C-28213-8691-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49085000
+_cell_length_b   3.59293000
+_cell_length_c   4.35142000
+_cell_angle_alpha   84.30533000
+_cell_angle_beta   106.61977000
+_cell_angle_gamma   110.29268000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99985810
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.52133144  0.40939550  0.12059353  1
+  C  C1  1  0.43904249  0.03833968  0.32623541  1
+  C  C2  1  0.33232779  0.40899741  0.74426176  1
+  C  C3  1  0.14984514  0.66842546  0.12023512  1
+  C  C4  1  -0.03808713  0.66813013  0.74426186  1
+  C  C5  1  1.04439128  1.03802742  0.53854601  1
+",-154.1945785
+498,C-40134-7379-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43247000
+_cell_length_b   3.88638000
+_cell_length_c   4.79270000
+_cell_angle_alpha   94.93404000
+_cell_angle_beta   73.60544000
+_cell_angle_gamma   88.30302000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.23566820
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.21305684  0.43918125  0.25717945  1
+  C  C1  1  -0.12122550  0.77468918  0.92528754  1
+  C  C2  1  0.99184200  0.99379649  0.70075145  1
+  C  C3  1  0.54581415  1.10740180  0.59137938  1
+  C  C4  1  0.65888164  0.32650911  0.36684330  1
+  C  C5  1  0.32459931  0.66201704  0.03495138  1
+",-154.46116266666667
+3593,C-90858-8157-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.45920000
+_cell_length_b   4.27025000
+_cell_length_c   4.20658000
+_cell_angle_alpha   60.66386000
+_cell_angle_beta   50.43425000
+_cell_angle_gamma   74.88681000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   53.67353076
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.01536487  0.60462543  0.81931305  1
+  C  C1  1  0.43169301  0.68308985  0.60264470  1
+  C  C2  1  0.87767646  0.92708021  0.56735033  1
+  C  C3  1  0.06265237  -0.07027266  0.11136804  1
+  C  C4  1  0.91763939  0.26544436  0.55663256  1
+  C  C5  1  0.46131960  0.84842124  0.78403641  1
+  C  C6  1  0.83045110  0.60205077  0.27515752  1
+  C  C7  1  0.97556610  0.26641200  0.82980489  1
+",-154.0854775
+4997,C-176689-6597-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47926000
+_cell_length_b   3.68895000
+_cell_length_c   4.89344000
+_cell_angle_alpha   87.23293000
+_cell_angle_beta   120.46652000
+_cell_angle_gamma   70.38946000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99782992
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.54956598  0.36937239  0.75781396  1
+  C  C1  1  0.16715526  0.73016643  0.05536523  1
+  C  C2  1  1.04248772  0.12840798  0.13017863  1
+  C  C3  1  0.59562702  0.28512787  0.26163391  1
+  C  C4  1  0.99632505  0.21239360  0.62666860  1
+  C  C5  1  0.42578606  0.76737293  0.83279546  1
+",-154.31402483333332
+9778,C-106842-844-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.30235000
+_cell_length_b   4.32522000
+_cell_length_c   6.17710000
+_cell_angle_alpha   86.10856000
+_cell_angle_beta   95.48332000
+_cell_angle_gamma   120.33857000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   75.77917076
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40976378  0.65958247  0.15065474  1
+  C  C1  1  0.41255671  0.86259577  0.54222526  1
+  C  C2  1  0.47133389  0.32775743  0.14572678  1
+  C  C3  1  0.40066100  0.16120947  0.93775219  1
+  C  C4  1  0.71142814  0.83489636  0.36491092  1
+  C  C5  1  0.11834545  0.18391614  0.33094363  1
+  C  C6  1  -0.04811246  0.44371208  0.25580451  1
+  C  C7  1  0.90196134  0.59866106  0.44752038  1
+  C  C8  1  0.44143535  0.85526261  -0.05585015  1
+  C  C9  1  0.41112319  0.36165461  0.75003538  1
+  C  C10  1  0.44641823  0.69708619  0.75575564  1
+  C  C11  1  0.46873718  0.25070701  0.53919063  1
+",-154.13921
+7645,C-34639-131-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43751000
+_cell_length_b   5.65525000
+_cell_length_c   7.45909000
+_cell_angle_alpha   80.57557000
+_cell_angle_beta   99.42295000
+_cell_angle_gamma   90.03449000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   100.02872232
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.56664258  0.92929734  0.54221966  1
+  C  C1  1  0.11084270  0.79394600  0.62827076  1
+  C  C2  1  0.09279063  0.54117591  0.58864989  1
+  C  C3  1  0.90908037  0.42772434  0.22677694  1
+  C  C4  1  0.55297025  0.43431019  0.51075475  1
+  C  C5  1  0.81265695  0.06358736  1.03694310  1
+  C  C6  1  0.18543920  0.40587079  0.76980550  1
+  C  C7  1  1.26425259  0.49988944  0.93475028  1
+  C  C8  1  0.81481555  0.38682770  1.03922488  1
+  C  C9  1  0.45371465  0.43640968  0.31458925  1
+  C  C10  1  0.61217543  0.16010864  0.62458595  1
+  C  C11  1  0.26049273  0.99759368  0.92908990  1
+  C  C12  1  0.21836732  0.76485175  0.84911831  1
+  C  C13  1  0.17356130  0.16455035  0.74685863  1
+  C  C14  1  0.91286297  0.97040686  0.23838518  1
+  C  C15  1  0.46064978  -0.04753093  0.33418643  1
+",-154.087675625
+4617,C-152575-7588-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45776000
+_cell_length_b   3.19428000
+_cell_length_c   9.57269000
+_cell_angle_alpha   97.38973000
+_cell_angle_beta   82.63962000
+_cell_angle_gamma   67.38972000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   67.49416749
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79200178  0.29757703  0.26586450  1
+  C  C1  1  0.36786409  0.22979111  0.18221053  1
+  C  C2  1  0.28329949  0.52170542  0.05575231  1
+  C  C3  1  0.55969489  1.09008333  0.93204547  1
+  C  C4  1  0.29225716  0.85454916  0.70499814  1
+  C  C5  1  -0.12265067  0.75951383  0.62951507  1
+  C  C6  1  1.04418769  0.56969114  0.48579504  1
+  C  C7  1  0.13463146  0.02391986  0.84860238  1
+  C  C8  1  0.63158084  0.47166671  0.40958444  1
+  C  C9  1  0.64397527  0.79736532  1.05831391  1
+",-154.278957
+3591,C-13900-9247-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.99856000
+_cell_length_b   4.24683000
+_cell_length_c   4.19934000
+_cell_angle_alpha   119.32644000
+_cell_angle_beta   90.38817000
+_cell_angle_gamma   111.43200000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.24686946
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63552326  0.76829577  0.65174859  1
+  C  C1  1  -0.03112397  0.10172530  0.31850233  1
+  C  C2  1  0.30206158  0.43510325  0.65268426  1
+  C  C3  1  -0.03094354  0.10123077  0.98565242  1
+  C  C4  1  0.30256652  0.43446989  0.98465068  1
+  C  C5  1  0.63531055  0.76844231  0.31946773  1
+",-154.42320833333335
+646,C-13925-8845-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46929000
+_cell_length_b   3.23661000
+_cell_length_c   5.17669000
+_cell_angle_alpha   87.29405000
+_cell_angle_beta   89.99759000
+_cell_angle_gamma   67.59620000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   38.20011856
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.24360881  0.20962534  0.85459180  1
+  C  C1  1  0.43672138  0.82675250  0.07450475  1
+  C  C2  1  0.07425370  0.54951836  0.07223897  1
+  C  C3  1  0.74390133  0.20915859  0.70149807  1
+  C  C4  1  0.26762515  0.16648402  0.29384794  1
+  C  C5  1  0.76741953  1.16680470  0.44692207  1
+",-154.25292716666667
+8612,C-47640-4572-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48699000
+_cell_length_b   3.51624000
+_cell_length_c   4.97446000
+_cell_angle_alpha   89.98640000
+_cell_angle_beta   90.02103000
+_cell_angle_gamma   90.00401000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.50092076
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.54416217  0.59128162  0.93228764  1
+  C  C1  1  0.54424117  0.59126740  0.43227306  1
+  C  C2  1  0.04416938  0.84185707  0.93229711  1
+  C  C3  1  0.54425047  0.34181445  0.18230053  1
+  C  C4  1  0.54415002  0.34189187  0.68230227  1
+  C  C5  1  0.04415559  0.09128498  0.68228284  1
+  C  C6  1  0.04425738  0.09126326  0.18228128  1
+  C  C7  1  0.04424002  0.84185965  0.43229287  1
+",-154.55254125
+4634,C-41264-888-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42500000
+_cell_length_b   4.20501000
+_cell_length_c   4.86541000
+_cell_angle_alpha   89.69686000
+_cell_angle_beta   119.97517000
+_cell_angle_gamma   89.86554000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.97582016
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.25942931  -0.09061940  0.83417945  1
+  C  C1  1  0.26230207  0.99528574  0.33755126  1
+  C  C2  1  0.91204441  0.84686640  0.48697871  1
+  C  C3  1  -0.14854327  0.49880500  0.42780854  1
+  C  C4  1  0.32121660  0.34318250  0.39781310  1
+  C  C5  1  0.91537147  0.93519656  -0.01016966  1
+",-154.295626
+9964,C-76038-158-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43078000
+_cell_length_b   3.09868000
+_cell_length_c   8.01890000
+_cell_angle_alpha   93.02732000
+_cell_angle_beta   105.06743000
+_cell_angle_gamma   83.43432000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.92421147
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.27558158  0.22998860  0.82486991  1
+  C  C1  1  0.44132331  0.06280810  -0.00893638  1
+  C  C2  1  0.69151715  0.31366708  0.74127236  1
+  C  C3  1  1.02539000  0.98273587  0.07532358  1
+  C  C4  1  0.77520127  0.74566446  0.32737223  1
+  C  C5  1  0.19105213  0.82565581  0.24299201  1
+  C  C6  1  0.94131979  0.57421593  0.49289378  1
+  C  C7  1  0.52548277  0.48961295  0.57647242  1
+",-154.45169875
+988,C-34643-7107-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48720000
+_cell_length_b   4.06173000
+_cell_length_c   4.69299000
+_cell_angle_alpha   106.03009000
+_cell_angle_beta   89.99709000
+_cell_angle_gamma   90.00534000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.56669798
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.38801331  0.82572484  0.11231173  1
+  C  C1  1  0.88814628  0.25260137  0.88320077  1
+  C  C2  1  -0.11203424  0.59309231  0.46558080  1
+  C  C3  1  1.38804051  0.79425061  0.57964611  1
+  C  C4  1  0.38830012  0.05959603  0.42072305  1
+  C  C5  1  0.88827072  0.26070388  0.53492281  1
+  C  C6  1  0.38797022  0.02745001  0.88801441  1
+  C  C7  1  -0.11200772  0.60099656  0.11736063  1
+",-154.362585
+2198,C-90863-258-62,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43067000
+_cell_length_b   4.01816000
+_cell_length_c   6.68828000
+_cell_angle_alpha   107.68342000
+_cell_angle_beta   112.46028000
+_cell_angle_gamma   89.17931000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.13053366
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46988633  0.70215569  0.46613050  1
+  C  C1  1  0.71984280  0.20219813  0.21608491  1
+  C  C2  1  0.80186612  0.37034366  0.79819596  1
+  C  C3  1  1.05198658  0.87018259  0.54836965  1
+  C  C4  1  0.21976586  0.20231676  0.71595680  1
+  C  C5  1  0.30203369  0.37012048  0.29842222  1
+  C  C6  1  -0.03028124  0.70237887  -0.03409577  1
+  C  C7  1  0.55190964  0.87030123  0.04824154  1
+",-154.457595
+7323,C-106079-687-70,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47724000
+_cell_length_b   6.99908000
+_cell_length_c   8.52802000
+_cell_angle_alpha   107.12307000
+_cell_angle_beta   92.87543000
+_cell_angle_gamma   92.26928000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C24
+_cell_volume   140.90113364
+_cell_formula_units_Z   24
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.81671542  0.09900125  0.62117844  1
+  C  C1  1  0.63644739  0.76315582  0.47693616  1
+  C  C2  1  0.52856316  0.61998911  0.74708013  1
+  C  C3  1  0.07188916  0.67838754  0.09006460  1
+  C  C4  1  0.65068331  -0.02920662  0.43661383  1
+  C  C5  1  0.05406480  0.04385702  0.19214617  1
+  C  C6  1  0.48315675  0.40442779  0.67892672  1
+  C  C7  1  0.05141129  0.36201341  0.05385045  1
+  C  C8  1  0.54187828  0.48996980  0.85533792  1
+  C  C9  1  0.05558072  0.49740279  -0.05140144  1
+  C  C10  1  1.05983885  0.28040332  0.42908716  1
+  C  C11  1  0.99109086  0.91172041  0.89515096  1
+  C  C12  1  0.02157022  0.86133787  0.05836163  1
+  C  C13  1  1.04255786  0.73036101  0.74118431  1
+  C  C14  1  0.46860155  0.03943027  -0.11990274  1
+  C  C15  1  0.56795339  0.34372593  0.35144206  1
+  C  C16  1  1.11722645  0.04156375  0.36596878  1
+  C  C17  1  0.53484067  0.23395556  0.03365554  1
+  C  C18  1  0.60411673  0.56167559  0.32418656  1
+  C  C19  1  0.95974891  0.30634546  0.60647781  1
+  C  C20  1  0.15694276  0.80036750  0.59058635  1
+  C  C21  1  0.55439836  0.16861171  0.18445360  1
+  C  C22  1  1.08561280  0.55643565  0.21552504  1
+  C  C23  1  0.32735420  0.03278695  0.69265205  1
+",-154.08993666666666
+2400,C-141065-1801-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48683000
+_cell_length_b   4.30387000
+_cell_length_c   4.30384000
+_cell_angle_alpha   131.80294000
+_cell_angle_beta   106.79584000
+_cell_angle_gamma   73.20536000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.57231385
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.92523340  0.58829699  0.42580448  1
+  C  C1  1  1.09177552  0.17150896  0.34235059  1
+  C  C2  1  0.75831661  0.50483918  1.00901939  1
+  C  C3  1  0.59177449  0.92162722  0.09247328  1
+  C  C4  1  0.42524266  0.83817251  0.67568132  1
+  C  C5  1  0.25830735  0.25496366  0.75914255  1
+",-154.54030783333334
+8185,C-53836-3159-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.74048000
+_cell_length_b   4.80994000
+_cell_length_c   4.80762000
+_cell_angle_alpha   44.23486000
+_cell_angle_beta   87.67411000
+_cell_angle_gamma   88.02625000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.17055166
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.81805418  0.44786209  0.55791514  1
+  C  C1  1  0.81774857  0.82958613  0.17630409  1
+  C  C2  1  0.81813142  -0.11216532  0.61717331  1
+  C  C3  1  0.81816598  0.10159476  0.21225651  1
+  C  C4  1  0.81814843  0.48327046  0.83062782  1
+  C  C5  1  0.81791132  0.04310027  0.77147462  1
+",-154.08521483333334
+1482,C-106833-6336-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50520000
+_cell_length_b   4.25075000
+_cell_length_c   4.80814000
+_cell_angle_alpha   116.20636000
+_cell_angle_beta   89.93611000
+_cell_angle_gamma   90.10420000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.93863856
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.58440414  0.74635154  0.74961900  1
+  C  C1  1  0.08427808  -0.15462934  -0.05350417  1
+  C  C2  1  0.58387349  0.72066605  0.43005984  1
+  C  C3  1  0.08325586  0.47820166  0.94633359  1
+  C  C4  1  0.08352888  0.50498594  0.26667056  1
+  C  C5  1  0.58346380  0.08676435  0.43023707  1
+  C  C6  1  1.08385652  0.13875235  0.26652600  1
+  C  C7  1  0.58328283  0.38025274  0.74953092  1
+",-154.2529525
+4889,C-73657-5503-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48183000
+_cell_length_b   3.66758000
+_cell_length_c   5.57179000
+_cell_angle_alpha   70.73719000
+_cell_angle_beta   77.12091000
+_cell_angle_gamma   90.00791000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.52257927
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.39377795  0.42833443  0.68766909  1
+  C  C1  1  0.78489352  0.81597725  0.91160359  1
+  C  C2  1  0.66164670  0.43311652  0.15485568  1
+  C  C3  1  0.28498853  0.05513703  0.91133628  1
+  C  C4  1  -0.10617295  0.66725968  0.68742461  1
+  C  C5  1  1.16169890  0.19447500  0.15480498  1
+  C  C6  1  0.54848057  0.58251846  0.37898023  1
+  C  C7  1  0.04843209  0.82077354  0.37901744  1
+",-154.24501875
+6403,C-193936-350-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48154000
+_cell_length_b   3.68918000
+_cell_length_c   4.84087000
+_cell_angle_alpha   122.57164000
+_cell_angle_beta   75.14734000
+_cell_angle_gamma   109.67322000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.00928488
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40102352  0.45190537  0.00969662  1
+  C  C1  1  -0.11853332  0.63398072  0.23119239  1
+  C  C2  1  0.62590378  0.69114198  0.80288503  1
+  C  C3  1  0.65967344  0.39485207  0.43783310  1
+  C  C4  1  0.08135975  0.10721378  0.30690738  1
+  C  C5  1  1.20445884  -0.02147673  0.93357698  1
+",-154.3125605
+9767,C-92134-5968-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48224000
+_cell_length_b   3.72842000
+_cell_length_c   4.58448000
+_cell_angle_alpha   90.02330000
+_cell_angle_beta   122.78127000
+_cell_angle_gamma   89.99150000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.67157096
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.60705606  0.28052366  0.38545114  1
+  C  C1  1  0.10697053  1.04260761  0.38530134  1
+  C  C2  1  0.01633331  0.28031141  0.79443685  1
+  C  C3  1  0.80959568  0.77627677  0.08959171  1
+  C  C4  1  0.30980060  0.54647597  0.08976631  1
+  C  C5  1  0.51602553  0.04246869  0.79424535  1
+",-154.15116316666666
+2742,C-92154-4888-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.23429000
+_cell_length_b   2.47287000
+_cell_length_c   6.10854000
+_cell_angle_alpha   101.64966000
+_cell_angle_beta   111.93065000
+_cell_angle_gamma   112.55787000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   38.30481753
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.06384852  0.33198509  0.14982909  1
+  C  C1  1  0.64242388  0.72981888  0.36861270  1
+  C  C2  1  0.05398865  0.64056182  0.77781699  1
+  C  C3  1  0.79449398  0.38231851  0.52144652  1
+  C  C4  1  0.20702896  0.29397384  0.93073290  1
+  C  C5  1  0.78615212  0.69300696  0.14971250  1
+",-154.25466616666668
+1641,C-13889-6847-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.94569000
+_cell_length_b   4.19183000
+_cell_length_c   4.43638000
+_cell_angle_alpha   112.18503000
+_cell_angle_beta   101.33091000
+_cell_angle_gamma   58.29699000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.15525961
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46299283  0.15695608  0.73535321  1
+  C  C1  1  0.48965817  0.42626178  1.04536244  1
+  C  C2  1  0.11147213  0.80922358  0.04584275  1
+  C  C3  1  0.89904736  0.21235710  0.23522709  1
+  C  C4  1  0.84050152  0.77397140  0.73488547  1
+  C  C5  1  1.05345758  0.37087096  0.54533704  1
+",-154.12640866666666
+8326,C-41262-9862-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49184000
+_cell_length_b   4.35130000
+_cell_length_c   3.59360000
+_cell_angle_alpha   84.31101000
+_cell_angle_beta   110.28243000
+_cell_angle_gamma   106.60292000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.02472108
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.98599250  0.32446545  0.60608622  1
+  C  C1  1  0.27499782  0.53036913  -0.02344702  1
+  C  C2  1  0.35769046  0.32481973  0.34750347  1
+  C  C3  1  0.88025920  0.74269487  -0.02380652  1
+  C  C4  1  0.16828863  0.94844667  0.34715558  1
+  C  C5  1  0.79732610  0.94831376  0.60580288  1
+",-154.19772633333335

--- a/data/ocp/val.csv
+++ b/data/ocp/val.csv
@@ -1,0 +1,16472 @@
+,material_id,cif,energy_per_atom
+2649,C-148264-7891-51,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48442000
+_cell_length_b   3.82397000
+_cell_length_c   5.98106000
+_cell_angle_alpha   120.34611000
+_cell_angle_beta   78.04820000
+_cell_angle_gamma   108.96027000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.31214527
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55960569  0.91296846  0.96734457  1
+  C  C1  1  -0.05100441  -0.20340566  0.07354088  1
+  C  C2  1  0.32074671  0.21342041  0.74557987  1
+  C  C3  1  0.28329421  -0.14011865  0.46598596  1
+  C  C4  1  0.52287208  0.55943895  0.68772460  1
+  C  C5  1  0.77493588  0.28459484  0.91073721  1
+  C  C6  1  0.89352450  -0.02434117  0.35977126  1
+  C  C7  1  1.06854384  0.48804132  0.52246945  1
+",-154.223695
+3587,C-130499-1826-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.89060000
+_cell_length_b   3.63590000
+_cell_length_c   4.81917000
+_cell_angle_alpha   112.10185000
+_cell_angle_beta   93.24400000
+_cell_angle_gamma   107.33042000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.97479101
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.45394228  0.24907323  0.60843244  1
+  C  C1  1  0.45264853  0.62906740  0.60777971  1
+  C  C2  1  0.44727613  0.59311715  0.30004157  1
+  C  C3  1  0.44908388  0.18712333  0.10821224  1
+  C  C4  1  0.45089841  0.03507314  0.79946885  1
+  C  C5  1  0.44652468  -0.02682335  0.29920659  1
+",-154.13165216666667
+8922,C-34635-9264-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48342000
+_cell_length_b   3.99972000
+_cell_length_c   7.50521000
+_cell_angle_alpha   96.62688000
+_cell_angle_beta   99.47775000
+_cell_angle_gamma   108.08889000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   68.78594582
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.03242347  0.13701408  0.25676218  1
+  C  C1  1  0.26015219  0.20361742  0.76635980  1
+  C  C2  1  0.61338574  0.98739178  0.68958851  1
+  C  C3  1  0.80957122  0.66817442  0.41057537  1
+  C  C4  1  1.10265859  0.73434766  0.92164692  1
+  C  C5  1  0.93097415  0.24400064  0.07122086  1
+  C  C6  1  0.31621725  0.12305230  0.96266531  1
+  C  C7  1  0.13902110  0.62705762  0.10625101  1
+  C  C8  1  0.75349451  0.74830060  0.21444254  1
+  C  C9  1  0.45630582  0.88363121  0.48748291  1
+  C  C10  1  -0.42349665  0.23966340  0.37316424  1
+  C  C11  1  0.49288555  0.63120507  0.80514595  1
+",-154.25491833333334
+9892,C-57111-4456-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50075000
+_cell_length_b   5.04877000
+_cell_length_c   6.62330000
+_cell_angle_alpha   123.43969000
+_cell_angle_beta   96.05694000
+_cell_angle_gamma   92.02550000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   68.94994185
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.25079884  0.80818903  0.87964911  1
+  C  C1  1  0.57205197  0.29344857  0.70396534  1
+  C  C2  1  0.35983197  0.31305561  0.28605250  1
+  C  C3  1  0.40164990  0.93542241  0.50949447  1
+  C  C4  1  0.29488495  0.42866374  0.10348482  1
+  C  C5  1  -0.11879705  0.80930327  0.56399501  1
+  C  C6  1  0.33254947  0.78897928  0.24521756  1
+  C  C7  1  0.77303117  0.93457271  0.82510112  1
+  C  C8  1  0.31829552  0.95198515  0.14308821  1
+  C  C9  1  0.73169498  0.28806107  0.94217184  1
+  C  C10  1  0.07851485  0.45019711  0.68523717  1
+  C  C11  1  0.92198473  0.45521975  0.44721315  1
+",-154.12753999999998
+9845,C-47660-7998-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.32211000
+_cell_length_b   3.91446000
+_cell_length_c   3.78642000
+_cell_angle_alpha   91.80922000
+_cell_angle_beta   96.03070000
+_cell_angle_gamma   105.82015000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.01895785
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.34902803  0.79019650  0.83757023  1
+  C  C1  1  0.07339330  1.00550593  0.29315188  1
+  C  C2  1  0.40341085  0.38793731  0.30351279  1
+  C  C3  1  0.77572304  0.05562924  0.95989110  1
+  C  C4  1  0.59043435  0.56724194  0.66805696  1
+  C  C5  1  0.72354663  0.40722653  0.01574744  1
+  C  C6  1  0.15361381  0.64548625  1.14745721  1
+  C  C7  1  -0.02532080  0.89955370  0.65597457  1
+",-154.08110125
+3497,C-170350-1491-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.26254000
+_cell_length_b   3.63531000
+_cell_length_c   3.27822000
+_cell_angle_alpha   75.36134000
+_cell_angle_beta   80.81749000
+_cell_angle_gamma   75.45741000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.22115181
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.96505380  0.41637727  0.25025324  1
+  C  C1  1  0.60307934  0.41620243  0.61096059  1
+  C  C2  1  0.33669191  0.79778028  0.66485695  1
+  C  C3  1  0.39204500  0.17926066  0.39918065  1
+  C  C4  1  0.02050844  0.79817602  -0.01736585  1
+  C  C5  1  0.75293881  0.17989044  0.03724502  1
+",-154.20185033333334
+8008,C-76016-983-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52410000
+_cell_length_b   4.36787000
+_cell_length_c   5.29921000
+_cell_angle_alpha   126.23834000
+_cell_angle_beta   94.22571000
+_cell_angle_gamma   94.15302000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.50316206
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.34589620  0.03065685  0.81215638  1
+  C  C1  1  0.38574583  0.35198984  0.42674669  1
+  C  C2  1  0.54683201  0.42820521  -0.05838569  1
+  C  C3  1  0.59899976  0.53184852  0.75749297  1
+  C  C4  1  -0.15184954  1.10347932  0.27095070  1
+  C  C5  1  0.30705936  0.73114203  0.44628972  1
+  C  C6  1  0.76993957  0.74984399  0.28512971  1
+  C  C7  1  0.82558311  -0.06675136  -0.07850939  1
+",-154.07819
+2710,C-28240-2315-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.86054000
+_cell_length_b   4.25509000
+_cell_length_c   3.28269000
+_cell_angle_alpha   78.42477000
+_cell_angle_beta   119.53058000
+_cell_angle_gamma   107.36522000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.68768149
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.61088944  0.39611156  0.34229308  1
+  C  C1  1  0.34079017  0.08876224  0.37630797  1
+  C  C2  1  0.99331801  0.39657458  -0.27698244  1
+  C  C3  1  0.95849747  0.08782684  0.99423670  1
+  C  C4  1  0.55423520  0.89678426  0.78101905  1
+  C  C5  1  0.39753270  0.58791032  -0.06270116  1
+",-154.11743183333334
+5644,C-170366-7168-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47268000
+_cell_length_b   3.23370000
+_cell_length_c   6.12938000
+_cell_angle_alpha   57.76137000
+_cell_angle_beta   78.33668000
+_cell_angle_gamma   67.49159000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   38.29628173
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.35251217  0.14051364  0.36868150  1
+  C  C1  1  0.67124428  0.12931198  0.74047664  1
+  C  C2  1  0.35340429  0.39531590  0.11223771  1
+  C  C3  1  0.85201538  0.98810170  0.52149285  1
+  C  C4  1  0.85380764  0.54761886  0.95917249  1
+  C  C5  1  0.03276523  0.40638142  0.74079091  1
+",-154.25429333333332
+10134,C-41268-3496-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47958000
+_cell_length_b   3.68891000
+_cell_length_c   4.89326000
+_cell_angle_alpha   92.82778000
+_cell_angle_beta   120.43739000
+_cell_angle_gamma   109.62086000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99704167
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.39032185  0.32955208  1.03694372  1
+  C  C1  1  0.79212497  0.40117683  0.40204307  1
+  C  C2  1  -0.03826826  0.88432373  0.83071783  1
+  C  C3  1  0.83777737  0.48612108  0.90560586  1
+  C  C4  1  0.22078606  0.84635388  0.60840035  1
+  C  C5  1  0.34492691  0.24416091  0.53292206  1
+",-154.315255
+6429,C-141033-8048-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.16074000
+_cell_length_b   4.05336000
+_cell_length_c   4.18902000
+_cell_angle_alpha   108.14530000
+_cell_angle_beta   99.30239000
+_cell_angle_gamma   58.88617000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.66255433
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.72271776  0.83223592  0.35898632  1
+  C  C1  1  -0.21770842  0.27122469  0.86018110  1
+  C  C2  1  0.37663049  0.48533916  0.67066038  1
+  C  C3  1  0.99762084  0.86773778  0.67079754  1
+  C  C4  1  0.34482551  0.21470905  0.35864624  1
+  C  C5  1  0.93812213  0.42860100  0.16956021  1
+",-154.10564966666666
+9997,C-41290-3170-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.68959000
+_cell_length_b   4.81697000
+_cell_length_c   5.47400000
+_cell_angle_alpha   131.83882000
+_cell_angle_beta   118.44041000
+_cell_angle_gamma   85.39766000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.30112238
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.82216109  0.29343033  0.83495893  1
+  C  C1  1  0.26332501  0.23514319  0.27532348  1
+  C  C2  1  0.20706190  0.67644997  0.21834441  1
+  C  C3  1  0.47627389  0.63955286  0.48823708  1
+  C  C4  1  0.42005800  0.08111434  0.43149767  1
+  C  C5  1  0.86145062  0.02245882  -0.12812528  1
+",-154.11072316666667
+8845,C-193946-2107-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46241000
+_cell_length_b   3.39398000
+_cell_length_c   6.10676000
+_cell_angle_alpha   110.81737000
+_cell_angle_beta   101.58078000
+_cell_angle_gamma   111.32435000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.12378699
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.32870649  0.48062460  1.01953989  1
+  C  C1  1  0.70454702  0.03626146  0.21656603  1
+  C  C2  1  0.47601448  0.17932761  0.61774279  1
+  C  C3  1  0.23550604  0.97350495  0.34251570  1
+  C  C4  1  -0.13900501  0.41930350  0.14591884  1
+  C  C5  1  0.08637018  0.27293779  0.74432115  1
+",-154.16504516666666
+4161,C-172943-9308-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.25001000
+_cell_length_b   3.63330000
+_cell_length_c   3.28538000
+_cell_angle_alpha   104.64201000
+_cell_angle_beta   80.86630000
+_cell_angle_gamma   104.45991000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.15593619
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.88042681  0.31387889  0.63241720  1
+  C  C1  1  0.61150565  0.93211919  0.68527322  1
+  C  C2  1  0.29642200  -0.06897846  0.00451603  1
+  C  C3  1  0.66801321  0.55086326  0.41829363  1
+  C  C4  1  0.02968990  0.54952655  0.05763720  1
+  C  C5  1  1.24085443  0.31250837  0.27145713  1
+",-154.19155783333335
+280,C-72728-4135-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48364000
+_cell_length_b   4.59728000
+_cell_length_c   7.40504000
+_cell_angle_alpha   63.84937000
+_cell_angle_beta   47.82725000
+_cell_angle_gamma   74.28344000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.20851232
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.38757163  1.00601663  0.40223640  1
+  C  C1  1  0.52699401  0.25752812  0.01964902  1
+  C  C2  1  0.59102378  0.87391001  0.08396952  1
+  C  C3  1  0.12890065  0.79301214  0.83471927  1
+  C  C4  1  0.98142702  0.20829919  0.30437999  1
+  C  C5  1  0.79126967  0.77492972  0.25826554  1
+  C  C6  1  0.77865834  0.34053788  0.62263133  1
+  C  C7  1  0.84201302  0.95719487  0.68692174  1
+  C  C8  1  0.24034176  0.42174396  0.87181828  1
+  C  C9  1  0.57800293  0.43914148  0.44839021  1
+",-154.385817
+7034,C-148219-4273-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43041000
+_cell_length_b   4.00680000
+_cell_length_c   6.19713000
+_cell_angle_alpha   70.80483000
+_cell_angle_beta   88.96155000
+_cell_angle_gamma   91.57358000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.94848332
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.43987491  1.04586925  0.60928877  1
+  C  C1  1  0.43987252  0.54572609  0.10938154  1
+  C  C2  1  -0.06004774  0.79739226  0.35808433  1
+  C  C3  1  0.43975194  0.88146337  0.44178655  1
+  C  C4  1  0.93997621  0.63319099  0.19066163  1
+  C  C5  1  -0.06000859  0.13330278  0.69057656  1
+  C  C6  1  0.43976523  0.38143682  0.94180407  1
+  C  C7  1  0.93995872  0.29741844  0.85805064  1
+",-154.4673775
+3091,C-184031-5230-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47357000
+_cell_length_b   3.72189000
+_cell_length_c   4.25160000
+_cell_angle_alpha   116.00275000
+_cell_angle_beta   89.97220000
+_cell_angle_gamma   90.08233000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.17950324
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.09137156  0.32273872  0.27291167  1
+  C  C1  1  0.09149790  0.91463192  0.27309249  1
+  C  C2  1  0.59150873  0.93412896  0.49540806  1
+  C  C3  1  0.59137643  0.52622368  0.49576779  1
+  C  C4  1  0.59139475  0.36912712  0.77359405  1
+  C  C5  1  0.09140044  0.47942479  -0.00507266  1
+",-154.28912983333333
+5437,C-102860-4456-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47413000
+_cell_length_b   3.69686000
+_cell_length_c   6.24511000
+_cell_angle_alpha   75.31537000
+_cell_angle_beta   101.42631000
+_cell_angle_gamma   90.01794000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   54.08494678
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.06183476  0.27910945  0.41520691  1
+  C  C1  1  0.06178522  0.68673755  0.41436596  1
+  C  C2  1  0.15429672  -0.09499659  0.59824751  1
+  C  C3  1  0.49121934  0.84008998  0.27314300  1
+  C  C4  1  0.72140238  0.83477808  0.73196169  1
+  C  C5  1  0.49035312  0.24777337  0.27199614  1
+  C  C6  1  0.83299333  0.69348928  -0.04590197  1
+  C  C7  1  0.39936553  0.62362267  0.08789648  1
+",-154.2147225
+8058,C-96700-8739-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48270000
+_cell_length_b   3.68848000
+_cell_length_c   4.89597000
+_cell_angle_alpha   113.04103000
+_cell_angle_beta   120.52530000
+_cell_angle_gamma   70.33955000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99959047
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.08267070  0.73631331  0.20555970  1
+  C  C1  1  0.41284488  0.80504520  0.57046102  1
+  C  C2  1  0.37351572  0.89277635  0.07476234  1
+  C  C3  1  0.39658136  0.25053463  0.77695314  1
+  C  C4  1  0.12209966  0.64784656  0.70104452  1
+  C  C5  1  0.09954658  0.29058794  0.99930380  1
+",-154.31142433333335
+7532,C-148244-5888-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46275000
+_cell_length_b   4.24895000
+_cell_length_c   4.24911000
+_cell_angle_alpha   100.42283000
+_cell_angle_beta   89.99819000
+_cell_angle_gamma   90.01627000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.72945171
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.95402452  0.31791029  0.56654081  1
+  C  C1  1  0.71213773  0.84412376  0.09246799  1
+  C  C2  1  1.08318587  0.31574283  0.93094065  1
+  C  C3  1  0.58325195  0.47969411  0.09476276  1
+  C  C4  1  0.45403489  0.47759946  0.45850547  1
+  C  C5  1  0.33270427  0.82922762  0.58016249  1
+  C  C6  1  0.83269739  -0.03376342  0.44408434  1
+  C  C7  1  0.21207489  0.95159235  0.93271749  1
+",-154.23614875
+472,C-113050-8539-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46403000
+_cell_length_b   7.51474000
+_cell_length_c   5.94335000
+_cell_angle_alpha   99.06812000
+_cell_angle_beta   114.52057000
+_cell_angle_gamma   80.53863000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   98.27197387
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17595357  0.70442897  0.71696788  1
+  C  C1  1  0.73770554  0.60211196  0.72811114  1
+  C  C2  1  0.53774862  0.29855039  0.37600780  1
+  C  C3  1  0.55930086  0.99881856  0.24921820  1
+  C  C4  1  0.74432496  0.11632231  0.49126312  1
+  C  C5  1  0.17195745  -0.11975326  0.79999943  1
+  C  C6  1  0.66111387  0.98999818  0.84458473  1
+  C  C7  1  -0.36850671  0.79685533  0.22030330  1
+  C  C8  1  0.39178436  0.33188803  0.74733189  1
+  C  C9  1  0.07208480  0.53682670  0.03003592  1
+  C  C10  1  0.89554914  0.07050053  0.12141571  1
+  C  C11  1  0.73288455  0.40768021  0.62676082  1
+  C  C12  1  0.61931961  0.41801896  0.01733617  1
+  C  C13  1  0.14513490  0.70568409  0.18831315  1
+  C  C14  1  0.88217684  0.28337200  0.21324404  1
+  C  C15  1  0.40030384  0.12928404  0.65366419  1
+",-154.262339375
+10102,C-13640-2755-55,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44379000
+_cell_length_b   6.49928000
+_cell_length_c   4.19715000
+_cell_angle_alpha   111.44099000
+_cell_angle_beta   89.93202000
+_cell_angle_gamma   100.79228000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   60.78673611
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.08382091  0.54834620  1.11114656  1
+  C  C1  1  0.61535826  0.60027333  0.64250368  1
+  C  C2  1  0.10891320  0.58804957  0.47870693  1
+  C  C3  1  0.62894191  0.63928836  1.00976214  1
+  C  C4  1  0.74818409  0.88738819  0.09924753  1
+  C  C5  1  0.30055020  -0.00782448  0.08834080  1
+  C  C6  1  -0.04413233  0.30016887  0.02169091  1
+  C  C7  1  0.40213815  0.19520995  0.03240887  1
+",-154.20422625
+3783,C-141022-7340-54,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47368000
+_cell_length_b   4.23482000
+_cell_length_c   5.45922000
+_cell_angle_alpha   89.95554000
+_cell_angle_beta   90.00568000
+_cell_angle_gamma   90.01400000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.18852871
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.51032481  0.71854763  0.20643882  1
+  C  C1  1  0.01089553  0.20685314  0.20745568  1
+  C  C2  1  0.01112678  0.06913330  0.94591601  1
+  C  C3  1  0.51129061  0.04983797  0.57955274  1
+  C  C4  1  0.01027977  0.54673161  0.29277602  1
+  C  C5  1  0.01148096  0.20640536  0.68434917  1
+  C  C6  1  0.51060553  0.84869923  -0.05378654  1
+  C  C7  1  1.01062414  0.54648631  0.60022346  1
+  C  C8  1  0.51079649  0.05000423  0.31230553  1
+  C  C9  1  0.51075029  0.71826582  0.68624572  1
+",-154.354799
+8776,C-40124-9886-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.12022000
+_cell_length_b   5.64826000
+_cell_length_c   4.54986000
+_cell_angle_alpha   90.80269000
+_cell_angle_beta   112.29870000
+_cell_angle_gamma   100.70388000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   72.58312543
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.69762816  0.15897782  0.19085491  1
+  C  C1  1  0.30694634  0.77893268  0.94467932  1
+  C  C2  1  1.09700847  0.55690551  0.29826890  1
+  C  C3  1  0.44074819  0.90703878  0.73003316  1
+  C  C4  1  0.68445179  0.14865301  0.86958657  1
+  C  C5  1  0.88972784  0.34766450  0.74631401  1
+  C  C6  1  0.33061866  0.80044650  0.43518254  1
+  C  C7  1  0.89578131  0.35720388  0.42246925  1
+  C  C8  1  0.08224728  0.54667818  -0.02330303  1
+  C  C9  1  0.46060666  0.92869484  0.21946557  1
+",-154.19858
+510,C-130232-8829-68,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46366000
+_cell_length_b   6.25468000
+_cell_length_c   10.92258000
+_cell_angle_alpha   107.30121000
+_cell_angle_beta   110.23599000
+_cell_angle_gamma   87.06985000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C22
+_cell_volume   150.52465128
+_cell_formula_units_Z   22
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.22132910  0.31611328  0.70578215  1
+  C  C1  1  0.66885040  0.85251647  0.32527382  1
+  C  C2  1  0.69568212  0.47295652  0.40850921  1
+  C  C3  1  0.45034414  0.71385377  0.18360127  1
+  C  C4  1  1.22195816  0.91649200  0.81788305  1
+  C  C5  1  0.79301611  0.37908906  0.06711224  1
+  C  C6  1  0.81421952  0.98513933  0.88593365  1
+  C  C7  1  0.03752396  0.15954402  0.57879111  1
+  C  C8  1  0.51951390  0.35180422  0.26155602  1
+  C  C9  1  0.82281981  0.75678085  0.10815198  1
+  C  C10  1  0.81443666  0.38947027  0.77041570  1
+  C  C11  1  0.36063175  1.12106035  1.16765151  1
+  C  C12  1  0.28844678  0.54184355  0.47718145  1
+  C  C13  1  0.45899699  0.69258897  0.61379079  1
+  C  C14  1  0.41955941  0.46515796  0.15665534  1
+  C  C15  1  0.44958751  1.08111838  0.51680407  1
+  C  C16  1  0.63450581  0.55288897  0.98003239  1
+  C  C17  1  1.04623274  0.76886226  0.68007536  1
+  C  C18  1  0.89533146  0.12695880  1.02838385  1
+  C  C19  1  0.80261292  0.99968398  0.11894629  1
+  C  C20  1  0.01682043  0.51938378  0.90284808  1
+  C  C21  1  0.25703101  0.92625352  0.38727475  1
+",-154.1220768181818
+3515,C-126183-8981-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42988000
+_cell_length_b   3.57475000
+_cell_length_c   5.27611000
+_cell_angle_alpha   89.31857000
+_cell_angle_beta   82.89812000
+_cell_angle_gamma   81.11663000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.93107935
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.10590131  0.03802881  0.45909597  1
+  C  C1  1  0.54894774  0.14940250  0.57073694  1
+  C  C2  1  0.77276426  0.70556802  0.12526114  1
+  C  C3  1  0.43892750  0.37361495  0.79105192  1
+  C  C4  1  -0.11787242  0.48464210  0.90277158  1
+  C  C5  1  0.21588261  0.81646143  0.23699964  1
+",-154.43978866666666
+1068,C-57156-2568-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45623000
+_cell_length_b   3.66613000
+_cell_length_c   6.91848000
+_cell_angle_alpha   67.39133000
+_cell_angle_beta   110.81535000
+_cell_angle_gamma   109.60369000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.31088591
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.06998235  0.44687727  0.30432917  1
+  C  C1  1  0.35669194  0.55322842  0.67862584  1
+  C  C2  1  1.05290568  0.26304718  0.02121000  1
+  C  C3  1  0.91524300  0.45884307  0.78485212  1
+  C  C4  1  0.34284551  0.56513851  0.15847782  1
+  C  C5  1  0.51656949  1.01524637  0.10812406  1
+  C  C6  1  0.21611237  0.74784252  0.44169638  1
+  C  C7  1  0.75371786  0.99645957  0.35469710  1
+",-154.2850525
+10079,C-142742-7620-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47429000
+_cell_length_b   4.28172000
+_cell_length_c   4.80493000
+_cell_angle_alpha   63.51540000
+_cell_angle_beta   75.08198000
+_cell_angle_gamma   89.99867000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.63715204
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.33035904  0.87889147  0.31826553  1
+  C  C1  1  0.08003536  -0.03775751  0.81827942  1
+  C  C2  1  0.26775374  0.14930237  0.44413036  1
+  C  C3  1  0.51776467  0.06593588  0.94409728  1
+  C  C4  1  0.76795524  0.64932852  0.44412696  1
+  C  C5  1  0.01774063  0.56591710  0.94413889  1
+  C  C6  1  -0.16987028  0.37887086  0.31830572  1
+  C  C7  1  0.58003780  0.46225992  0.81829044  1
+",-154.52280625
+6367,C-56473-8976-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42993000
+_cell_length_b   3.88774000
+_cell_length_c   6.59647000
+_cell_angle_alpha   70.95755000
+_cell_angle_beta   97.36214000
+_cell_angle_gamma   96.27529000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.26905748
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.77373038  1.04780530  0.68055450  1
+  C  C1  1  0.77355361  0.71594752  0.84737166  1
+  C  C2  1  0.27358112  0.21596458  0.59737831  1
+  C  C3  1  0.27356672  0.21597334  0.09739330  1
+  C  C4  1  0.27371044  0.54783625  0.43056912  1
+  C  C5  1  0.77355382  0.71598292  0.34738739  1
+  C  C6  1  0.77372340  0.04783688  0.18057733  1
+  C  C7  1  0.27371032  0.54781411  0.93055599  1
+",-154.45161
+8581,C-176681-3152-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.67594000
+_cell_length_b   2.46299000
+_cell_length_c   10.81374000
+_cell_angle_alpha   90.00021000
+_cell_angle_beta   106.57524000
+_cell_angle_gamma   70.42111000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   87.91477488
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.32066024  0.28635323  0.71189763  1
+  C  C1  1  0.53332055  0.17676040  0.23180903  1
+  C  C2  1  0.45509897  0.21596075  0.85534658  1
+  C  C3  1  -0.03501183  0.96061150  1.11356067  1
+  C  C4  1  0.81488012  0.04103919  0.54221340  1
+  C  C5  1  1.20958696  0.84305327  0.51271685  1
+  C  C6  1  0.98233864  -0.04714074  0.25941541  1
+  C  C7  1  0.41516468  0.73484426  0.14382457  1
+  C  C8  1  0.53306867  0.67718885  0.91945815  1
+  C  C9  1  0.36016826  0.26783814  0.45987500  1
+  C  C10  1  0.46787467  -0.28709083  0.65861194  1
+  C  C11  1  0.23090864  0.32884947  0.31292438  1
+  C  C12  1  -0.28478287  0.58547148  1.06169246  1
+  C  C13  1  0.86290371  0.51700742  0.63035683  1
+",-154.2800592857143
+7145,C-176654-3153-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48072000
+_cell_length_b   3.68692000
+_cell_length_c   4.21395000
+_cell_angle_alpha   104.65986000
+_cell_angle_beta   90.10125000
+_cell_angle_gamma   70.42999000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98706813
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.65053538  0.72160669  0.94312194  1
+  C  C1  1  0.16953350  0.68399573  0.72096604  1
+  C  C2  1  0.39122148  0.23934931  0.51476860  1
+  C  C3  1  0.43119088  1.16653972  0.14922562  1
+  C  C4  1  0.96980199  0.08207958  0.64562231  1
+  C  C5  1  0.85317876  0.32281297  1.01792709  1
+",-154.30698316666667
+7017,C-72754-2980-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.64623000
+_cell_length_b   4.68470000
+_cell_length_c   8.33786000
+_cell_angle_alpha   100.70534000
+_cell_angle_beta   114.23772000
+_cell_angle_gamma   73.04983000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   89.89785595
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.62329293  0.24418425  0.63421936  1
+  C  C1  1  0.23231034  1.05166398  0.34619547  1
+  C  C2  1  0.79574854  0.27165924  0.06812926  1
+  C  C3  1  0.36331151  0.30698775  0.44490636  1
+  C  C4  1  0.24592607  0.54924572  0.35367626  1
+  C  C5  1  0.96386392  0.53200558  0.16168694  1
+  C  C6  1  1.02719852  -0.28117846  0.77627481  1
+  C  C7  1  0.71599910  0.89620818  0.61862523  1
+  C  C8  1  0.49207914  0.18501983  0.89584846  1
+  C  C9  1  0.41355486  0.80990132  0.44602658  1
+  C  C10  1  0.18123244  0.36233195  0.73877383  1
+  C  C11  1  -0.02357423  0.02976037  0.16778287  1
+  C  C12  1  0.84500772  0.77413832  0.06985516  1
+  C  C13  1  0.58557385  0.83673178  0.88108531  1
+",-154.09121785714288
+1534,C-13640-2755-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43246000
+_cell_length_b   4.85828000
+_cell_length_c   5.75936000
+_cell_angle_alpha   98.93532000
+_cell_angle_beta   88.53273000
+_cell_angle_gamma   59.78608000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.67103849
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.81831280  0.82408110  0.83614753  1
+  C  C1  1  0.48440984  0.15731319  0.83689915  1
+  C  C2  1  0.81833314  0.32406826  0.83614039  1
+  C  C3  1  0.04985303  0.65553772  0.33734722  1
+  C  C4  1  0.04987585  0.15551937  0.33730847  1
+  C  C5  1  1.38389977  0.82224012  0.33645302  1
+  C  C6  1  0.48437583  0.65733645  0.83693381  1
+  C  C7  1  0.38388653  0.32225038  0.33654201  1
+",-154.45315
+4417,C-34655-7081-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51249000
+_cell_length_b   4.70135000
+_cell_length_c   6.64424000
+_cell_angle_alpha   79.19131000
+_cell_angle_beta   78.93327000
+_cell_angle_gamma   74.43687000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   73.42688717
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.84370057  0.79898287  0.71253149  1
+  C  C1  1  0.76300451  0.53768347  0.13635865  1
+  C  C2  1  1.15182168  0.25149247  0.64428506  1
+  C  C3  1  0.68070114  0.49428589  0.34605938  1
+  C  C4  1  0.72440067  0.24332358  0.50851652  1
+  C  C5  1  0.92817636  0.35469606  0.98471458  1
+  C  C6  1  0.60061595  0.87606969  0.12087154  1
+  C  C7  1  0.97006763  0.47726427  0.78000620  1
+  C  C8  1  0.23041781  -0.04806869  0.78551611  1
+  C  C9  1  0.50580787  0.82115194  0.36746417  1
+  C  C10  1  1.08393785  0.01726235  0.01322811  1
+  C  C11  1  -0.09518614  0.91680270  0.47347321  1
+",-154.17264833333334
+9340,C-145300-1207-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43253000
+_cell_length_b   6.19880000
+_cell_length_c   6.14144000
+_cell_angle_alpha   133.60914000
+_cell_angle_beta   100.03880000
+_cell_angle_gamma   102.81257000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.93392910
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.19835138  0.97190089  0.80825944  1
+  C  C1  1  0.12719945  0.21019644  0.54905092  1
+  C  C2  1  0.19835138  0.47190089  0.30825944  1
+  C  C3  1  -0.13545124  0.13888144  -0.02484429  1
+  C  C4  1  0.86454876  0.63888144  0.47515571  1
+  C  C5  1  0.12719945  0.71019644  0.04905092  1
+  C  C6  1  0.46100207  0.54321590  -0.11784536  1
+  C  C7  1  0.46100207  0.04321590  0.38215464  1
+",-154.46805375
+4013,C-40110-5594-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.26115000
+_cell_length_b   5.45126000
+_cell_length_c   4.24252000
+_cell_angle_alpha   67.33673000
+_cell_angle_beta   49.72425000
+_cell_angle_gamma   40.13941000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.17363470
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.47620139  0.70835323  0.63204971  1
+  C  C1  1  0.47731898  0.70909954  0.31441843  1
+  C  C2  1  0.07037108  0.32769618  0.04733517  1
+  C  C3  1  0.88254143  0.09044858  0.26007248  1
+  C  C4  1  0.88321337  0.08978085  0.89920789  1
+  C  C5  1  0.07100035  0.32704513  0.68639922  1
+",-154.19341699999998
+9676,C-136217-3562-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48114000
+_cell_length_b   3.68943000
+_cell_length_c   4.21560000
+_cell_angle_alpha   104.69591000
+_cell_angle_beta   89.98724000
+_cell_angle_gamma   70.33940000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99558689
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.58662654  0.59824445  0.75775511  1
+  C  C1  1  0.90538345  0.95898300  0.46046973  1
+  C  C2  1  0.12894741  0.51384829  0.25428400  1
+  C  C3  1  0.16462440  0.44175891  0.88893500  1
+  C  C4  1  0.38625384  0.99668268  0.68277947  1
+  C  C5  1  0.70751526  0.35677747  0.38527268  1
+",-154.30877866666663
+8919,C-91030-8-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45827000
+_cell_length_b   8.71460000
+_cell_length_c   7.41598000
+_cell_angle_alpha   84.47323000
+_cell_angle_beta   90.01427000
+_cell_angle_gamma   73.66279000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C22
+_cell_volume   151.68567165
+_cell_formula_units_Z   22
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.30189983  0.86750324  0.17564920  1
+  C  C1  1  0.81535004  0.36048237  0.29004573  1
+  C  C2  1  -0.29883366  0.98787739  0.55050653  1
+  C  C3  1  0.06197926  0.61220382  0.21686911  1
+  C  C4  1  0.02097996  0.16478450  0.85044183  1
+  C  C5  1  0.20804559  0.47621272  0.70301802  1
+  C  C6  1  0.71964000  0.45995492  0.44396838  1
+  C  C7  1  0.78638832  0.39751680  0.63505052  1
+  C  C8  1  0.52303017  0.16155286  0.94336877  1
+  C  C9  1  0.41823372  0.25787641  0.30051535  1
+  C  C10  1  0.54807954  0.12565640  0.16354228  1
+  C  C11  1  1.28456509  0.90440424  0.57090824  1
+  C  C12  1  0.65059204  0.52480342  0.15915825  1
+  C  C13  1  0.18886493  0.49619667  0.89019278  1
+  C  C14  1  0.14037916  0.03182115  0.18643706  1
+  C  C15  1  1.03709516  0.64874417  0.58867860  1
+  C  C16  1  0.44784983  0.73912046  0.59853879  1
+  C  C17  1  -0.03167900  0.21623128  0.64286148  1
+  C  C18  1  0.11914588  0.56119348  0.41689857  1
+  C  C19  1  0.67549628  0.50893398  0.97128510  1
+  C  C20  1  0.88247759  0.78673110  0.17651935  1
+  C  C21  1  0.52207196  0.16315281  0.54070553  1
+",-154.14327136363636
+4923,C-134199-8894-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.85638000
+_cell_length_b   4.22751000
+_cell_length_c   4.68326000
+_cell_angle_alpha   116.88584000
+_cell_angle_beta   137.19527000
+_cell_angle_gamma   89.97635000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.79026069
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.19911202  0.10042576  0.87912331  1
+  C  C1  1  0.17910751  0.41970470  0.19412592  1
+  C  C2  1  0.81118913  0.18355046  1.04081165  1
+  C  C3  1  0.69958059  0.76238905  0.87961983  1
+  C  C4  1  0.56705570  0.33643310  0.03226858  1
+  C  C5  1  0.31056639  0.84031006  1.04002052  1
+  C  C6  1  0.67855822  0.75767510  0.19349971  1
+  C  C7  1  1.06743784  0.67953717  0.03281728  1
+",-154.1074625
+8461,C-53801-6753-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48301000
+_cell_length_b   3.84104000
+_cell_length_c   3.74855000
+_cell_angle_alpha   90.02242000
+_cell_angle_beta   89.99900000
+_cell_angle_gamma   89.99299000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.75119558
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20383931  0.49496092  0.74289609  1
+  C  C1  1  0.70397109  0.20043292  0.23927242  1
+  C  C2  1  0.20379113  0.78961253  0.47503516  1
+  C  C3  1  0.70379679  0.78941963  0.23945135  1
+  C  C4  1  0.70383319  0.49478846  0.97143343  1
+  C  C5  1  0.20397349  0.20062905  0.47480644  1
+",-154.16435916666669
+2450,C-80153-8379-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48379000
+_cell_length_b   3.82285000
+_cell_length_c   5.22496000
+_cell_angle_alpha   81.08320000
+_cell_angle_beta   90.03015000
+_cell_angle_gamma   108.93718000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.29362007
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.13898610  0.69153497  0.66169860  1
+  C  C1  1  0.59342185  0.59767870  0.82657314  1
+  C  C2  1  0.35483784  0.11998791  0.60600988  1
+  C  C3  1  0.84602809  0.10024827  0.05065098  1
+  C  C4  1  0.63158363  0.67222506  0.10618248  1
+  C  C5  1  0.39144255  0.19392161  0.88556880  1
+  C  C6  1  0.96506846  0.34204769  0.49974769  1
+  C  C7  1  0.02128829  0.44994888  0.21300471  1
+",-154.22159125
+7079,C-80188-9960-62,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51614000
+_cell_length_b   5.12390000
+_cell_length_c   5.70934000
+_cell_angle_alpha   102.79264000
+_cell_angle_beta   81.31856000
+_cell_angle_gamma   89.17461000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   70.87050081
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.43394860  0.32129001  0.96682604  1
+  C  C1  1  -0.49513890  0.05594089  0.86146631  1
+  C  C2  1  0.21753087  0.27172004  0.41840873  1
+  C  C3  1  0.03162540  0.50887078  0.65682521  1
+  C  C4  1  0.88876646  0.71531565  0.53212556  1
+  C  C5  1  0.47269622  0.53622071  0.82292967  1
+  C  C6  1  0.85161380  0.61349886  0.28013426  1
+  C  C7  1  0.72797480  0.09983727  0.40333751  1
+  C  C8  1  0.34510519  0.43363403  0.22369864  1
+  C  C9  1  0.85060306  0.85466111  0.16685405  1
+  C  C10  1  0.68380248  0.96744417  0.61395832  1
+  C  C11  1  0.41711382  -0.16489053  0.00375680  1
+",-154.08303
+7421,C-80199-6032-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.63163000
+_cell_length_b   3.27397000
+_cell_length_c   6.82812000
+_cell_angle_alpha   109.14654000
+_cell_angle_beta   96.83268000
+_cell_angle_gamma   104.54110000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   72.41616504
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.73675614  0.43511824  0.43499292  1
+  C  C1  1  0.49928301  0.75439339  0.54133090  1
+  C  C2  1  0.11782066  0.01649079  0.06942946  1
+  C  C3  1  0.11848742  0.85509886  0.22700532  1
+  C  C4  1  0.73713639  0.61555280  0.25463797  1
+  C  C5  1  0.73643949  0.93551372  0.93510417  1
+  C  C6  1  0.11803863  0.51615317  0.56932439  1
+  C  C7  1  0.11817888  0.35555458  0.72715373  1
+  C  C8  1  0.49900962  0.25466734  0.04137457  1
+  C  C9  1  0.49964715  0.93369003  0.36046687  1
+  C  C10  1  0.73681399  0.11584562  0.75468432  1
+  C  C11  1  0.49918773  0.43418054  0.86062419  1
+",-154.19716583333334
+7140,C-9610-495-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47594000
+_cell_length_b   4.86126000
+_cell_length_c   4.79211000
+_cell_angle_alpha   112.05223000
+_cell_angle_beta   89.99262000
+_cell_angle_gamma   120.62059000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   44.66461957
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.31304293  1.16018156  1.18795502  1
+  C  C1  1  0.23599994  0.58294201  0.03239591  1
+  C  C2  1  0.86350782  0.70931782  0.54441854  1
+  C  C3  1  0.68390752  0.53029741  0.18756516  1
+  C  C4  1  0.57035241  -0.08318019  0.69889372  1
+  C  C5  1  0.49280236  0.33953310  0.54489022  1
+  C  C6  1  -0.05990940  0.28621842  0.69925788  1
+  C  C7  1  0.60611102  0.95255447  1.03278684  1
+",-154.4056725
+1781,C-106883-2108-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.33356000
+_cell_length_b   4.32356000
+_cell_length_c   6.11594000
+_cell_angle_alpha   78.74842000
+_cell_angle_beta   70.69709000
+_cell_angle_gamma   61.41437000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   72.97917929
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.85471448  0.18620585  0.68818533  1
+  C  C1  1  0.08617372  0.36098709  0.01402474  1
+  C  C2  1  0.15868180  0.59562235  0.58542620  1
+  C  C3  1  0.88565046  -0.10020336  0.24147514  1
+  C  C4  1  0.43453557  0.77397490  0.84974780  1
+  C  C5  1  0.89399852  0.44869922  0.79974720  1
+  C  C6  1  0.69154298  0.38615238  0.46800808  1
+  C  C7  1  0.29378524  0.86244847  0.63090853  1
+  C  C8  1  0.86847589  0.21559134  0.24321084  1
+  C  C9  1  0.00727419  0.75176284  0.02285022  1
+  C  C10  1  0.57343001  0.03659869  0.89928982  1
+  C  C11  1  0.78502452  0.71057352  0.45524591  1
+",-154.09730583333334
+9641,C-184046-597-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.55300000
+_cell_length_b   5.04320000
+_cell_length_c   5.04222000
+_cell_angle_alpha   130.38530000
+_cell_angle_beta   94.02398000
+_cell_angle_gamma   85.99115000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   68.61403434
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79460636  0.02431770  0.73726547  1
+  C  C1  1  0.43114516  1.14436176  0.61752194  1
+  C  C2  1  0.79464516  0.38316393  1.09611328  1
+  C  C3  1  0.69090817  0.40440899  0.38838892  1
+  C  C4  1  0.69101060  0.73210424  0.71610903  1
+  C  C5  1  0.53479829  0.12280983  0.32541648  1
+  C  C6  1  0.11298664  0.60660139  0.19940566  1
+  C  C7  1  0.43126461  0.50297322  0.97617847  1
+  C  C8  1  0.53495202  0.79506826  0.99774310  1
+  C  C9  1  0.11288169  0.92110608  0.51383666  1
+",-154.156171
+9810,C-157672-8945-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.29625000
+_cell_length_b   4.59552000
+_cell_length_c   4.20990000
+_cell_angle_alpha   88.21615000
+_cell_angle_beta   59.57697000
+_cell_angle_gamma   79.03897000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   70.15738010
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.14614300  0.83552698  0.87557681  1
+  C  C1  1  0.44739451  0.93123968  0.22609957  1
+  C  C2  1  0.42122333  0.24786836  0.34501647  1
+  C  C3  1  0.13643288  0.80523412  0.53098626  1
+  C  C4  1  0.77764430  -0.04471019  0.54043354  1
+  C  C5  1  0.16317720  0.48756484  0.41185221  1
+  C  C6  1  0.70463402  0.25631538  0.42281284  1
+  C  C7  1  0.87917577  0.47962533  0.33486870  1
+  C  C8  1  0.80635557  0.77975783  0.21656325  1
+  C  C9  1  0.43773882  0.89978687  0.88154375  1
+",-154.102693
+6187,C-96672-9795-53,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48670000
+_cell_length_b   2.48850000
+_cell_length_c   6.57308000
+_cell_angle_alpha   100.90780000
+_cell_angle_beta   100.83312000
+_cell_angle_gamma   120.03483000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.60970953
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71794999  0.55372903  0.30179232  1
+  C  C1  1  0.71822284  0.88758460  0.96858588  1
+  C  C2  1  0.46811883  0.97065982  0.38537136  1
+  C  C3  1  0.71844575  0.22078260  0.63559713  1
+  C  C4  1  0.46800789  0.63716559  0.71864051  1
+  C  C5  1  0.46779641  0.30397537  1.05159650  1
+",-154.54087266666667
+6907,C-40120-327-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48051000
+_cell_length_b   4.83935000
+_cell_length_c   3.68793000
+_cell_angle_alpha   57.46862000
+_cell_angle_beta   70.33746000
+_cell_angle_gamma   75.19069000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99193101
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.08316984  0.03109211  -0.03195996  1
+  C  C1  1  0.82289424  0.60254221  0.91157919  1
+  C  C2  1  0.40128098  0.73335369  0.62399839  1
+  C  C3  1  0.86077830  0.23759435  0.20694643  1
+  C  C4  1  0.28229639  0.10666453  0.49464515  1
+  C  C5  1  0.60270865  0.80947261  0.15025470  1
+",-154.310074
+3487,C-80202-9135-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48436000
+_cell_length_b   4.04695000
+_cell_length_c   5.01369000
+_cell_angle_alpha   66.15573000
+_cell_angle_beta   94.42553000
+_cell_angle_gamma   101.00270000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.25809170
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.39193491  0.66878075  0.87428803  1
+  C  C1  1  -0.10803527  0.57331179  0.06511103  1
+  C  C2  1  0.58052808  0.85173138  0.34954991  1
+  C  C3  1  1.02852633  0.62069508  0.34934005  1
+  C  C4  1  1.08016612  0.23058078  0.59092640  1
+  C  C5  1  0.21193501  0.27844305  0.87447817  1
+  C  C6  1  0.71198068  0.18314637  0.06534647  1
+  C  C7  1  0.52813654  0.00003679  0.59095284  1
+",-154.07078875
+2468,C-130526-2423-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47739000
+_cell_length_b   2.55975000
+_cell_length_c   5.73154000
+_cell_angle_alpha   90.68421000
+_cell_angle_beta   102.41070000
+_cell_angle_gamma   89.84038000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.49468307
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.03051873  0.43073717  0.70827461  1
+  C  C1  1  0.33819743  0.44384237  0.32824919  1
+  C  C2  1  0.68318103  0.93456516  1.01338261  1
+  C  C3  1  0.91029155  0.44410808  0.47333000  1
+  C  C4  1  0.25972454  -0.06111097  0.16775876  1
+  C  C5  1  0.60312442  0.42955950  0.85257004  1
+",-154.2815395
+6123,C-170350-1491-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42989000
+_cell_length_b   2.42950000
+_cell_length_c   8.44242000
+_cell_angle_alpha   87.58053000
+_cell_angle_beta   81.88506000
+_cell_angle_gamma   59.98486000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.69980051
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.28015572  0.67584099  0.49356285  1
+  C  C1  1  1.03886053  0.70569213  0.82637504  1
+  C  C2  1  0.61413259  0.00849125  0.49302144  1
+  C  C3  1  0.70555839  0.37199696  0.82635106  1
+  C  C4  1  0.19340151  0.11405190  0.15200633  1
+  C  C5  1  0.86006515  0.78105868  0.15180718  1
+",-154.45115633333333
+2790,C-56468-3855-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.37473000
+_cell_length_b   4.08138000
+_cell_length_c   3.79139000
+_cell_angle_alpha   108.56545000
+_cell_angle_beta   107.01758000
+_cell_angle_gamma   100.26333000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.16510040
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.25503624  0.84674535  0.92581807  1
+  C  C1  1  0.40325373  1.00733573  0.65892170  1
+  C  C2  1  0.51763481  0.65954673  0.44127925  1
+  C  C3  1  0.08384498  0.00505758  0.26307748  1
+  C  C4  1  0.74057227  0.36984509  0.89888127  1
+  C  C5  1  0.05975483  0.37182203  0.29405286  1
+  C  C6  1  -0.11266999  0.52867214  0.63035631  1
+  C  C7  1  0.62640753  0.71800445  0.11629594  1
+",-154.2262275
+6197,C-102873-2379-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46798000
+_cell_length_b   7.53388000
+_cell_length_c   5.49228000
+_cell_angle_alpha   94.94187000
+_cell_angle_beta   84.38479000
+_cell_angle_gamma   99.61001000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   99.95037384
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87823870  0.12783394  -0.06004595  1
+  C  C1  1  0.96286460  0.31090625  0.09172462  1
+  C  C2  1  1.12838730  0.45912084  0.91511584  1
+  C  C3  1  0.27672253  0.84156669  0.97770545  1
+  C  C4  1  0.39299178  0.45579336  0.45860434  1
+  C  C5  1  0.31893248  0.10482890  0.30811503  1
+  C  C6  1  0.17860522  0.34951827  0.67465839  1
+  C  C7  1  0.73820994  0.74945129  0.96880712  1
+  C  C8  1  0.32861043  0.03432097  0.03186910  1
+  C  C9  1  0.06677200  0.75655737  0.47182791  1
+  C  C10  1  0.89499475  0.17615613  0.68199629  1
+  C  C11  1  0.41783069  0.30579356  0.24835055  1
+  C  C12  1  0.95134591  0.56818807  0.46364823  1
+  C  C13  1  -0.23036036  0.05307277  0.45160023  1
+  C  C14  1  0.67531752  0.56631686  -0.06661449  1
+  C  C15  1  0.62207361  0.85232985  0.48423735  1
+",-154.144619375
+2676,C-56479-4760-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47606000
+_cell_length_b   5.39448000
+_cell_length_c   4.79497000
+_cell_angle_alpha   56.62653000
+_cell_angle_beta   90.00681000
+_cell_angle_gamma   62.68190000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   44.68234961
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.95245591  -0.22210293  1.12139860  1
+  C  C1  1  0.14384093  0.58608900  0.66997893  1
+  C  C2  1  0.32210428  0.40783683  0.49133058  1
+  C  C3  1  0.77438745  0.95613000  0.30009484  1
+  C  C4  1  0.69709401  0.53318016  0.87780060  1
+  C  C5  1  0.03018728  0.19998511  0.54454056  1
+  C  C6  1  0.06616924  1.16408870  0.24703578  1
+  C  C7  1  0.39906579  0.83096313  0.91368242  1
+",-154.40767
+7306,C-80148-5004-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45498000
+_cell_length_b   7.02626000
+_cell_length_c   6.22730000
+_cell_angle_alpha   94.29200000
+_cell_angle_beta   78.66146000
+_cell_angle_gamma   121.64935000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   89.60488957
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.69671175  0.55981391  0.59048181  1
+  C  C1  1  0.63992986  0.39304903  0.19630731  1
+  C  C2  1  0.59062563  1.09355610  0.39845017  1
+  C  C3  1  -0.04851653  0.54743005  0.03615025  1
+  C  C4  1  0.94436963  1.03685736  0.52171195  1
+  C  C5  1  0.46353032  0.94475310  0.20387940  1
+  C  C6  1  0.12154641  0.48447528  0.51440329  1
+  C  C7  1  -0.33100663  0.67307850  -0.02195195  1
+  C  C8  1  -0.00633459  0.33636270  0.31947572  1
+  C  C9  1  -0.08577868  0.75670477  0.73983694  1
+  C  C10  1  0.63126213  0.88196098  0.68141022  1
+  C  C11  1  -0.11160850  -0.13064947  0.12778751  1
+",-154.15226416666667
+632,C-106844-7188-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.42588000
+_cell_length_b   3.26650000
+_cell_length_c   4.54183000
+_cell_angle_alpha   89.99387000
+_cell_angle_beta   108.56797000
+_cell_angle_gamma   89.98784000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.18030288
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.30141871  0.79052659  0.60457970  1
+  C  C1  1  -0.00425802  0.44323256  0.63563817  1
+  C  C2  1  1.13542454  0.29058924  0.96992895  1
+  C  C3  1  0.94050001  0.07171437  0.43866799  1
+  C  C4  1  0.63525384  0.72255350  0.46999642  1
+  C  C5  1  0.80157942  0.22245056  0.10447960  1
+  C  C6  1  0.44040579  0.94333028  0.93855453  1
+  C  C7  1  0.49549940  0.57181072  0.13560083  1
+",-154.19017125
+8261,C-172914-2327-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.26869000
+_cell_length_b   3.27388000
+_cell_length_c   4.23646000
+_cell_angle_alpha   84.76565000
+_cell_angle_beta   56.02109000
+_cell_angle_gamma   99.11466000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.21388362
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.44606535  0.78191629  0.40407185  1
+  C  C1  1  0.63478856  0.63492835  0.64145196  1
+  C  C2  1  0.08468360  0.42049774  0.40463583  1
+  C  C3  1  0.19863264  0.36597761  1.02290699  1
+  C  C4  1  0.88256091  0.04843002  0.02273068  1
+  C  C5  1  0.99596174  0.99496460  0.64134598  1
+",-154.19867833333333
+3630,C-134187-5202-54,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43184000
+_cell_length_b   4.20478000
+_cell_length_c   6.16612000
+_cell_angle_alpha   68.94158000
+_cell_angle_beta   101.05892000
+_cell_angle_gamma   90.20810000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.60032119
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53843713  0.83122954  0.65836811  1
+  C  C1  1  0.44792632  0.81144648  0.16046304  1
+  C  C2  1  0.03844361  0.33121848  0.65835303  1
+  C  C3  1  0.94746010  -0.02130406  0.16023893  1
+  C  C4  1  0.44756184  0.47868256  0.16024567  1
+  C  C5  1  0.94803065  0.31142581  0.16047395  1
+  C  C6  1  0.53797552  0.49843912  0.65815515  1
+  C  C7  1  0.03799204  -0.00156893  0.65817621  1
+",-154.45897875
+4336,C-176656-6648-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.41401000
+_cell_length_b   3.37005000
+_cell_length_c   7.13781000
+_cell_angle_alpha   97.01472000
+_cell_angle_beta   97.17904000
+_cell_angle_gamma   88.25677000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   80.85997020
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.08523317  0.15813258  0.43300267  1
+  C  C1  1  0.34810010  0.42875327  0.80833899  1
+  C  C2  1  0.41770428  0.51120333  0.43425802  1
+  C  C3  1  0.84936855  0.92785471  0.81502140  1
+  C  C4  1  0.02182492  -0.04846915  0.23036526  1
+  C  C5  1  0.28386186  -0.13399317  0.55629133  1
+  C  C6  1  0.35504831  0.59576882  0.23097739  1
+  C  C7  1  1.06148386  0.27581515  0.92899324  1
+  C  C8  1  0.06321759  0.66611304  0.68182329  1
+  C  C9  1  0.56903607  0.12737101  0.68211585  1
+  C  C10  1  0.61501638  -0.15117435  0.12826060  1
+  C  C11  1  0.26360681  0.19411364  0.11820314  1
+  C  C12  1  0.69569784  0.63867732  0.93286898  1
+  C  C13  1  0.78202816  0.36324041  0.54908744  1
+",-154.2605557142857
+720,C-136217-3562-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48116000
+_cell_length_b   3.68920000
+_cell_length_c   4.83872000
+_cell_angle_alpha   68.58055000
+_cell_angle_beta   104.87784000
+_cell_angle_gamma   70.33446000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99697119
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.16569106  -0.04436541  0.70737879  1
+  C  C1  1  0.47956997  0.89807067  0.27871183  1
+  C  C2  1  0.49593118  0.65859344  0.07221534  1
+  C  C3  1  0.45658247  0.24282282  0.57666782  1
+  C  C4  1  0.18287486  0.71562525  0.50090555  1
+  C  C5  1  0.20527817  0.37104303  0.20311947  1
+",-154.3110305
+6045,C-34635-9264-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46583000
+_cell_length_b   3.20697000
+_cell_length_c   7.68217000
+_cell_angle_alpha   107.35488000
+_cell_angle_beta   90.05327000
+_cell_angle_gamma   67.29170000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   53.03704352
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.10130915  0.19362991  0.33365031  1
+  C  C1  1  0.65039005  0.09345980  0.22565901  1
+  C  C2  1  0.41916106  0.55440994  0.75851645  1
+  C  C3  1  0.75161616  0.88897506  0.04144338  1
+  C  C4  1  0.85684549  0.68295793  0.49070654  1
+  C  C5  1  0.30917611  0.77279653  -0.05816826  1
+  C  C6  1  0.21673675  0.96159493  0.49291059  1
+  C  C7  1  0.97051603  0.45147540  0.65064209  1
+",-154.2578775
+9843,C-184066-1258-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47944000
+_cell_length_b   3.87935000
+_cell_length_c   6.40348000
+_cell_angle_alpha   72.40562000
+_cell_angle_beta   101.20314000
+_cell_angle_gamma   90.09751000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.48534942
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.59087556  0.93102443  0.77139187  1
+  C  C1  1  0.02495126  0.48647415  0.64003997  1
+  C  C2  1  0.24823317  0.06967502  0.09121394  1
+  C  C3  1  -0.09848196  0.72312101  0.40208209  1
+  C  C4  1  0.33582612  0.68159035  0.27020737  1
+  C  C5  1  0.59120022  0.52789392  0.77163633  1
+  C  C6  1  0.33609187  0.27862104  0.27022049  1
+  C  C7  1  0.90118295  1.10610821  0.40186729  1
+  C  C8  1  1.02512528  0.10424149  0.63982763  1
+  C  C9  1  0.67930255  0.13941429  0.95104813  1
+",-154.296537
+2890,C-142781-4679-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50991000
+_cell_length_b   5.68061000
+_cell_length_c   6.86098000
+_cell_angle_alpha   72.28824000
+_cell_angle_beta   90.01397000
+_cell_angle_gamma   90.05008000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   93.18569701
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.45561870  0.75390866  0.97198371  1
+  C  C1  1  -0.04274940  0.13323796  0.81981700  1
+  C  C2  1  0.95650862  0.88913971  1.00340019  1
+  C  C3  1  0.95616091  0.91311197  0.24703354  1
+  C  C4  1  0.45411802  0.73719124  0.75738085  1
+  C  C5  1  0.45477169  0.96280680  0.57128283  1
+  C  C6  1  0.45544356  0.82602376  0.37958364  1
+  C  C7  1  0.45727410  0.27532851  0.84501254  1
+  C  C8  1  0.45708444  0.27801751  1.05521832  1
+  C  C9  1  -0.04330103  0.40017399  0.46365659  1
+  C  C10  1  0.95718995  0.18290877  0.17346376  1
+  C  C11  1  0.45645069  0.54144470  0.49945366  1
+  C  C12  1  0.45645982  0.52838505  0.71218378  1
+  C  C13  1  0.95714342  0.41448784  0.24815026  1
+  C  C14  1  0.45678747  0.50647337  0.12425301  1
+  C  C15  1  -0.04384045  0.11526696  0.59673084  1
+",-154.154118125
+7501,C-126177-4900-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42987000
+_cell_length_b   3.30038000
+_cell_length_c   6.43155000
+_cell_angle_alpha   89.01168000
+_cell_angle_beta   120.06368000
+_cell_angle_gamma   97.31905000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.21005849
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.10803266  0.10134727  0.68400553  1
+  C  C1  1  0.44128937  0.32434390  -0.09391351  1
+  C  C2  1  1.10816262  0.76796076  0.35062277  1
+  C  C3  1  0.44123468  0.65768427  0.23936702  1
+  C  C4  1  0.44100341  -0.00906850  0.57271707  1
+  C  C5  1  0.10826976  0.43470040  0.01733751  1
+",-154.4537805
+1961,C-106853-7201-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43152000
+_cell_length_b   4.20569000
+_cell_length_c   6.26559000
+_cell_angle_alpha   103.84347000
+_cell_angle_beta   111.95696000
+_cell_angle_gamma   90.06951000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.40633319
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.05159192  0.92523323  0.29920341  1
+  C  C1  1  0.54721924  0.05936088  0.79564208  1
+  C  C2  1  0.54947112  0.09155104  0.29745833  1
+  C  C3  1  0.54931814  0.39302553  0.79735550  1
+  C  C4  1  0.04723247  0.55936357  -0.20435203  1
+  C  C5  1  0.04934005  0.89304307  0.79738716  1
+  C  C6  1  0.55157869  0.42523054  0.29919752  1
+  C  C7  1  0.04949302  0.59156858  0.29748999  1
+",-154.453595
+5743,C-106842-844-58,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45314000
+_cell_length_b   4.16022000
+_cell_length_c   5.09610000
+_cell_angle_alpha   105.21796000
+_cell_angle_beta   104.08854000
+_cell_angle_gamma   90.00415000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.56168432
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.20882983  0.60519481  0.33125605  1
+  C  C1  1  0.50169312  0.31885563  0.74560069  1
+  C  C2  1  0.76372131  0.23882946  0.27279921  1
+  C  C3  1  0.29934738  0.76674460  0.35058588  1
+  C  C4  1  0.59612875  0.05856110  0.93638399  1
+  C  C5  1  1.03122736  0.52222399  0.80359672  1
+  C  C6  1  0.33120833  1.13212371  0.40871614  1
+  C  C7  1  1.06551689  0.85542569  0.87716982  1
+",-154.16484125
+1013,C-13897-9657-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.89385000
+_cell_length_b   3.68851000
+_cell_length_c   2.48070000
+_cell_angle_alpha   70.36466000
+_cell_angle_beta   59.54133000
+_cell_angle_gamma   67.03857000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99754258
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.37528346  0.83583113  0.75912669  1
+  C  C1  1  0.16935076  0.28131075  0.74035079  1
+  C  C2  1  0.87125202  0.92151179  0.71886741  1
+  C  C3  1  0.24410017  0.67938969  0.46755342  1
+  C  C4  1  0.94673921  0.31913513  0.44418178  1
+  C  C5  1  0.74020587  0.76426731  0.42867210  1
+",-154.30864033333333
+6503,C-28224-863-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.39697000
+_cell_length_b   2.46193000
+_cell_length_c   5.30140000
+_cell_angle_alpha   89.99861000
+_cell_angle_beta   94.52694000
+_cell_angle_gamma   111.21128000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.18412404
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.65483160  0.33918805  0.42482785  1
+  C  C1  1  0.30256716  0.16204572  0.61995725  1
+  C  C2  1  0.58744302  0.30292193  0.14924844  1
+  C  C3  1  0.49340491  0.75764910  0.74688505  1
+  C  C4  1  0.55927237  0.78944976  1.02220337  1
+  C  C5  1  0.84747044  -0.06433185  0.55036484  1
+",-154.163474
+5276,C-113032-4206-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.24980000
+_cell_length_b   2.98471000
+_cell_length_c   4.81365000
+_cell_angle_alpha   72.49343000
+_cell_angle_beta   84.57177000
+_cell_angle_gamma   73.59892000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   55.85770472
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.67140334  0.84707764  1.14402405  1
+  C  C1  1  0.99580253  0.90205706  0.14448778  1
+  C  C2  1  0.50908715  -0.10182469  0.88354909  1
+  C  C3  1  0.49557722  0.76820026  0.40002216  1
+  C  C4  1  0.00799903  0.49780425  0.65862098  1
+  C  C5  1  0.65787040  0.71724122  0.66063897  1
+  C  C6  1  0.17124289  0.71279271  0.39955238  1
+  C  C7  1  1.15896225  0.11782154  -0.11438131  1
+",-154.12476375
+8664,C-40104-915-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48186000
+_cell_length_b   3.68801000
+_cell_length_c   4.21953000
+_cell_angle_alpha   75.03278000
+_cell_angle_beta   90.03310000
+_cell_angle_gamma   70.36214000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.97897929
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.69492601  0.34848074  0.69617554  1
+  C  C1  1  0.43984653  0.86165020  0.12499480  1
+  C  C2  1  0.46981289  0.79466243  0.48962352  1
+  C  C3  1  0.89161833  0.95129939  0.62027253  1
+  C  C4  1  0.21570079  0.30770755  0.91842021  1
+  C  C5  1  0.01829205  0.70446658  0.99457349  1
+",-154.31226866666665
+10110,C-189694-8518-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48790000
+_cell_length_b   4.30687000
+_cell_length_c   4.30573000
+_cell_angle_alpha   120.00130000
+_cell_angle_beta   106.77118000
+_cell_angle_gamma   106.80610000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.61301180
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.41868193  0.47442090  0.36973971  1
+  C  C1  1  0.66875374  0.89118250  0.45317323  1
+  C  C2  1  0.66875374  0.55784916  0.78650656  1
+  C  C3  1  0.66875374  0.22451583  0.11983989  1
+  C  C4  1  0.41868193  0.14108757  0.70307304  1
+  C  C5  1  0.41868193  0.80775424  1.03640637  1
+",-154.54655383333332
+2775,C-72742-3701-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.12743000
+_cell_length_b   2.43056000
+_cell_length_c   5.79380000
+_cell_angle_alpha   78.66057000
+_cell_angle_beta   93.31124000
+_cell_angle_gamma   88.46739000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.07656407
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.78063740  0.79772085  0.63983444  1
+  C  C1  1  0.89124247  0.24203127  0.75141012  1
+  C  C2  1  1.22428461  0.57538275  0.08485298  1
+  C  C3  1  0.11377158  0.13106500  0.97324292  1
+  C  C4  1  0.55771611  0.90878363  0.41814530  1
+  C  C5  1  0.44698542  0.46444041  0.30662505  1
+",-154.463071
+1304,C-130514-1931-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44757000
+_cell_length_b   4.19771000
+_cell_length_c   8.07306000
+_cell_angle_alpha   54.78469000
+_cell_angle_beta   89.85169000
+_cell_angle_gamma   89.94230000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   67.76436758
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.56575338  0.67016960  0.78220174  1
+  C  C1  1  0.56679361  0.26358564  0.36553049  1
+  C  C2  1  0.06597144  0.92178485  0.69209911  1
+  C  C3  1  0.06704493  0.81610552  0.11080351  1
+  C  C4  1  0.56553445  0.39228657  0.72541074  1
+  C  C5  1  1.06541459  0.24587371  0.71660595  1
+  C  C6  1  0.06677693  0.16293951  0.07982096  1
+  C  C7  1  0.56671259  0.39849421  0.02521146  1
+  C  C8  1  0.06643012  1.14050567  0.46542686  1
+  C  C9  1  0.56707636  0.59212733  0.14200458  1
+",-154.218292
+8271,C-172943-9308-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   5.26560000
+_cell_length_b   4.25543000
+_cell_length_c   4.30268000
+_cell_angle_alpha   122.05684000
+_cell_angle_beta   115.61712000
+_cell_angle_gamma   80.26665000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   73.44863213
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.03059942  0.68792915  0.35810219  1
+  C  C1  1  0.65327875  1.07720626  0.36594326  1
+  C  C2  1  0.41611612  0.30812250  -0.30964590  1
+  C  C3  1  0.83485659  0.88307550  0.18681274  1
+  C  C4  1  0.83469531  0.88179315  0.85876339  1
+  C  C5  1  0.03084962  0.68658494  0.68815038  1
+  C  C6  1  0.22867091  0.49405851  0.86172026  1
+  C  C7  1  0.65344843  1.07619654  0.69260129  1
+  C  C8  1  0.22870260  0.49512868  0.19003635  1
+  C  C9  1  0.41598974  0.30916697  0.36347615  1
+",-154.136188
+1022,C-9603-8567-58,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43163000
+_cell_length_b   6.11458000
+_cell_length_c   6.36230000
+_cell_angle_alpha   118.65703000
+_cell_angle_beta   97.58681000
+_cell_angle_gamma   74.11465000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   79.83955463
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.88179650  0.10483976  0.46989924  1
+  C  C1  1  -0.02182759  0.82825456  0.41266767  1
+  C  C2  1  0.36031305  0.24191303  0.61888850  1
+  C  C3  1  0.02851907  0.73061498  0.85484116  1
+  C  C4  1  0.50325972  0.24909799  0.85538424  1
+  C  C5  1  0.64538792  0.49009059  0.46877012  1
+  C  C6  1  0.16911726  0.50245394  0.61807752  1
+  C  C7  1  0.26772134  0.12671178  0.13063868  1
+  C  C8  1  1.06447457  0.23197252  -0.04575084  1
+  C  C9  1  0.76697629  0.20417375  0.28389867  1
+  C  C10  1  0.46636949  0.84628769  0.95428936  1
+  C  C11  1  0.54279829  0.71045672  0.41256859  1
+",-154.22008166666666
+3559,C-92124-4005-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48246000
+_cell_length_b   3.74364000
+_cell_length_c   3.84549000
+_cell_angle_alpha   90.02556000
+_cell_angle_beta   90.00113000
+_cell_angle_gamma   90.00217000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.73781375
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.74593306  0.57586172  1.03097366  1
+  C  C1  1  0.24604888  0.33949544  0.62086174  1
+  C  C2  1  0.24588437  0.33917197  0.03073300  1
+  C  C3  1  0.24599674  0.07221995  0.32579678  1
+  C  C4  1  0.74609757  0.57618519  0.62110240  1
+  C  C5  1  0.74598520  0.84313721  0.32603862  1
+",-154.1582925
+1063,C-142785-5183-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47095000
+_cell_length_b   4.78551000
+_cell_length_c   6.84686000
+_cell_angle_alpha   74.61134000
+_cell_angle_beta   80.05311000
+_cell_angle_gamma   60.82056000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   68.06330381
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.49609461  0.93089490  0.10051937  1
+  C  C1  1  0.51410273  0.47904374  -0.05041990  1
+  C  C2  1  0.70007968  0.38225310  0.41549828  1
+  C  C3  1  1.19302974  0.70560129  0.09733314  1
+  C  C4  1  0.44251131  0.67449356  0.72502195  1
+  C  C5  1  0.22143512  0.25696613  0.95181108  1
+  C  C6  1  0.78589033  0.87714732  0.66365621  1
+  C  C7  1  0.55232916  -0.08889094  0.32814403  1
+  C  C8  1  0.90291489  0.01851675  0.42529988  1
+  C  C9  1  0.37282573  0.19530907  0.73184462  1
+  C  C10  1  0.07983349  0.55701467  0.32067182  1
+  C  C11  1  0.72669930  0.37631132  0.63685053  1
+",-154.17666
+5872,C-141055-6281-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42965000
+_cell_length_b   3.04952000
+_cell_length_c   5.96884000
+_cell_angle_alpha   84.21793000
+_cell_angle_beta   100.72896000
+_cell_angle_gamma   87.90688000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.16137646
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.03970266  0.06636533  0.60336444  1
+  C  C1  1  0.48315480  0.17457165  0.49081000  1
+  C  C2  1  0.70633120  0.73260440  0.93655519  1
+  C  C3  1  0.14982955  0.84119906  0.82416571  1
+  C  C4  1  0.81645809  0.50744149  0.15732746  1
+  C  C5  1  0.37294211  0.39903187  0.26980820  1
+",-154.45520833333333
+7888,C-96719-5209-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47666000
+_cell_length_b   4.25767000
+_cell_length_c   5.94419000
+_cell_angle_alpha   69.01078000
+_cell_angle_beta   77.95328000
+_cell_angle_gamma   90.00094000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.04032327
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.96740664  0.35120989  0.27430889  1
+  C  C1  1  0.17175831  0.22879785  0.86738846  1
+  C  C2  1  0.84233079  1.08876043  0.53016464  1
+  C  C3  1  0.50838448  0.56559947  0.19322886  1
+  C  C4  1  0.34240006  0.87326623  0.53021282  1
+  C  C5  1  0.20642653  0.60651543  0.79654775  1
+  C  C6  1  1.02929859  0.08512291  0.15240025  1
+  C  C7  1  0.71196665  0.09525253  0.78655824  1
+  C  C8  1  0.47255483  0.87250558  0.26420285  1
+  C  C9  1  0.64948962  0.70696818  0.90858196  1
+",-154.394216
+1086,C-189703-1540-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49203000
+_cell_length_b   3.59630000
+_cell_length_c   4.35102000
+_cell_angle_alpha   84.28022000
+_cell_angle_beta   73.34323000
+_cell_angle_gamma   69.62972000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.02171787
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.24504621  -0.03067395  0.41539380  1
+  C  C1  1  0.32703227  0.59846139  0.62090674  1
+  C  C2  1  0.13937186  0.59860723  0.99729512  1
+  C  C3  1  0.77015227  0.33978116  -0.00275265  1
+  C  C4  1  0.85221244  0.96924782  0.20276942  1
+  C  C5  1  0.95717146  0.33976274  0.62097997  1
+",-154.1968075
+4681,C-170908-5383-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46067000
+_cell_length_b   5.15185000
+_cell_length_c   5.74521000
+_cell_angle_alpha   83.66723000
+_cell_angle_beta   77.59543000
+_cell_angle_gamma   89.94949000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   70.67821882
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.77810544  0.76880884  1.04537419  1
+  C  C1  1  0.40784265  0.14018841  0.78413007  1
+  C  C2  1  0.64887146  0.65326681  0.30218050  1
+  C  C3  1  0.29781268  0.94354961  0.00384983  1
+  C  C4  1  0.34218185  0.37596741  0.92077792  1
+  C  C5  1  -0.01066971  0.66616725  0.62241653  1
+  C  C6  1  0.53842409  0.09981389  0.52855695  1
+  C  C7  1  0.86319663  0.55081767  0.87970697  1
+  C  C8  1  0.10585396  0.21970641  0.39502246  1
+  C  C9  1  0.53858274  0.81142505  0.52526798  1
+  C  C10  1  1.10205793  0.50802559  0.39861260  1
+  C  C11  1  0.22900337  0.17920877  0.14038340  1
+",-154.10712
+3067,C-53828-4519-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42608000
+_cell_length_b   5.34169000
+_cell_length_c   5.59337000
+_cell_angle_alpha   79.26913000
+_cell_angle_beta   76.69958000
+_cell_angle_gamma   89.97215000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   69.24062860
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63299232  0.59079645  0.32064428  1
+  C  C1  1  0.63655354  0.11144638  0.31051081  1
+  C  C2  1  1.11942806  0.98005635  0.34466124  1
+  C  C3  1  0.37167330  0.68973573  0.86502765  1
+  C  C4  1  -0.11149392  0.82120881  0.83151406  1
+  C  C5  1  0.11677018  0.71163564  0.35045664  1
+  C  C6  1  0.89191722  0.08946168  0.82456867  1
+  C  C7  1  0.37652577  1.21000963  -0.14719074  1
+  C  C8  1  0.30034913  0.42028668  -0.00043620  1
+  C  C9  1  0.70972150  0.38134716  0.17324079  1
+",-154.190655
+3251,C-177270-1673-54,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.34306000
+_cell_length_b   4.47203000
+_cell_length_c   5.81506000
+_cell_angle_alpha   69.28630000
+_cell_angle_beta   69.25618000
+_cell_angle_gamma   61.95691000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   69.88613111
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.85311404  0.78137148  -0.01791980  1
+  C  C1  1  0.42855437  0.36847670  0.55668932  1
+  C  C2  1  0.29409971  0.47438820  0.09822893  1
+  C  C3  1  0.13192546  0.55926020  0.35197435  1
+  C  C4  1  0.70260866  0.56275110  -0.09156691  1
+  C  C5  1  0.12008379  0.26234735  0.83213984  1
+  C  C6  1  0.61507511  0.64566325  0.47201924  1
+  C  C7  1  1.06094773  -0.00977489  0.75665310  1
+  C  C8  1  0.20316253  0.89093245  0.33118028  1
+  C  C9  1  0.55788820  0.79320366  0.67202973  1
+  C  C10  1  0.82278060  0.03249508  0.55461924  1
+  C  C11  1  0.36402360  1.09937901  1.07403028  1
+",-154.0761425
+5693,C-126138-5994-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.31866000
+_cell_length_b   3.63627000
+_cell_length_c   4.01555000
+_cell_angle_alpha   113.85096000
+_cell_angle_beta   98.28301000
+_cell_angle_gamma   93.36307000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.48975370
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40603386  0.45582925  0.82730122  1
+  C  C1  1  0.90850272  0.39563834  0.32557106  1
+  C  C2  1  0.90821178  0.01551405  0.32544900  1
+  C  C3  1  0.21457537  1.04901315  0.63431039  1
+  C  C4  1  0.21427866  0.66904182  0.63432712  1
+  C  C5  1  0.71736292  0.60857879  0.13213941  1
+",-154.14474866666666
+6953,C-72699-8017-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43094000
+_cell_length_b   3.14940000
+_cell_length_c   5.75441000
+_cell_angle_alpha   92.83961000
+_cell_angle_beta   102.18440000
+_cell_angle_gamma   90.11826000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.00693673
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.45630514  0.60386529  0.34851498  1
+  C  C1  1  0.12297181  0.93719862  0.68184831  1
+  C  C2  1  0.78963847  0.27053195  1.01518165  1
+  C  C3  1  0.34564659  0.37868901  0.12715322  1
+  C  C4  1  0.67897993  1.04535568  0.79381989  1
+  C  C5  1  1.01231326  0.71202235  0.46048655  1
+",-154.45818966666667
+2684,C-172930-9950-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.88971000
+_cell_length_b   4.20645000
+_cell_length_c   4.20859000
+_cell_angle_alpha   119.99839000
+_cell_angle_beta   90.90726000
+_cell_angle_gamma   98.55351000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.56769727
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.74696592  0.43102478  0.35401234  1
+  C  C1  1  0.74692492  0.76427044  0.68712614  1
+  C  C2  1  0.74692718  0.43093662  1.02045770  1
+  C  C3  1  0.74692295  0.76434864  1.02067139  1
+  C  C4  1  0.74692069  0.09768246  0.68733982  1
+  C  C5  1  0.74688194  0.09759429  0.35378518  1
+",-154.4066865
+6137,C-148219-4273-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.61565000
+_cell_length_b   4.86855000
+_cell_length_c   5.79376000
+_cell_angle_alpha   127.13077000
+_cell_angle_beta   88.73686000
+_cell_angle_gamma   112.61234000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   71.93794333
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53152076  0.88432247  0.00864289  1
+  C  C1  1  0.82139433  0.21096915  0.34613256  1
+  C  C2  1  0.22768582  0.21155887  0.32530921  1
+  C  C3  1  0.46911646  0.40221781  1.02912470  1
+  C  C4  1  0.19080361  0.88460454  0.33584717  1
+  C  C5  1  0.80671034  0.73282651  0.82091707  1
+  C  C6  1  0.25555665  0.04827111  0.00298991  1
+  C  C7  1  0.76392725  0.73270490  0.37204934  1
+  C  C8  1  0.63065869  0.04821822  0.50548572  1
+  C  C9  1  0.20935017  0.58123254  1.02063023  1
+  C  C10  1  -0.22918558  0.40204641  0.83341957  1
+  C  C11  1  0.68113039  0.52350298  0.49192525  1
+",-154.27163166666665
+4926,C-141029-5572-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.25827000
+_cell_length_b   4.59737000
+_cell_length_c   4.34354000
+_cell_angle_alpha   52.79588000
+_cell_angle_beta   64.55657000
+_cell_angle_gamma   58.56655000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.96522969
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87873354  0.33979796  0.76774127  1
+  C  C1  1  0.20177978  0.92895705  0.82786980  1
+  C  C2  1  0.21419369  0.55649403  0.20059344  1
+  C  C3  1  0.18138351  0.86753225  0.51909897  1
+  C  C4  1  0.18578943  0.49651995  0.61120137  1
+  C  C5  1  0.82689671  0.51221154  0.35824640  1
+  C  C6  1  0.52600071  0.92475921  0.19613228  1
+  C  C7  1  0.60480030  0.24755369  0.13907306  1
+  C  C8  1  0.79111028  0.16001195  0.43083137  1
+  C  C9  1  0.47533805  0.08715377  0.78347335  1
+",-154.079421
+1646,C-142808-2016-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47354000
+_cell_length_b   6.21498000
+_cell_length_c   6.87173000
+_cell_angle_alpha   86.93614000
+_cell_angle_beta   79.33991000
+_cell_angle_gamma   80.77294000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   102.44185672
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.67825160  0.90601167  0.19009801  1
+  C  C1  1  0.05646917  0.50148233  0.45793813  1
+  C  C2  1  0.35995536  0.63337909  0.75422845  1
+  C  C3  1  0.84455639  0.11094861  0.12155123  1
+  C  C4  1  0.68810666  0.14020796  0.55229675  1
+  C  C5  1  0.54622722  0.17804128  0.78490481  1
+  C  C6  1  0.39407917  0.40969932  0.85855324  1
+  C  C7  1  0.47955300  0.83147096  0.38523925  1
+  C  C8  1  0.26315109  0.22571531  0.19757019  1
+  C  C9  1  1.04780395  0.06857379  0.88203062  1
+  C  C10  1  0.17857993  0.24856952  0.45081160  1
+  C  C11  1  1.20375679  0.81259007  0.90421922  1
+  C  C12  1  0.90983116  0.66018907  0.63234178  1
+  C  C13  1  0.67761099  0.55386468  0.13399192  1
+  C  C14  1  0.66679646  0.77047911  0.03127662  1
+  C  C15  1  0.25227747  0.43247796  0.07740391  1
+  C  C16  1  0.87924182  0.88261801  0.50850914  1
+  C  C17  1  0.56992207  0.58620095  0.35288552  1
+",-154.0793322222222
+7309,C-53838-1497-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.06259000
+_cell_length_b   2.42919000
+_cell_length_c   5.84698000
+_cell_angle_alpha   78.91636000
+_cell_angle_beta   93.73048000
+_cell_angle_gamma   88.20306000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.55469593
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.16081889  -0.05117413  0.99164759  1
+  C  C1  1  0.05018480  0.50433578  0.88013651  1
+  C  C2  1  0.82754735  0.61550530  0.65828869  1
+  C  C3  1  0.71686915  1.17100364  0.54679910  1
+  C  C4  1  0.38345634  0.83765636  0.21349541  1
+  C  C5  1  0.49413454  0.28215802  0.32498500  1
+",-154.4439685
+6020,C-107738-4561-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48482000
+_cell_length_b   4.08630000
+_cell_length_c   4.67940000
+_cell_angle_alpha   96.68105000
+_cell_angle_beta   105.45005000
+_cell_angle_gamma   89.99491000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.46162941
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.02761873  0.58360962  0.74969134  1
+  C  C1  1  0.45478218  0.70283668  0.60547781  1
+  C  C2  1  0.79691208  0.29588003  0.29363346  1
+  C  C3  1  0.68386186  -0.01061029  0.06220908  1
+  C  C4  1  0.51230550  0.05872677  0.72162745  1
+  C  C5  1  0.29582523  0.52218547  0.29117458  1
+  C  C6  1  0.18491199  0.76457103  1.06409474  1
+  C  C7  1  -0.03169347  0.22809820  0.63529925  1
+",-154.36869875
+565,C-73671-1897-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.58556000
+_cell_length_b   3.59563000
+_cell_length_c   4.08890000
+_cell_angle_alpha   75.98651000
+_cell_angle_beta   76.09150000
+_cell_angle_gamma   86.99837000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.64610588
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.92387949  0.56986002  0.18224031  1
+  C  C1  1  0.80930262  -0.04512387  0.63002803  1
+  C  C2  1  0.00661152  0.65114122  0.83672124  1
+  C  C3  1  0.50684559  0.15135591  0.83669220  1
+  C  C4  1  0.30932577  0.45485736  0.63003214  1
+  C  C5  1  0.12170602  0.26628310  0.38899609  1
+  C  C6  1  0.62164643  0.76631561  0.38900126  1
+  C  C7  1  0.42374666  0.06971015  0.18221303  1
+",-154.1824375
+1561,C-90811-1769-58,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.21871000
+_cell_length_b   3.30244000
+_cell_length_c   4.82681000
+_cell_angle_alpha   77.97481000
+_cell_angle_beta   89.93639000
+_cell_angle_gamma   50.01841000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.60053198
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.09590703  0.73533114  0.50504780  1
+  C  C1  1  0.87603784  0.48597486  1.04736973  1
+  C  C2  1  0.55260090  0.85972682  0.22059024  1
+  C  C3  1  0.23945369  0.48607325  0.04745794  1
+  C  C4  1  0.65869619  0.60945799  0.76280823  1
+  C  C5  1  0.76990526  0.73648923  0.50511322  1
+  C  C6  1  0.33262970  0.61056225  0.76285362  1
+  C  C7  1  0.18940409  0.85967367  0.22056703  1
+",-154.21766875
+1381,C-73631-2702-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.27083000
+_cell_length_b   4.21587000
+_cell_length_c   4.83145000
+_cell_angle_alpha   89.88071000
+_cell_angle_beta   102.09722000
+_cell_angle_gamma   50.51894000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.46486926
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.12503266  0.33900100  0.30779656  1
+  C  C1  1  0.99982308  0.24577368  0.02318452  1
+  C  C2  1  0.75268791  0.38837033  0.48126970  1
+  C  C3  1  0.12523489  0.70223970  0.30814610  1
+  C  C4  1  0.00152811  0.91959509  1.02335840  1
+  C  C5  1  0.75220822  0.02483554  0.48085835  1
+  C  C6  1  0.87610997  0.80769682  0.76584060  1
+  C  C7  1  -0.12271293  0.48159434  0.76598356  1
+",-154.2111975
+1495,C-172935-9081-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44969000
+_cell_length_b   5.43385000
+_cell_length_c   5.71917000
+_cell_angle_alpha   55.81879000
+_cell_angle_beta   89.97282000
+_cell_angle_gamma   89.96578000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   62.97907480
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.35665507  0.56214788  0.88272138  1
+  C  C1  1  -0.14387700  -0.14951945  0.43178186  1
+  C  C2  1  0.85621188  0.42319203  0.31165472  1
+  C  C3  1  0.85602371  0.74733055  0.22059947  1
+  C  C4  1  0.35584575  0.13209774  0.76710882  1
+  C  C5  1  -0.14335003  0.65161316  0.74102892  1
+  C  C6  1  0.35597673  0.93383044  0.07640776  1
+  C  C7  1  0.35639710  0.36071504  0.19630216  1
+  C  C8  1  0.85581587  0.22170494  0.62522674  1
+  C  C9  1  0.35613392  0.03685956  0.28735346  1
+",-154.201071
+800,C-176675-1406-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50849000
+_cell_length_b   7.14091000
+_cell_length_c   5.34783000
+_cell_angle_alpha   113.46337000
+_cell_angle_beta   76.47239000
+_cell_angle_gamma   100.07622000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   85.07613346
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.34739301  0.62499683  1.00767342  1
+  C  C1  1  0.82006330  0.20849543  0.63261098  1
+  C  C2  1  0.44640903  0.51576385  0.69948809  1
+  C  C3  1  0.14300808  0.73626158  0.51309739  1
+  C  C4  1  0.09844730  0.17246547  0.04967972  1
+  C  C5  1  0.46304450  0.83715116  0.97615478  1
+  C  C6  1  0.84015216  0.00231762  0.39159783  1
+  C  C7  1  0.95148476  0.39544862  0.56829866  1
+  C  C8  1  0.55833083  0.71662799  0.66372316  1
+  C  C9  1  0.97166880  0.97070960  0.09330517  1
+  C  C10  1  0.22872985  0.15039857  0.75690524  1
+  C  C11  1  0.20229600  0.56426225  0.23296308  1
+  C  C12  1  0.25431234  0.94008675  0.50109949  1
+  C  C13  1  0.09168414  0.36683508  0.26086159  1
+",-154.08903857142857
+3083,C-13897-9657-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46885000
+_cell_length_b   3.37753000
+_cell_length_c   5.22606000
+_cell_angle_alpha   89.16962000
+_cell_angle_beta   89.99933000
+_cell_angle_gamma   68.55748000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.55692002
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.69261336  0.88055463  0.47355641  1
+  C  C1  1  0.65016564  0.96019353  0.74789575  1
+  C  C2  1  0.84223568  0.58011939  -0.05020239  1
+  C  C3  1  0.06211768  0.13617358  0.87264380  1
+  C  C4  1  0.21649516  0.83081826  0.34941474  1
+  C  C5  1  0.25472348  0.75503601  0.07493079  1
+",-154.15392266666666
+8307,C-96705-9216-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.31730000
+_cell_length_b   3.51652000
+_cell_length_c   3.51681000
+_cell_angle_alpha   59.99372000
+_cell_angle_beta   89.99220000
+_cell_angle_gamma   89.99533000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.52629253
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.26837280  -0.11781748  0.90638644  1
+  C  C1  1  0.76835384  0.80969292  0.44232586  1
+  C  C2  1  0.43360104  0.11466502  0.44189770  1
+  C  C3  1  0.10044089  0.11414081  0.13789591  1
+  C  C4  1  0.93407320  0.57785988  0.90614432  1
+  C  C5  1  0.60052773  0.57827245  0.21032357  1
+",-154.40795733333331
+10050,C-127247-3767-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46590000
+_cell_length_b   4.25186000
+_cell_length_c   10.64105000
+_cell_angle_alpha   66.40716000
+_cell_angle_beta   89.58919000
+_cell_angle_gamma   89.00674000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   102.22679598
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20327604  0.54863107  0.42141182  1
+  C  C1  1  0.65921954  0.32483581  0.62877089  1
+  C  C2  1  -0.05381944  0.35794094  0.04823801  1
+  C  C3  1  0.20337032  1.13302633  0.83618223  1
+  C  C4  1  0.45540701  0.56188056  0.98153770  1
+  C  C5  1  0.12956229  0.82006630  0.48124790  1
+  C  C6  1  0.13621921  0.54305784  0.62877394  1
+  C  C7  1  0.34511532  0.91905049  0.98594995  1
+  C  C8  1  0.34460760  0.63404784  0.27188568  1
+  C  C9  1  0.94600220  0.19720906  0.20963610  1
+  C  C10  1  0.68367916  1.04234247  0.77227434  1
+  C  C11  1  0.85421244  0.99321409  0.05061430  1
+  C  C12  1  0.61081149  0.04251128  0.43797897  1
+  C  C13  1  0.45501233  0.26833113  0.27610325  1
+  C  C14  1  0.85394971  0.83749643  0.20727740  1
+  C  C15  1  0.61081973  0.65985594  0.81979790  1
+  C  C16  1  0.68350523  0.32991697  0.48529936  1
+  C  C17  1  1.12978974  0.52444874  0.77638948  1
+",-154.20780222222223
+6141,C-57120-3338-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.32154000
+_cell_length_b   3.32310000
+_cell_length_c   5.44484000
+_cell_angle_alpha   52.82001000
+_cell_angle_beta   86.30298000
+_cell_angle_gamma   83.32812000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.55789982
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.38688150  0.84545872  1.04302814  1
+  C  C1  1  0.90920755  0.05265135  0.35921023  1
+  C  C2  1  0.28285712  0.96627633  0.52618533  1
+  C  C3  1  0.30451294  0.63932354  -0.12409099  1
+  C  C4  1  0.55384438  0.40772344  0.35944806  1
+  C  C5  1  0.63625840  0.61379901  0.52652669  1
+  C  C6  1  1.03113571  0.20083412  1.04327614  1
+  C  C7  1  0.65754180  0.28698270  0.87629980  1
+",-154.18973375
+7769,C-176681-3152-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43070000
+_cell_length_b   3.21579000
+_cell_length_c   6.59632000
+_cell_angle_alpha   90.96066000
+_cell_angle_beta   111.77290000
+_cell_angle_gamma   112.07241000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.63675135
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.10294485  0.08674179  1.03316948  1
+  C  C1  1  0.43731550  0.64319032  0.58820831  1
+  C  C2  1  0.43665456  0.30589482  0.25574593  1
+  C  C3  1  0.10309722  0.41975072  0.36609335  1
+  C  C4  1  0.43584990  0.97333861  0.92220979  1
+  C  C5  1  1.10370456  0.75497035  0.69953224  1
+",-154.46533866666667
+3819,C-134199-8894-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50825000
+_cell_length_b   3.94576000
+_cell_length_c   4.77726000
+_cell_angle_alpha   93.19723000
+_cell_angle_beta   98.28957000
+_cell_angle_gamma   79.91537000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.04087437
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.47863874  0.04927965  0.56390509  1
+  C  C1  1  0.18836703  0.96447516  0.03292492  1
+  C  C2  1  0.29655425  0.23439890  0.27979920  1
+  C  C3  1  1.00663222  0.14984672  0.74954579  1
+  C  C4  1  0.66629167  0.67963662  0.53408680  1
+  C  C5  1  0.73081622  0.72303625  0.03742348  1
+  C  C6  1  -0.18527119  0.51944671  0.77807260  1
+  C  C7  1  0.75225786  0.47577380  0.27505202  1
+",-154.12853125
+8650,C-50231-4728-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42664000
+_cell_length_b   10.12382000
+_cell_length_c   6.75447000
+_cell_angle_alpha   64.91490000
+_cell_angle_beta   100.94205000
+_cell_angle_gamma   97.23555000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C20
+_cell_volume   147.35961561
+_cell_formula_units_Z   20
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70645514  0.98656276  0.25515916  1
+  C  C1  1  0.93476133  0.25087019  0.41902510  1
+  C  C2  1  0.18979670  1.05047592  0.15897362  1
+  C  C3  1  0.16500482  0.75888023  0.40846230  1
+  C  C4  1  0.71855861  0.83858721  0.43100208  1
+  C  C5  1  0.44252832  0.02858917  0.64906033  1
+  C  C6  1  0.44541996  0.18067637  0.50631931  1
+  C  C7  1  0.13525554  0.31001305  0.81054067  1
+  C  C8  1  0.92479811  0.95216026  0.69238291  1
+  C  C9  1  0.20644163  0.62046089  0.62416045  1
+  C  C10  1  0.49332201  0.69456220  0.14498721  1
+  C  C11  1  0.67797858  0.53602846  0.65501196  1
+  C  C12  1  0.38807270  0.45879079  0.14496208  1
+  C  C13  1  0.90086340  0.38928572  0.23488656  1
+  C  C14  1  0.63938795  0.38990169  0.73801806  1
+  C  C15  1  0.14806462  0.17640438  -0.03285903  1
+  C  C16  1  0.32740791  0.70778229  0.76918573  1
+  C  C17  1  1.04694876  0.72365253  0.21804042  1
+  C  C18  1  0.83694017  0.80635505  0.68474683  1
+  C  C19  1  0.39038222  0.61617144  1.00467256  1
+",-154.0924915
+6407,C-57144-6540-53,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48316000
+_cell_length_b   5.11053000
+_cell_length_c   8.55071000
+_cell_angle_alpha   117.84213000
+_cell_angle_beta   89.99624000
+_cell_angle_gamma   89.99291000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   95.94931787
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.56892390  0.11812738  0.47788106  1
+  C  C1  1  0.06877243  0.80882920  1.01947404  1
+  C  C2  1  0.06858260  0.62961412  0.27540802  1
+  C  C3  1  0.06907059  0.92648975  0.44184470  1
+  C  C4  1  0.56915192  0.61225265  0.73670332  1
+  C  C5  1  0.06870328  0.16184398  0.74522757  1
+  C  C6  1  0.56899520  0.65891773  0.57308963  1
+  C  C7  1  0.06849816  0.34372857  0.29047865  1
+  C  C8  1  0.06892957  0.76625085  0.83704525  1
+  C  C9  1  0.06789684  0.13538429  0.08791205  1
+  C  C10  1  0.56857489  0.62764326  0.18549465  1
+  C  C11  1  0.56872825  0.71746334  1.06696452  1
+  C  C12  1  0.56864961  0.34400647  0.39940743  1
+  C  C13  1  1.06904605  0.84083744  0.58533064  1
+  C  C14  1  1.06788741  1.09551632  0.90469978  1
+  C  C15  1  0.56898272  0.28672766  0.69251699  1
+",-154.06679625
+6432,C-136241-2721-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.55806000
+_cell_length_b   3.69267000
+_cell_length_c   4.59780000
+_cell_angle_alpha   90.12890000
+_cell_angle_beta   91.13786000
+_cell_angle_gamma   71.57960000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   73.40726655
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.96932477  0.59022483  0.33680030  1
+  C  C1  1  0.24259243  0.43590626  0.48864079  1
+  C  C2  1  0.74972090  0.46937851  0.46994084  1
+  C  C3  1  0.32129395  0.80581465  0.11495693  1
+  C  C4  1  0.45999382  0.56532067  0.35933224  1
+  C  C5  1  0.00052828  0.81504219  1.10399735  1
+  C  C6  1  0.88829907  0.22720041  0.71330778  1
+  C  C7  1  0.76432227  1.02328402  0.90815880  1
+  C  C8  1  0.21023055  0.21343274  0.72279460  1
+  C  C9  1  0.44537824  0.00976792  0.92001337  1
+",-154.19476400000002
+6029,C-130499-1826-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.93009000
+_cell_length_b   3.63661000
+_cell_length_c   4.82439000
+_cell_angle_alpha   112.16677000
+_cell_angle_beta   89.22151000
+_cell_angle_gamma   110.66327000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.11867932
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17043138  0.83209395  0.34658534  1
+  C  C1  1  0.17135488  0.27350794  0.84537991  1
+  C  C2  1  1.17142786  0.86654489  0.65280641  1
+  C  C3  1  0.17039698  0.42516871  0.15385821  1
+  C  C4  1  0.17420311  0.48695908  0.65355372  1
+  C  C5  1  0.16720939  0.21136923  0.34547851  1
+",-154.1424395
+395,C-102866-2261-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42571000
+_cell_length_b   6.19430000
+_cell_length_c   4.15705000
+_cell_angle_alpha   109.78979000
+_cell_angle_beta   90.09402000
+_cell_angle_gamma   101.20112000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.49962369
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.67938410  0.44510354  0.64678415  1
+  C  C1  1  0.13756619  0.37078940  0.10451357  1
+  C  C2  1  0.99805173  0.07853752  0.49216226  1
+  C  C3  1  0.45012187  0.98057419  0.34621987  1
+  C  C4  1  1.12017868  0.32603816  0.73103354  1
+  C  C5  1  0.35399260  0.79019843  0.03055417  1
+  C  C6  1  0.65229786  0.40199738  0.27496141  1
+  C  C7  1  0.80456517  0.69227148  0.88420642  1
+",-154.2221475
+5245,C-177222-86-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.34647000
+_cell_length_b   3.87118000
+_cell_length_c   3.92960000
+_cell_angle_alpha   92.24197000
+_cell_angle_beta   68.22586000
+_cell_angle_gamma   79.30329000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   59.91113392
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.35169452  0.69763141  0.20535991  1
+  C  C1  1  0.59110197  0.22467853  0.72482189  1
+  C  C2  1  0.67769401  0.69779716  0.20502694  1
+  C  C3  1  0.53197204  0.99123591  0.49634664  1
+  C  C4  1  0.29326998  0.46835281  0.97305952  1
+  C  C5  1  0.91626772  0.22446857  0.72666031  1
+  C  C6  1  0.20587381  0.99113363  0.49656219  1
+  C  C7  1  0.96826265  0.46901238  0.97098059  1
+",-154.074525
+10093,C-102887-506-60,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43059000
+_cell_length_b   6.51964000
+_cell_length_c   6.41284000
+_cell_angle_alpha   59.42674000
+_cell_angle_beta   79.28682000
+_cell_angle_gamma   79.49163000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   85.50449225
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.62538952  1.22291978  0.53364458  1
+  C  C1  1  1.06804071  0.22485245  0.64355736  1
+  C  C2  1  -0.26527606  0.22472771  0.31043793  1
+  C  C3  1  0.95869606  0.22347309  0.86646419  1
+  C  C4  1  0.40119924  0.22499526  0.97702048  1
+  C  C5  1  0.29214346  0.22277206  0.20034571  1
+  C  C6  1  0.06502278  0.72503957  0.14523057  1
+  C  C7  1  0.62248100  0.72297628  0.03541476  1
+  C  C8  1  0.95569976  0.72341999  0.36827729  1
+  C  C9  1  0.28944425  0.72253672  0.70218733  1
+  C  C10  1  0.39816569  0.72476243  0.47888484  1
+  C  C11  1  0.73187869  0.72457026  0.81233926  1
+",-154.44178333333335
+2527,C-96692-7228-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.38370000
+_cell_length_b   2.46626000
+_cell_length_c   6.24987000
+_cell_angle_alpha   78.51944000
+_cell_angle_beta   57.07397000
+_cell_angle_gamma   68.50854000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.73428387
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.51349653  -0.00444975  0.68854357  1
+  C  C1  1  0.38508285  0.39563707  1.01470103  1
+  C  C2  1  0.68844928  -0.19386258  0.88947202  1
+  C  C3  1  0.86243118  0.96005623  0.41396548  1
+  C  C4  1  0.03375130  0.43773093  0.28909638  1
+  C  C5  1  0.21046716  0.58460590  0.81384902  1
+",-154.16123466666667
+93,C-34639-131-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.43513000
+_cell_length_b   3.48772000
+_cell_length_c   4.61221000
+_cell_angle_alpha   68.56679000
+_cell_angle_beta   87.52313000
+_cell_angle_gamma   85.34481000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   51.26127736
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.56966825  0.28302310  0.03619782  1
+  C  C1  1  0.50851330  -0.02381197  0.88162268  1
+  C  C2  1  -0.14855316  0.64485847  0.86962638  1
+  C  C3  1  0.41863978  0.19854931  0.55463297  1
+  C  C4  1  0.16582955  0.52502453  0.39169274  1
+  C  C5  1  0.22697603  0.61443895  0.04806263  1
+  C  C6  1  0.65501092  0.05996195  0.36358025  1
+  C  C7  1  0.91035722  0.73559456  0.52551972  1
+",-154.115585
+3809,C-102922-4323-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47353000
+_cell_length_b   3.28805000
+_cell_length_c   6.91765000
+_cell_angle_alpha   61.59834000
+_cell_angle_beta   79.69042000
+_cell_angle_gamma   67.87282000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.84497049
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.69294811  0.51202890  1.01813641  1
+  C  C1  1  0.37254902  0.47085078  0.69884867  1
+  C  C2  1  0.69319815  0.15124751  0.37902560  1
+  C  C3  1  0.01184135  0.19273246  0.69883131  1
+  C  C4  1  0.87310803  0.97033595  0.19885446  1
+  C  C5  1  1.19302870  1.01241093  0.51814353  1
+  C  C6  1  0.51244854  0.69222689  0.19879981  1
+  C  C7  1  0.19271011  0.65140358  0.87902622  1
+",-154.3308625
+6586,C-96694-8817-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46077000
+_cell_length_b   4.57012000
+_cell_length_c   7.97501000
+_cell_angle_alpha   103.95404000
+_cell_angle_beta   90.03713000
+_cell_angle_gamma   57.39447000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   72.40009564
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.26672532  0.94136151  1.01054629  1
+  C  C1  1  0.73642415  0.97212288  0.45686985  1
+  C  C2  1  -0.19719807  0.90566483  0.26426545  1
+  C  C3  1  0.14546667  1.06267397  0.54324221  1
+  C  C4  1  0.89290573  0.31537249  0.71548766  1
+  C  C5  1  0.17059848  0.53758271  0.11676218  1
+  C  C6  1  0.98683936  0.72121520  0.96358805  1
+  C  C7  1  -0.12159710  0.32982530  0.11398973  1
+  C  C8  1  0.25826561  0.44965876  0.79165340  1
+  C  C9  1  0.14707264  0.06126044  0.21161008  1
+",-154.137344
+2882,C-102909-4745-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43906000
+_cell_length_b   4.14453000
+_cell_length_c   8.76230000
+_cell_angle_alpha   91.61204000
+_cell_angle_beta   98.00853000
+_cell_angle_gamma   89.98832000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   87.67678117
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46712624  0.74901372  0.74554086  1
+  C  C1  1  0.44984926  0.43778975  0.70419908  1
+  C  C2  1  0.70047722  -0.06675674  0.20686367  1
+  C  C3  1  0.10757598  0.36062450  0.00456313  1
+  C  C4  1  0.85503202  1.12464481  0.51678636  1
+  C  C5  1  0.23721410  -0.02973134  0.28292087  1
+  C  C6  1  0.61361773  0.51684110  1.01620075  1
+  C  C7  1  1.08266535  1.01427453  0.96459036  1
+  C  C8  1  0.31669747  0.07158815  0.44249523  1
+  C  C9  1  0.93817111  0.24579244  0.68028177  1
+  C  C10  1  0.98646345  0.93305701  0.78383610  1
+  C  C11  1  0.61943928  -0.13050004  0.03717282  1
+",-154.243495
+6859,C-177252-751-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48372000
+_cell_length_b   3.82307000
+_cell_length_c   5.22445000
+_cell_angle_alpha   98.81692000
+_cell_angle_beta   89.99359000
+_cell_angle_gamma   71.04008000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.29639801
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.74230009  0.66142728  0.42094823  1
+  C  C1  1  0.95743184  0.23278863  0.36413895  1
+  C  C2  1  0.70663656  0.73477618  0.14108280  1
+  C  C3  1  0.46554818  0.21342667  0.91948736  1
+  C  C4  1  0.25338812  0.64071690  -0.02365069  1
+  C  C5  1  0.13111172  0.88357975  0.52720692  1
+  C  C6  1  0.50470533  0.13821114  0.19882652  1
+  C  C7  1  0.07676695  -0.00931075  0.81388852  1
+",-154.22019875
+1428,C-189728-4378-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51288000
+_cell_length_b   4.18846000
+_cell_length_c   4.11168000
+_cell_angle_alpha   119.39757000
+_cell_angle_beta   89.99334000
+_cell_angle_gamma   107.58781000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.36404268
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36355604  0.85638406  0.81534340  1
+  C  C1  1  -0.02505268  1.07968333  0.42673034  1
+  C  C2  1  0.36323695  0.85598113  0.18382516  1
+  C  C3  1  0.97512953  0.07961685  0.79565721  1
+  C  C4  1  0.17009758  0.46805871  0.47081470  1
+  C  C5  1  0.16996868  0.46781481  0.14002789  1
+",-154.23198816666667
+5623,C-47640-4572-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43101000
+_cell_length_b   4.58672000
+_cell_length_c   6.30191000
+_cell_angle_alpha   105.88283000
+_cell_angle_beta   89.38831000
+_cell_angle_gamma   121.06099000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.16427480
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.45071566  0.32413686  0.38560353  1
+  C  C1  1  1.20105843  0.57449740  0.13578253  1
+  C  C2  1  0.36587762  0.73919859  0.96818218  1
+  C  C3  1  0.61567367  0.48896166  0.21806593  1
+  C  C4  1  -0.04896206  -0.17551151  -0.11421927  1
+  C  C5  1  0.70077559  0.07416655  0.63562737  1
+  C  C6  1  0.86538506  0.23866794  0.46791928  1
+  C  C7  1  0.11562674  -0.01112059  0.71803165  1
+",-154.45935
+7374,C-152595-6978-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45632000
+_cell_length_b   2.53087000
+_cell_length_c   6.38114000
+_cell_angle_alpha   83.03316000
+_cell_angle_beta   90.64574000
+_cell_angle_gamma   90.86172000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.37003162
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64109541  0.30164238  0.81605982  1
+  C  C1  1  0.63884220  0.44092599  0.59504451  1
+  C  C2  1  0.14160381  0.13991113  0.15324736  1
+  C  C3  1  1.13668153  0.50846016  0.48854524  1
+  C  C4  1  0.14313271  0.23580446  0.92216491  1
+  C  C5  1  0.13762024  0.60900328  0.25773856  1
+",-154.07519516666667
+5763,C-47668-7767-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48867000
+_cell_length_b   5.29087000
+_cell_length_c   4.76118000
+_cell_angle_alpha   116.43462000
+_cell_angle_beta   121.51452000
+_cell_angle_gamma   89.99546000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.58086696
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46495152  0.19105433  0.48969279  1
+  C  C1  1  -0.13159646  0.26057022  0.89214294  1
+  C  C2  1  0.45500422  0.14607772  0.97879077  1
+  C  C3  1  -0.04674664  0.61312181  0.47765641  1
+  C  C4  1  0.87819173  0.30531824  0.40290278  1
+  C  C5  1  1.11008642  0.84300209  1.13397223  1
+  C  C6  1  0.22300091  0.60812657  0.24760843  1
+  C  C7  1  0.37983880  0.83799433  0.90394124  1
+",-154.3626225
+5508,C-107771-927-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48265000
+_cell_length_b   5.56771000
+_cell_length_c   5.56879000
+_cell_angle_alpha   46.83846000
+_cell_angle_beta   77.12055000
+_cell_angle_gamma   102.88495000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.48275441
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.47307423  0.68953316  0.50593042  1
+  C  C1  1  0.47276102  0.92290636  0.73836464  1
+  C  C2  1  0.21191792  -0.07166042  0.26708421  1
+  C  C3  1  0.47241738  0.07702707  0.89371420  1
+  C  C4  1  0.21214072  0.54933777  -0.11268836  1
+  C  C5  1  0.21177889  0.16188113  0.49957160  1
+  C  C6  1  0.47328707  0.31053628  0.12617203  1
+  C  C7  1  0.21143617  0.31598806  0.65494405  1
+",-154.23980875
+8164,C-113068-6749-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44933000
+_cell_length_b   3.66127000
+_cell_length_c   9.80589000
+_cell_angle_alpha   78.45117000
+_cell_angle_beta   75.55594000
+_cell_angle_gamma   70.38054000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   79.55615431
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.09738569  -0.05850496  0.41185602  1
+  C  C1  1  0.41966173  0.69494196  0.71372217  1
+  C  C2  1  -0.06083988  0.28803818  0.89949289  1
+  C  C3  1  1.14588396  0.45132704  0.10959997  1
+  C  C4  1  0.82423068  0.69820922  0.80767525  1
+  C  C5  1  0.65844009  0.28668831  0.67826116  1
+  C  C6  1  0.74900400  0.36669557  0.04845315  1
+  C  C7  1  0.58580458  1.10679137  0.84302686  1
+  C  C8  1  0.49430433  1.02607661  0.47297053  1
+  C  C9  1  0.92663237  0.64570429  0.23190978  1
+  C  C10  1  0.31665590  0.74621430  0.28976953  1
+  C  C11  1  0.30517694  0.10531250  0.62186349  1
+",-154.26841166666665
+6229,C-47627-477-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.26351000
+_cell_length_b   4.71114000
+_cell_length_c   4.66475000
+_cell_angle_alpha   76.22529000
+_cell_angle_beta   110.10034000
+_cell_angle_gamma   133.90680000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.52468589
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.75343188  0.72912051  0.08078352  1
+  C  C1  1  0.82062072  0.44196072  0.59284613  1
+  C  C2  1  0.13115602  0.11286511  0.92545280  1
+  C  C3  1  0.74791020  0.72923251  0.42557720  1
+  C  C4  1  0.10583902  0.44167635  0.91354675  1
+  C  C5  1  0.06434564  0.40027701  0.41347735  1
+  C  C6  1  0.77878423  0.40047086  0.09276078  1
+  C  C7  1  0.13702220  0.11297474  0.58067576  1
+",-154.14142625
+1261,C-107744-9535-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45351000
+_cell_length_b   4.16594000
+_cell_length_c   5.64934000
+_cell_angle_alpha   60.35488000
+_cell_angle_beta   102.60830000
+_cell_angle_gamma   89.98680000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.57432836
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.60057335  0.23779344  0.89926015  1
+  C  C1  1  0.56468818  0.93004425  0.84124835  1
+  C  C2  1  0.82737127  0.67841618  0.37278875  1
+  C  C3  1  0.13243902  0.68820769  -0.02381227  1
+  C  C4  1  0.29826352  0.53353491  0.31455140  1
+  C  C5  1  1.10946715  0.37994602  0.91886652  1
+  C  C6  1  0.86435092  0.93951796  0.44498097  1
+  C  C7  1  0.39265848  1.08464694  0.50284232  1
+",-154.1673425
+8149,C-134179-5260-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48287000
+_cell_length_b   3.79252000
+_cell_length_c   5.93362000
+_cell_angle_alpha   97.34678000
+_cell_angle_beta   102.08174000
+_cell_angle_gamma   89.99062000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   54.16643844
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.60407590  0.26685866  0.96979970  1
+  C  C1  1  0.69586115  0.59198837  0.15316366  1
+  C  C2  1  0.27281437  0.62567334  0.30678456  1
+  C  C3  1  0.69184861  1.00230009  0.14450058  1
+  C  C4  1  0.35981140  0.36267660  0.48137133  1
+  C  C5  1  0.92789271  0.35558380  0.61774170  1
+  C  C6  1  1.03535058  0.27476591  0.83309702  1
+  C  C7  1  0.26839538  0.03515253  0.29753495  1
+",-154.085735
+533,C-92128-7037-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45645000
+_cell_length_b   6.79364000
+_cell_length_c   6.66310000
+_cell_angle_alpha   112.96440000
+_cell_angle_beta   99.96458000
+_cell_angle_gamma   95.48827000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   99.19300476
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.03126839  1.01448807  0.64464269  1
+  C  C1  1  0.03852484  0.51202617  0.69491273  1
+  C  C2  1  0.70426461  0.81867748  -0.01094631  1
+  C  C3  1  0.77845409  1.04537068  0.98694715  1
+  C  C4  1  -0.12795440  0.05790154  0.43341919  1
+  C  C5  1  1.07575073  0.50602754  0.20836837  1
+  C  C6  1  0.73040914  0.83260271  0.23818751  1
+  C  C7  1  0.47831399  0.40083919  0.60555403  1
+  C  C8  1  0.59521690  0.01187719  0.74362242  1
+  C  C9  1  0.13399107  0.70400049  -0.12384365  1
+  C  C10  1  0.19304973  0.71775525  0.24967947  1
+  C  C11  1  0.36937955  0.17033836  1.08045874  1
+  C  C12  1  0.40457064  0.18825209  0.46112533  1
+  C  C13  1  0.51483302  0.38868435  0.16576482  1
+",-154.09802642857144
+6129,C-130509-1794-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43865000
+_cell_length_b   5.13811000
+_cell_length_c   6.51873000
+_cell_angle_alpha   113.12890000
+_cell_angle_beta   118.89050000
+_cell_angle_gamma   68.94299000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   64.29229941
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.68422949  0.31990360  0.08233225  1
+  C  C1  1  0.93492144  0.03841885  0.16929039  1
+  C  C2  1  0.79569822  0.61850816  0.27658710  1
+  C  C3  1  0.99816688  0.29577001  0.92498675  1
+  C  C4  1  0.47628474  0.91146299  0.63189542  1
+  C  C5  1  0.57766293  0.44745465  0.73208103  1
+  C  C6  1  0.48008522  0.64365489  0.43392927  1
+  C  C7  1  -0.10068611  0.49546048  0.62934598  1
+  C  C8  1  0.54688887  0.89965777  0.18971577  1
+  C  C9  1  0.00322031  1.02715460  0.72772163  1
+",-154.116693
+909,C-184086-7799-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48049000
+_cell_length_b   5.04076000
+_cell_length_c   5.46376000
+_cell_angle_alpha   122.83112000
+_cell_angle_beta   89.99357000
+_cell_angle_gamma   90.00533000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.40439376
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.42037069  0.86334285  0.05708683  1
+  C  C1  1  0.57962198  0.51845791  0.50376947  1
+  C  C2  1  1.07960903  0.38882285  0.31110816  1
+  C  C3  1  1.07963124  1.03184978  0.22836915  1
+  C  C4  1  0.57961953  0.33406839  0.64631249  1
+  C  C5  1  1.07949582  0.03180004  0.76157753  1
+  C  C6  1  0.57950379  0.86321349  0.76421509  1
+  C  C7  1  0.57959965  0.51838821  0.97309902  1
+  C  C8  1  0.07956996  0.13069503  0.54441777  1
+  C  C9  1  0.07951720  0.38845305  0.03589168  1
+",-154.33689199999998
+9534,C-57129-5279-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43215000
+_cell_length_b   4.71968000
+_cell_length_c   6.35187000
+_cell_angle_alpha   63.76697000
+_cell_angle_beta   74.90907000
+_cell_angle_gamma   64.30615000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.72303286
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.04990207  0.88709425  0.50831850  1
+  C  C1  1  0.30082726  0.38679144  0.25720844  1
+  C  C2  1  0.38389299  0.21950048  0.84173446  1
+  C  C3  1  0.54989814  0.88710546  0.00831940  1
+  C  C4  1  0.80085967  0.38677464  0.75717005  1
+  C  C5  1  -0.11614409  0.21951232  0.34177798  1
+  C  C6  1  0.63490374  0.71922293  0.59063176  1
+  C  C7  1  0.13486972  0.71923927  1.09064881  1
+",-154.46009875
+873,C-152560-3717-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45849000
+_cell_length_b   3.40160000
+_cell_length_c   5.93287000
+_cell_angle_alpha   63.08832000
+_cell_angle_beta   77.96906000
+_cell_angle_gamma   68.67664000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.15614575
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20417683  0.76943155  0.08030907  1
+  C  C1  1  0.71250763  0.87937365  -0.04641848  1
+  C  C2  1  0.57312569  0.62747099  0.48401640  1
+  C  C3  1  0.17477276  0.55414437  0.35610493  1
+  C  C4  1  0.74197223  0.09585410  0.67775517  1
+  C  C5  1  0.34349695  0.02311604  0.54962211  1
+",-154.14465099999998
+5963,C-76054-3397-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49225000
+_cell_length_b   3.29502000
+_cell_length_c   10.02558000
+_cell_angle_alpha   109.22259000
+_cell_angle_beta   82.75826000
+_cell_angle_gamma   112.19495000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   71.97964714
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.89773871  0.23669268  0.82200067  1
+  C  C1  1  0.21910757  0.67294751  0.61531767  1
+  C  C2  1  1.22138167  0.44220690  0.38370202  1
+  C  C3  1  -0.09612647  0.59368545  0.17710090  1
+  C  C4  1  0.71748883  0.98597329  0.92906471  1
+  C  C5  1  0.53821373  0.52142864  0.82208916  1
+  C  C6  1  0.71863482  0.76201277  0.70431725  1
+  C  C7  1  0.40110233  -0.08160287  0.49944848  1
+  C  C8  1  -0.27734234  0.12850972  1.07013758  1
+  C  C9  1  0.72206468  0.35299678  0.29469656  1
+  C  C10  1  1.04083639  0.19678891  0.49937185  1
+  C  C11  1  0.54371459  0.87796751  0.17718716  1
+",-154.18530333333334
+6079,C-189703-1540-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.50466000
+_cell_length_b   3.82148000
+_cell_length_c   4.20604000
+_cell_angle_alpha   97.49795000
+_cell_angle_beta   117.30104000
+_cell_angle_gamma   110.17250000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.08267974
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.80019883  0.65813846  0.41989482  1
+  C  C1  1  0.46631119  0.32502072  0.41964439  1
+  C  C2  1  0.46693049  0.32470281  0.75320017  1
+  C  C3  1  0.13363881  -0.00861914  0.75315526  1
+  C  C4  1  1.13266727  0.99154087  1.08608984  1
+  C  C5  1  0.79903731  0.65834548  1.08593623  1
+",-154.41381016666665
+2475,C-136251-4147-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44697000
+_cell_length_b   6.45765000
+_cell_length_c   9.12145000
+_cell_angle_alpha   126.68966000
+_cell_angle_beta   120.41625000
+_cell_angle_gamma   76.60425000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   99.14772655
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.12727426  0.49072367  0.89680254  1
+  C  C1  1  0.50697940  0.50192893  0.55010700  1
+  C  C2  1  0.73092058  0.68886681  0.29298285  1
+  C  C3  1  0.48225820  0.51944147  0.82782807  1
+  C  C4  1  0.44455785  0.43551338  1.05353311  1
+  C  C5  1  0.09229035  0.06148476  0.34849009  1
+  C  C6  1  0.00402342  0.51224719  0.36674751  1
+  C  C7  1  1.19671601  0.59754644  0.68181220  1
+  C  C8  1  0.30343507  0.88678228  0.81179010  1
+  C  C9  1  0.53339527  0.19830533  0.36327831  1
+  C  C10  1  0.38294402  0.34228478  0.26065428  1
+  C  C11  1  0.85218104  1.01384137  -0.12252848  1
+  C  C12  1  0.20575504  0.83563443  0.32873676  1
+  C  C13  1  1.01593717  0.29062426  0.04579204  1
+",-154.12267285714285
+8595,C-13696-4228-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.34600000
+_cell_length_b   4.91418000
+_cell_length_c   6.37260000
+_cell_angle_alpha   90.40696000
+_cell_angle_beta   115.31229000
+_cell_angle_gamma   102.07421000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   92.07397393
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.08746618  0.06056433  0.27894775  1
+  C  C1  1  0.33101562  0.87399333  0.88646724  1
+  C  C2  1  0.03043798  0.33450546  0.58355696  1
+  C  C3  1  0.80557571  0.29550127  0.77021038  1
+  C  C4  1  0.51820286  0.00292318  0.72065635  1
+  C  C5  1  0.95936771  0.58337126  0.14841803  1
+  C  C6  1  0.39296208  0.26177481  0.20037199  1
+  C  C7  1  1.31679482  0.83571291  0.25883585  1
+  C  C8  1  0.75143358  0.77559617  0.69607760  1
+  C  C9  1  0.54936349  1.01867008  0.13023070  1
+  C  C10  1  0.09960990  1.04760648  0.51109023  1
+  C  C11  1  0.49854428  0.60285956  0.95644693  1
+  C  C12  1  0.14838509  0.41375455  1.01432739  1
+  C  C13  1  -0.27045047  0.77364488  0.45960066  1
+  C  C14  1  0.80141168  0.48515481  0.36498894  1
+  C  C15  1  0.50975169  0.49878640  0.73854630  1
+",-154.102391875
+860,C-34660-1476-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.69991000
+_cell_length_b   4.28333000
+_cell_length_c   4.26812000
+_cell_angle_alpha   121.12349000
+_cell_angle_beta   103.54366000
+_cell_angle_gamma   97.38508000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   53.70309102
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.13088447  0.05929534  0.37508673  1
+  C  C1  1  1.08586947  0.72011754  0.71096716  1
+  C  C2  1  0.17273721  0.08890696  0.74279629  1
+  C  C3  1  0.27134218  0.44961716  0.44297678  1
+  C  C4  1  0.68693306  0.64887615  0.72088375  1
+  C  C5  1  0.23228747  0.42038318  0.07593939  1
+  C  C6  1  0.31516262  0.78840544  0.10629283  1
+  C  C7  1  0.71476202  0.86075502  0.09730536  1
+",-154.0855825
+5,C-28215-4713-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47571000
+_cell_length_b   4.89153000
+_cell_length_c   6.53200000
+_cell_angle_alpha   98.91404000
+_cell_angle_beta   86.64061000
+_cell_angle_gamma   96.69427000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   77.54813051
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.11797987  0.74060731  0.86563444  1
+  C  C1  1  0.16010789  -0.06252962  0.51318087  1
+  C  C2  1  0.48721413  0.45814630  0.36059792  1
+  C  C3  1  0.45558985  0.55222616  0.14006503  1
+  C  C4  1  0.36070797  0.10768640  0.32651987  1
+  C  C5  1  -0.01513959  0.71349560  1.09894123  1
+  C  C6  1  0.40342516  0.30465116  0.97347147  1
+  C  C7  1  0.84498876  0.14212335  1.00241660  1
+  C  C8  1  0.53476439  0.33208780  0.74023577  1
+  C  C9  1  1.03336446  0.58827211  0.47927550  1
+  C  C10  1  0.67771296  0.90310993  0.83651217  1
+  C  C11  1  0.64069601  1.02464815  0.64176124  1
+  C  C12  1  0.87921138  0.02059411  0.19775863  1
+  C  C13  1  1.06383927  0.49327514  0.69947097  1
+",-154.1517464285714
+5842,C-57140-5474-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52402000
+_cell_length_b   4.44758000
+_cell_length_c   4.37012000
+_cell_angle_alpha   73.91415000
+_cell_angle_beta   94.16860000
+_cell_angle_gamma   99.08986000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.52368631
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.39063872  -0.03367980  0.18168400  1
+  C  C1  1  0.61729857  0.30980849  0.15890914  1
+  C  C2  1  0.81825498  0.43869153  0.42760342  1
+  C  C3  1  0.56581842  0.49306716  0.87116269  1
+  C  C4  1  0.33878315  0.32885873  0.63423776  1
+  C  C5  1  0.85378692  0.80512576  0.36124810  1
+  C  C6  1  0.31305929  0.97957419  0.81398752  1
+  C  C7  1  0.77607123  0.82366285  0.72118566  1
+",-154.0791575
+5044,C-113032-4206-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45672000
+_cell_length_b   3.66484000
+_cell_length_c   6.44198000
+_cell_angle_alpha   105.99791000
+_cell_angle_beta   90.04992000
+_cell_angle_gamma   109.57540000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.25258828
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87452283  0.30194609  0.05004630  1
+  C  C1  1  0.10034102  0.75151525  1.10166445  1
+  C  C2  1  0.82102868  0.19517270  0.42417622  1
+  C  C3  1  0.37115943  0.29452251  0.53004462  1
+  C  C4  1  0.46770611  0.49002176  0.76656550  1
+  C  C5  1  1.09219200  0.73783027  0.85408945  1
+  C  C6  1  0.31590730  0.18671916  0.90430832  1
+  C  C7  1  0.72295265  0.99830057  0.18809285  1
+",-154.28885625
+859,C-9597-1186-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47363000
+_cell_length_b   4.80353000
+_cell_length_c   5.94070000
+_cell_angle_alpha   74.14018000
+_cell_angle_beta   89.99940000
+_cell_angle_gamma   75.06566000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   65.41909752
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.65260393  0.20986997  0.19676543  1
+  C  C1  1  0.37748508  0.76485021  0.14211656  1
+  C  C2  1  0.86448292  0.79190237  -0.01130075  1
+  C  C3  1  0.31922861  0.87656592  0.53011875  1
+  C  C4  1  0.71080345  0.09821005  0.80878755  1
+  C  C5  1  0.58402462  0.34828318  0.93267936  1
+  C  C6  1  0.19782329  0.12523008  0.65539231  1
+  C  C7  1  -0.01403048  0.54323020  0.86342937  1
+  C  C8  1  0.53127058  0.45852422  0.32205541  1
+  C  C9  1  0.25062918  1.01492882  0.26602276  1
+  C  C10  1  0.91730373  0.68161824  0.59935809  1
+  C  C11  1  1.04424519  0.43151596  0.47546857  1
+",-154.5218475
+7814,C-130550-4259-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50124000
+_cell_length_b   6.24832000
+_cell_length_c   5.44566000
+_cell_angle_alpha   71.77738000
+_cell_angle_beta   80.20234000
+_cell_angle_gamma   92.86841000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   79.17422597
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.72188852  0.40972128  0.86857404  1
+  C  C1  1  0.74055761  0.55719791  0.38197169  1
+  C  C2  1  0.22023879  0.25917320  0.25367070  1
+  C  C3  1  0.31488938  0.50825481  0.24000257  1
+  C  C4  1  0.65880341  0.37914468  0.64768151  1
+  C  C5  1  0.71994038  0.80537064  0.38701925  1
+  C  C6  1  0.17882668  0.85272822  0.53067154  1
+  C  C7  1  0.78171887  0.98166045  0.09277458  1
+  C  C8  1  0.32404312  0.96133156  0.93448378  1
+  C  C9  1  0.16577132  0.75336670  0.83794374  1
+  C  C10  1  0.59949542  0.61478545  -0.05985413  1
+  C  C11  1  0.56158547  0.13905986  0.66203351  1
+  C  C12  1  0.12300039  0.09676816  0.52199745  1
+  C  C13  1  0.75604275  0.22131048  0.11057539  1
+",-154.148835
+6966,C-189734-3200-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.54166000
+_cell_length_b   4.15027000
+_cell_length_c   6.83755000
+_cell_angle_alpha   65.97286000
+_cell_angle_beta   68.10928000
+_cell_angle_gamma   71.91035000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   60.04567456
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.05853700  0.77813547  0.40073632  1
+  C  C1  1  0.19750533  0.36791007  -0.03191779  1
+  C  C2  1  0.50003083  0.60896476  0.54440892  1
+  C  C3  1  -0.10531303  0.15796416  0.37626955  1
+  C  C4  1  0.24070117  0.68549695  0.76420312  1
+  C  C5  1  -0.05526991  0.46671401  0.17288183  1
+  C  C6  1  0.61407461  0.92103306  0.77217421  1
+  C  C7  1  0.31792952  0.70109904  0.18101497  1
+  C  C8  1  0.66467562  0.22915031  0.56873470  1
+  C  C9  1  0.36093576  0.01981928  0.97707507  1
+",-154.196574
+287,C-40144-9743-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.02647000
+_cell_length_b   4.21050000
+_cell_length_c   4.21034000
+_cell_angle_alpha   59.99515000
+_cell_angle_beta   77.40847000
+_cell_angle_gamma   64.35412000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.88464608
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.19386153  0.16524858  0.83266263  1
+  C  C1  1  0.20299790  0.82869644  0.16599701  1
+  C  C2  1  0.20284221  0.49540990  0.83266508  1
+  C  C3  1  0.19384662  0.49858367  0.16598693  1
+  C  C4  1  0.20287002  0.16206707  0.49933144  1
+  C  C5  1  0.19384203  0.83191024  0.49932971  1
+",-154.43311666666668
+3794,C-130503-1906-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45754000
+_cell_length_b   4.48393000
+_cell_length_c   7.90248000
+_cell_angle_alpha   76.39442000
+_cell_angle_beta   90.06289000
+_cell_angle_gamma   74.09074000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   81.19478983
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.10654632  0.93269496  0.92423570  1
+  C  C1  1  0.04718295  0.62421827  0.03743853  1
+  C  C2  1  0.77007478  0.18729705  1.02045350  1
+  C  C3  1  0.89496154  0.92040700  0.36234706  1
+  C  C4  1  0.76002790  0.19794408  0.21370065  1
+  C  C5  1  0.41234474  -0.10696321  0.63615182  1
+  C  C6  1  0.35623209  0.00862500  0.80259217  1
+  C  C7  1  0.59973200  0.52191056  0.66153969  1
+  C  C8  1  0.84097701  1.03384731  0.52890702  1
+  C  C9  1  0.64834556  0.41477676  0.48981403  1
+  C  C10  1  0.14231807  0.42785953  0.21858423  1
+  C  C11  1  0.17614764  0.37615211  0.94800691  1
+  C  C12  1  1.17120787  0.38069408  0.76017004  1
+  C  C13  1  0.07579148  0.55845610  0.38208934  1
+",-154.17670785714287
+1486,C-141018-4458-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44345000
+_cell_length_b   4.18038000
+_cell_length_c   6.64929000
+_cell_angle_alpha   96.99086000
+_cell_angle_beta   89.91194000
+_cell_angle_gamma   90.02358000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   67.41447847
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.67655486  0.33293071  1.00339427  1
+  C  C1  1  1.18024446  0.70707865  0.73637450  1
+  C  C2  1  0.67811455  0.68604455  0.05423192  1
+  C  C3  1  0.68136576  0.78730992  0.29359118  1
+  C  C4  1  0.68190539  0.49180631  0.42350712  1
+  C  C5  1  1.17828599  0.81932475  -0.04100505  1
+  C  C6  1  0.18162090  0.97714808  0.34480345  1
+  C  C7  1  0.18204107  0.29534439  0.39294396  1
+  C  C8  1  0.17627462  0.17518633  0.98734913  1
+  C  C9  1  0.68076211  0.64456469  0.64004362  1
+",-154.243163
+3685,C-193942-6433-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46229000
+_cell_length_b   3.39556000
+_cell_length_c   5.30185000
+_cell_angle_alpha   85.23434000
+_cell_angle_beta   89.99919000
+_cell_angle_gamma   68.82652000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.17108960
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.83993986  0.60836559  0.69191286  1
+  C  C1  1  0.61107584  0.06435451  0.62268037  1
+  C  C2  1  0.46214756  0.35397842  0.09444632  1
+  C  C3  1  0.43508742  0.41703965  0.81894775  1
+  C  C4  1  0.97642571  0.32464257  0.22131720  1
+  C  C5  1  0.01482571  0.25630676  0.49700201  1
+",-154.1614155
+2496,C-145315-3954-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.71259000
+_cell_length_b   4.13653000
+_cell_length_c   5.45292000
+_cell_angle_alpha   113.20786000
+_cell_angle_beta   105.91758000
+_cell_angle_gamma   94.19621000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   72.44148191
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.33600664  1.04486355  0.39481521  1
+  C  C1  1  0.62671247  0.48307646  0.23043112  1
+  C  C2  1  0.41121514  0.39288739  0.92849692  1
+  C  C3  1  0.99033497  0.36443855  0.90522525  1
+  C  C4  1  -0.02495748  0.33227613  0.19157881  1
+  C  C5  1  0.68530153  0.89418110  0.35647849  1
+  C  C6  1  0.39481926  0.41547519  0.39731446  1
+  C  C7  1  0.58506572  0.74343548  0.67948510  1
+  C  C8  1  0.31957839  1.01332904  0.68193298  1
+  C  C9  1  0.91674063  0.96283788  0.18954283  1
+  C  C10  1  -0.27495229  0.63346927  -0.09272318  1
+  C  C11  1  0.89962833  -0.01634365  0.65841661  1
+",-154.068535
+7610,C-145335-4867-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43861000
+_cell_length_b   7.44451000
+_cell_length_c   8.32531000
+_cell_angle_alpha   65.62521000
+_cell_angle_beta   72.87874000
+_cell_angle_gamma   99.42972000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   124.29838036
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.30039164  0.34690697  0.63665234  1
+  C  C1  1  0.79850986  0.70894671  0.81979988  1
+  C  C2  1  0.42343765  0.01864801  0.35436383  1
+  C  C3  1  -0.04891525  0.39109223  0.50915502  1
+  C  C4  1  0.81296979  0.58391003  0.74193939  1
+  C  C5  1  0.85909704  0.91986581  0.36931833  1
+  C  C6  1  0.20177680  0.62555916  0.37768173  1
+  C  C7  1  -0.00676085  0.27029299  0.40700719  1
+  C  C8  1  0.36828683  0.54165635  0.66628574  1
+  C  C9  1  0.28065184  0.77987975  -0.12646173  1
+  C  C10  1  0.68064785  0.69822297  0.43528540  1
+  C  C11  1  0.03502472  0.70493642  0.08457142  1
+  C  C12  1  0.43396464  0.68224406  0.17448123  1
+  C  C13  1  0.49563176  0.20350000  0.37141695  1
+  C  C14  1  1.04715120  0.11725355  0.77299632  1
+  C  C15  1  0.46412087  0.01286938  0.80365026  1
+",-154.2012075
+1410,C-57113-4466-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42856000
+_cell_length_b   4.15026000
+_cell_length_c   6.29779000
+_cell_angle_alpha   76.69792000
+_cell_angle_beta   101.08862000
+_cell_angle_gamma   89.99457000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   60.55471867
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.28683371  1.05897328  0.34511415  1
+  C  C1  1  1.05716338  0.20067417  0.89195356  1
+  C  C2  1  0.40116353  1.07212023  0.58266491  1
+  C  C3  1  0.27293593  0.72191091  0.30640545  1
+  C  C4  1  0.73136206  0.24118247  0.23499980  1
+  C  C5  1  0.75760186  0.57612099  0.27878092  1
+  C  C6  1  -0.04646719  0.10998032  0.68439452  1
+  C  C7  1  0.61109232  0.23325823  -0.00440181  1
+",-154.27155375
+4769,C-145355-492-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48319000
+_cell_length_b   4.82503000
+_cell_length_c   5.74547000
+_cell_angle_alpha   89.98358000
+_cell_angle_beta   77.50849000
+_cell_angle_gamma   90.00393000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.20959572
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.97316335  0.78193751  0.93662219  1
+  C  C1  1  0.66404481  0.68508255  0.55630144  1
+  C  C2  1  0.90510744  0.51459067  0.07303503  1
+  C  C3  1  -0.02679435  0.24671785  0.93668662  1
+  C  C4  1  0.32747287  0.51440557  0.22860498  1
+  C  C5  1  0.30464035  1.01444558  0.27313151  1
+  C  C6  1  0.54776536  0.84435235  0.78828947  1
+  C  C7  1  1.23688050  0.28151005  0.40927734  1
+  C  C8  1  0.23744525  0.74622618  0.40895066  1
+  C  C9  1  0.66363428  0.34409533  0.55645219  1
+  C  C10  1  0.88298621  0.01473154  0.11682100  1
+  C  C11  1  0.54766393  0.18551292  0.78845617  1
+",-154.44288333333333
+5267,C-145321-8105-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.89381000
+_cell_length_b   5.28249000
+_cell_length_c   5.24297000
+_cell_angle_alpha   101.72169000
+_cell_angle_beta   89.02821000
+_cell_angle_gamma   118.40759000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   92.48029082
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17179852  0.30905482  0.29534962  1
+  C  C1  1  0.06305109  0.35893899  1.02078099  1
+  C  C2  1  0.04574436  0.80526036  0.28964125  1
+  C  C3  1  0.83136976  1.05098054  0.83902425  1
+  C  C4  1  0.66439827  1.04691675  0.58331175  1
+  C  C5  1  0.04320398  0.85644330  0.79932022  1
+  C  C6  1  0.33812757  0.55691773  0.83973848  1
+  C  C7  1  0.42357309  0.87656373  0.93164587  1
+  C  C8  1  0.83403183  0.00026709  0.32966541  1
+  C  C9  1  0.53898136  0.29988725  0.28924535  1
+  C  C10  1  0.21359689  0.80962487  0.54538376  1
+  C  C11  1  0.81470554  0.49761658  0.10809296  1
+  C  C12  1  0.45401956  0.98073058  0.19865906  1
+  C  C13  1  0.70577231  0.54741483  0.83387906  1
+  C  C14  1  0.72605628  0.35004605  0.57898629  1
+  C  C15  1  0.15155210  0.50652032  0.54981108  1
+",-154.109098125
+6741,C-106861-4375-51,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43210000
+_cell_length_b   5.09181000
+_cell_length_c   6.30298000
+_cell_angle_alpha   116.41041000
+_cell_angle_beta   124.43243000
+_cell_angle_gamma   75.19028000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.65901411
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.19938141  0.84435181  0.65790443  1
+  C  C1  1  0.46642889  0.25998855  0.24027788  1
+  C  C2  1  0.79853753  0.59080467  0.90510832  1
+  C  C3  1  0.46778321  0.01234294  0.49213938  1
+  C  C4  1  0.46699699  0.75998605  0.74034104  1
+  C  C5  1  0.46508744  0.50752247  -0.01169123  1
+  C  C6  1  0.79865323  0.34173927  0.15583774  1
+  C  C7  1  0.80056860  1.09478974  0.40828884  1
+",-154.44593875
+2042,C-142757-9743-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49513000
+_cell_length_b   5.15239000
+_cell_length_c   4.26473000
+_cell_angle_alpha   118.91846000
+_cell_angle_beta   90.00074000
+_cell_angle_gamma   89.99275000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.99043930
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.22155713  0.08280941  0.13879310  1
+  C  C1  1  0.22129896  0.50196277  0.13084888  1
+  C  C2  1  0.72127394  0.62786768  1.05179315  1
+  C  C3  1  0.72160892  0.13667810  0.62643079  1
+  C  C4  1  0.22172093  0.16281862  0.83717296  1
+  C  C5  1  0.22135593  0.42235313  0.43241102  1
+  C  C6  1  0.72140042  0.44912606  0.64345278  1
+  C  C7  1  0.72156068  0.95665403  1.21793341  1
+",-154.25477875
+9457,C-28254-7962-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.24787000
+_cell_length_b   4.23901000
+_cell_length_c   3.63024000
+_cell_angle_alpha   90.27341000
+_cell_angle_beta   75.61520000
+_cell_angle_gamma   49.86454000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.08369085
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.06261248  0.25942380  -0.07827430  1
+  C  C1  1  0.48741598  1.04649707  0.15900378  1
+  C  C2  1  0.27642916  0.67430989  0.54119309  1
+  C  C3  1  1.06228860  0.62032701  0.92265857  1
+  C  C4  1  0.48714139  0.40774041  0.15997711  1
+  C  C5  1  0.27339399  0.99262413  0.54035855  1
+",-154.1855335
+5412,C-72722-2079-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.08433000
+_cell_length_b   4.36623000
+_cell_length_c   4.11517000
+_cell_angle_alpha   59.30228000
+_cell_angle_beta   69.81746000
+_cell_angle_gamma   66.13658000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.89809445
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.23021328  0.23040504  0.83636528  1
+  C  C1  1  -0.10274141  0.89701189  0.50351496  1
+  C  C2  1  0.22905653  0.56432555  0.50170720  1
+  C  C3  1  0.56216128  0.89768728  -0.16539069  1
+  C  C4  1  0.89601938  0.23096061  0.16857180  1
+  C  C5  1  0.56402502  0.56370334  0.17027166  1
+",-154.43808566666667
+2702,C-142803-3273-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48777000
+_cell_length_b   4.69759000
+_cell_length_c   4.75948000
+_cell_angle_alpha   103.57673000
+_cell_angle_beta   58.48192000
+_cell_angle_gamma   89.98585000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.58091778
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.03096031  0.44481236  0.45126339  1
+  C  C1  1  0.30961060  0.86212800  0.11112963  1
+  C  C2  1  -0.03867270  0.09833315  0.45963433  1
+  C  C3  1  1.00416841  0.40078437  0.91767762  1
+  C  C4  1  1.03505229  0.86727361  0.88554571  1
+  C  C5  1  0.23601609  1.09339657  0.68531189  1
+  C  C6  1  0.30251235  0.51562730  0.11888724  1
+  C  C7  1  0.26822566  0.55980904  0.65222947  1
+",-154.363485
+7150,C-28220-4725-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47200000
+_cell_length_b   3.25664000
+_cell_length_c   8.31354000
+_cell_angle_alpha   86.94946000
+_cell_angle_beta   98.50264000
+_cell_angle_gamma   112.15613000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   61.30397593
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.39990143  0.78394720  -0.06376490  1
+  C  C1  1  0.52364865  0.42655453  0.54061070  1
+  C  C2  1  0.83932682  0.42535301  0.17300268  1
+  C  C3  1  -0.02505189  0.42733668  0.44400274  1
+  C  C4  1  1.14956191  0.42116664  0.79878611  1
+  C  C5  1  0.60265327  0.42203871  0.70229104  1
+  C  C6  1  0.72496831  0.06597836  0.30733750  1
+  C  C7  1  0.03868012  0.06218003  0.93625778  1
+  C  C8  1  1.08719881  0.78775204  0.30744739  1
+  C  C9  1  0.28722696  0.42424990  0.06988997  1
+",-154.278932
+413,C-80191-3962-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44223000
+_cell_length_b   6.50787000
+_cell_length_c   4.19466000
+_cell_angle_alpha   108.90194000
+_cell_angle_beta   90.01187000
+_cell_angle_gamma   79.16246000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   61.81628220
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70946129  0.83862303  0.88007488  1
+  C  C1  1  0.39335995  0.45041176  0.93345767  1
+  C  C2  1  0.92603447  0.39747199  0.40824685  1
+  C  C3  1  0.05058138  0.15349018  0.24348016  1
+  C  C4  1  0.89921622  0.44007019  0.08529340  1
+  C  C5  1  0.60499111  0.04788222  0.13035041  1
+  C  C6  1  0.26376740  0.73194986  0.76810871  1
+  C  C7  1  0.38072089  0.48740166  0.60656730  1
+",-154.22663375
+7585,C-50225-6005-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44593000
+_cell_length_b   7.89357000
+_cell_length_c   7.38342000
+_cell_angle_alpha   67.63484000
+_cell_angle_beta   86.65128000
+_cell_angle_gamma   73.14254000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C20
+_cell_volume   125.94722481
+_cell_formula_units_Z   20
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71157219  0.04682239  0.07350949  1
+  C  C1  1  0.61498913  0.49891885  0.95499267  1
+  C  C2  1  0.80761598  0.85146977  0.62030322  1
+  C  C3  1  0.71100410  0.41379788  0.50056506  1
+  C  C4  1  0.42731676  0.78790788  0.32787946  1
+  C  C5  1  0.86683228  0.87341324  0.25438742  1
+  C  C6  1  0.80203314  0.26938660  0.71723100  1
+  C  C7  1  0.68627298  0.97439792  0.90368092  1
+  C  C8  1  -0.13598026  0.31102932  0.14816561  1
+  C  C9  1  0.00288349  0.64701328  0.62494642  1
+  C  C10  1  0.12098523  0.49441952  0.83563436  1
+  C  C11  1  0.22207252  0.30470151  0.82155675  1
+  C  C12  1  0.25645115  0.38347245  0.40359378  1
+  C  C13  1  0.43253383  0.67362444  0.99169685  1
+  C  C14  1  1.11273886  1.04925668  0.76940933  1
+  C  C15  1  0.11694246  0.17047765  0.04417459  1
+  C  C16  1  0.54298314  0.61864875  0.51621900  1
+  C  C17  1  0.23811899  -0.06348350  0.63744975  1
+  C  C18  1  -0.14309318  0.76404596  -0.01816628  1
+  C  C19  1  0.33649110  0.31916751  0.25705840  1
+",-154.140547
+7940,C-142748-3187-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47425000
+_cell_length_b   4.80384000
+_cell_length_c   4.80498000
+_cell_angle_alpha   52.92513000
+_cell_angle_beta   104.90863000
+_cell_angle_gamma   104.91509000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.64323265
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.43309510  0.25676105  1.06047326  1
+  C  C1  1  -0.25465357  0.56962488  0.37334875  1
+  C  C2  1  1.24538025  0.06962183  0.87332115  1
+  C  C3  1  0.68324549  0.17341543  0.64380948  1
+  C  C4  1  -0.06670042  0.75676044  0.56048986  1
+  C  C5  1  1.18302434  0.67341029  0.14383237  1
+  C  C6  1  0.49558615  -0.01372456  0.45667855  1
+  C  C7  1  0.99531396  0.48627585  0.95670467  1
+",-154.52353
+4568,C-176667-771-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48714000
+_cell_length_b   2.48692000
+_cell_length_c   8.96094000
+_cell_angle_alpha   82.02355000
+_cell_angle_beta   82.02262000
+_cell_angle_gamma   90.01119000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   54.34815763
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.82720350  0.47129948  0.03223798  1
+  C  C1  1  0.42746050  0.07056806  0.83227550  1
+  C  C2  1  0.27797557  0.42213048  0.13205102  1
+  C  C3  1  0.07661071  0.22109034  0.53220770  1
+  C  C4  1  0.47638531  0.62119901  0.73221529  1
+  C  C5  1  0.22682817  -0.12806061  0.23221216  1
+  C  C6  1  0.67765880  0.82129872  0.33209671  1
+  C  C7  1  -0.12287561  1.02228663  -0.06788659  1
+  C  C8  1  1.02738497  0.67150132  0.63226916  1
+  C  C9  1  0.62686608  0.27231206  0.43222037  1
+",-154.544581
+2291,C-57129-5279-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43022000
+_cell_length_b   5.67950000
+_cell_length_c   4.20552000
+_cell_angle_alpha   95.26079000
+_cell_angle_beta   89.82549000
+_cell_angle_gamma   79.79399000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.87628314
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20575810  0.73651341  0.77685789  1
+  C  C1  1  -0.29417657  0.73468559  0.60961800  1
+  C  C2  1  0.20582343  0.73468559  0.10961800  1
+  C  C3  1  0.87710638  0.24047504  0.52828252  1
+  C  C4  1  0.87696544  0.23908595  0.86109884  1
+  C  C5  1  0.70575810  0.73651341  0.27685789  1
+  C  C6  1  0.37696544  0.23908595  0.36109884  1
+  C  C7  1  0.37710638  0.24047504  0.02828252  1
+",-154.44421875
+5579,C-47640-4572-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50862000
+_cell_length_b   4.21107000
+_cell_length_c   5.85329000
+_cell_angle_alpha   81.98237000
+_cell_angle_beta   53.71438000
+_cell_angle_gamma   73.14305000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.65988462
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.06948690  0.59341745  0.76963181  1
+  C  C1  1  0.63583806  1.02727277  0.51061627  1
+  C  C2  1  0.74519627  0.10187891  0.04601907  1
+  C  C3  1  -0.07004686  0.20905465  0.23030688  1
+  C  C4  1  0.88624496  0.74226008  0.01250256  1
+  C  C5  1  0.69258364  0.57224630  0.25894608  1
+  C  C6  1  0.26904145  0.78926458  0.51505805  1
+  C  C7  1  0.13980717  0.25185326  0.76586157  1
+",-154.1113825
+1096,C-170342-4227-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49107000
+_cell_length_b   3.59422000
+_cell_length_c   4.35083000
+_cell_angle_alpha   84.30046000
+_cell_angle_beta   106.63093000
+_cell_angle_gamma   110.30350000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.00628776
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.48847702  0.55806579  0.49673614  1
+  C  C1  1  0.67914384  0.55823849  0.87315832  1
+  C  C2  1  0.30766443  0.81697380  0.87310715  1
+  C  C3  1  0.59703686  0.18809538  0.07881739  1
+  C  C4  1  0.20287031  0.18799045  0.29130638  1
+  C  C5  1  0.11882023  0.81701998  0.49683703  1
+",-154.1947335
+2532,C-73621-2756-54,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48088000
+_cell_length_b   4.84329000
+_cell_length_c   6.24634000
+_cell_angle_alpha   100.17473000
+_cell_angle_beta   85.18728000
+_cell_angle_gamma   72.96905000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   69.89628483
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.77262551  0.16570916  1.01659775  1
+  C  C1  1  0.94580448  0.31879144  0.65446201  1
+  C  C2  1  0.49289646  0.29969272  0.50182943  1
+  C  C3  1  0.49008352  0.48292492  0.12424320  1
+  C  C4  1  0.82960233  0.60363512  0.80512578  1
+  C  C5  1  0.74923499  0.75132584  0.45765199  1
+  C  C6  1  0.64801681  0.86166031  0.70582831  1
+  C  C7  1  0.90176498  0.63456432  0.03866620  1
+  C  C8  1  0.37415261  0.55856460  0.38194137  1
+  C  C9  1  0.65781194  1.01044576  0.35738187  1
+  C  C10  1  1.00931285  0.06314123  0.77587478  1
+  C  C11  1  0.76435822  0.95257770  0.13558432  1
+",-154.14509083333334
+3755,C-72718-9015-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48456000
+_cell_length_b   4.99765000
+_cell_length_c   4.77624000
+_cell_angle_alpha   83.37515000
+_cell_angle_beta   74.83882000
+_cell_angle_gamma   89.77739000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.83857091
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.90000735  1.04573909  0.57180056  1
+  C  C1  1  0.72316559  0.98786119  0.92412432  1
+  C  C2  1  0.70291167  0.28539213  0.96609412  1
+  C  C3  1  0.42600526  0.21769728  0.51882408  1
+  C  C4  1  0.19730908  0.81629539  0.97726507  1
+  C  C5  1  0.33270959  0.66154078  0.70610918  1
+  C  C6  1  1.29082840  0.37248472  0.78950395  1
+  C  C7  1  0.06071946  0.61015318  0.24925759  1
+  C  C8  1  0.56293974  0.42343219  0.24622639  1
+  C  C9  1  -0.07957264  0.74805785  0.52969084  1
+",-154.375189
+5580,C-106835-1204-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.41061000
+_cell_length_b   3.60617000
+_cell_length_c   6.71002000
+_cell_angle_alpha   100.85113000
+_cell_angle_beta   89.89946000
+_cell_angle_gamma   109.97485000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   53.71763327
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.41406810  0.79610197  -0.04611489  1
+  C  C1  1  0.46190303  0.89149524  0.17461861  1
+  C  C2  1  1.03443584  0.02852706  0.50289427  1
+  C  C3  1  0.20782659  0.38301801  0.83037469  1
+  C  C4  1  0.24439277  0.44876858  0.61792529  1
+  C  C5  1  0.45321016  0.86548299  0.59902639  1
+  C  C6  1  -0.01588075  0.93572508  0.27917825  1
+  C  C7  1  0.56916796  1.10339796  0.82721329  1
+",-154.06611125
+8616,C-13897-9657-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47866000
+_cell_length_b   2.47793000
+_cell_length_c   6.77938000
+_cell_angle_alpha   68.54979000
+_cell_angle_beta   68.57092000
+_cell_angle_gamma   59.96729000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.68116765
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.10636583  0.61971811  0.98177040  1
+  C  C1  1  1.00431179  0.72901821  0.31664908  1
+  C  C2  1  0.17170202  0.89609183  0.06573417  1
+  C  C3  1  1.06017157  0.78863940  0.73079244  1
+  C  C4  1  0.44951623  0.17742024  0.64735119  1
+  C  C5  1  0.61523953  0.34072870  0.39997302  1
+",-154.52812366666666
+4401,C-177224-1603-53,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.40704000
+_cell_length_b   3.34978000
+_cell_length_c   4.58149000
+_cell_angle_alpha   68.46724000
+_cell_angle_beta   89.11945000
+_cell_angle_gamma   87.93481000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.60678943
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.38947840  0.52840248  0.33838294  1
+  C  C1  1  0.86614235  0.90513296  0.62288242  1
+  C  C2  1  0.53185566  0.64178033  0.81289438  1
+  C  C3  1  0.37669932  0.87017466  0.01859694  1
+  C  C4  1  0.67825284  0.23110031  0.33766732  1
+  C  C5  1  0.19907965  0.57025122  0.62304113  1
+  C  C6  1  0.03192552  0.12981965  0.83747800  1
+  C  C7  1  0.68683296  0.20704159  0.01851108  1
+",-154.1993
+8250,C-136221-5891-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.25413000
+_cell_length_b   4.60602000
+_cell_length_c   6.42882000
+_cell_angle_alpha   88.25919000
+_cell_angle_beta   80.94694000
+_cell_angle_gamma   112.48516000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   87.49045053
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.39824445  0.21040167  0.22854496  1
+  C  C1  1  0.86744824  0.81467617  0.77764332  1
+  C  C2  1  0.71653132  0.41830589  1.04348853  1
+  C  C3  1  1.13069228  0.12349083  0.75974617  1
+  C  C4  1  0.67134154  0.18241050  0.39950309  1
+  C  C5  1  0.04497987  0.38070579  0.86122503  1
+  C  C6  1  0.47497842  0.60887357  0.94896789  1
+  C  C7  1  0.70338111  0.86856174  0.39288469  1
+  C  C8  1  0.52608036  0.32672463  0.58986050  1
+  C  C9  1  0.14221341  0.40707539  0.31371259  1
+  C  C10  1  0.34744418  0.56776274  0.49386457  1
+  C  C11  1  0.04851218  0.89416293  0.23499469  1
+  C  C12  1  0.12525962  0.63117131  0.13909353  1
+  C  C13  1  -0.03471340  0.55201583  0.67240553  1
+",-154.0804
+987,C-47660-7998-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45990000
+_cell_length_b   4.06192000
+_cell_length_c   7.13799000
+_cell_angle_alpha   74.15731000
+_cell_angle_beta   98.78353000
+_cell_angle_gamma   86.03862000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.34652914
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.16629546  0.28439968  0.27614352  1
+  C  C1  1  0.33727803  0.85650719  0.74421061  1
+  C  C2  1  0.78852944  1.03271540  0.63182173  1
+  C  C3  1  0.69209228  0.41600914  0.63157033  1
+  C  C4  1  0.89278818  0.32644771  0.05691966  1
+  C  C5  1  0.36458922  0.24480310  -0.04289660  1
+  C  C6  1  0.86324245  -0.05917825  0.43006552  1
+  C  C7  1  0.25624907  0.47917885  0.74429167  1
+  C  C8  1  0.44181322  0.87612219  0.95703955  1
+  C  C9  1  0.28808526  0.51986226  0.27584196  1
+  C  C10  1  1.01194787  0.69439100  0.05671127  1
+  C  C11  1  0.41316774  0.71020623  0.42961637  1
+",-154.12846666666667
+3798,C-184033-8328-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.08317000
+_cell_length_b   3.44336000
+_cell_length_c   4.81023000
+_cell_angle_alpha   68.94891000
+_cell_angle_beta   92.54917000
+_cell_angle_gamma   67.77481000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.14655379
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.16297262  0.38346802  0.87421519  1
+  C  C1  1  0.72064265  0.82628903  0.37590437  1
+  C  C2  1  0.37122517  0.17044375  0.68238478  1
+  C  C3  1  1.10636806  0.44765645  0.37374367  1
+  C  C4  1  0.75781849  0.79181071  0.68064545  1
+  C  C5  1  0.31506091  0.23458693  0.18193495  1
+",-154.10028133333333
+7916,C-126155-7469-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46350000
+_cell_length_b   6.57571000
+_cell_length_c   6.57553000
+_cell_angle_alpha   54.90849000
+_cell_angle_beta   98.23179000
+_cell_angle_gamma   81.75377000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   82.84019252
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.73486203  0.22231220  0.37801543  1
+  C  C1  1  0.60327955  0.43800104  0.40655547  1
+  C  C2  1  0.40198631  0.70526989  0.13975510  1
+  C  C3  1  1.00350183  0.73448173  0.43698023  1
+  C  C4  1  0.50356368  0.80704939  0.50959217  1
+  C  C5  1  0.80543443  0.11253098  -0.04273578  1
+  C  C6  1  0.50226869  0.37429600  0.07412070  1
+  C  C7  1  0.63853229  0.78992782  0.75421584  1
+  C  C8  1  0.19768968  0.25586486  0.81394561  1
+  C  C9  1  0.00228967  0.30113856  0.00083252  1
+  C  C10  1  1.12573518  0.44900038  0.53580035  1
+  C  C11  1  0.36581732  0.05330525  0.48956828  1
+  C  C12  1  0.26972833  0.67806107  0.92322768  1
+  C  C13  1  -0.12091119  0.83431773  0.15087540  1
+",-154.0802907142857
+883,C-72708-4973-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48063000
+_cell_length_b   4.21990000
+_cell_length_c   3.68903000
+_cell_angle_alpha   104.94766000
+_cell_angle_beta   70.29895000
+_cell_angle_gamma   90.00806000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.96576999
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.61752219  0.93865601  0.02196049  1
+  C  C1  1  -0.06050138  0.64086564  0.37902495  1
+  C  C2  1  0.73777915  0.56520945  0.77682120  1
+  C  C3  1  0.19633582  0.06914900  0.86467049  1
+  C  C4  1  0.15970365  0.43423379  -0.06694734  1
+  C  C5  1  0.41928138  -0.13754079  0.41900312  1
+",-154.30823883333332
+9315,C-28264-8801-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.06231000
+_cell_length_b   2.43052000
+_cell_length_c   5.93156000
+_cell_angle_alpha   77.64800000
+_cell_angle_beta   84.73823000
+_cell_angle_gamma   89.06986000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.94468390
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.25735056  0.20655279  0.97097764  1
+  C  C1  1  1.14980661  0.65032995  0.08312537  1
+  C  C2  1  0.48385894  0.31687074  0.75002086  1
+  C  C3  1  0.81706553  -0.01644197  0.41663742  1
+  C  C4  1  -0.07580751  0.53986003  0.30434191  1
+  C  C5  1  0.59149467  0.87308456  0.63790540  1
+",-154.45264866666668
+6058,C-170380-2255-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45865000
+_cell_length_b   3.40043000
+_cell_length_c   5.97188000
+_cell_angle_alpha   62.37125000
+_cell_angle_beta   78.06376000
+_cell_angle_gamma   68.66874000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.16011349
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.67634348  0.99332240  0.14098215  1
+  C  C1  1  0.64050571  0.78169352  0.41670712  1
+  C  C2  1  1.21292824  0.31530432  0.73826017  1
+  C  C3  1  0.04109837  0.85239035  0.54412900  1
+  C  C4  1  0.18745013  0.09905376  0.01407098  1
+  C  C5  1  0.81124587  0.24560135  0.61069537  1
+",-154.14797783333333
+6750,C-142783-5832-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49669000
+_cell_length_b   2.50139000
+_cell_length_c   9.62349000
+_cell_angle_alpha   115.74443000
+_cell_angle_beta   98.69332000
+_cell_angle_gamma   98.82190000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   51.86895598
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.75540752  0.30169734  0.98481253  1
+  C  C1  1  0.03066328  0.76785593  0.73883467  1
+  C  C2  1  0.20036032  0.59938790  0.40522189  1
+  C  C3  1  0.45778402  0.58949011  0.65883005  1
+  C  C4  1  1.02140707  0.29030633  0.23850695  1
+  C  C5  1  0.28792310  0.24510625  0.48504607  1
+  C  C6  1  -0.07106333  0.64357228  0.15857024  1
+  C  C7  1  0.18333952  0.12508757  0.90492799  1
+",-154.06919
+3028,C-107717-3127-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.67669000
+_cell_length_b   2.48442000
+_cell_length_c   4.08694000
+_cell_angle_alpha   89.99680000
+_cell_angle_beta   83.32104000
+_cell_angle_gamma   105.39187000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.44800508
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.22849431  1.01621555  0.34288849  1
+  C  C1  1  0.19774691  0.49902779  0.86922129  1
+  C  C2  1  0.53984165  0.67028388  0.93604340  1
+  C  C3  1  0.76970072  0.28589509  0.40487409  1
+  C  C4  1  0.08397842  0.44427546  0.22467476  1
+  C  C5  1  0.54257112  0.17183306  0.16273081  1
+  C  C6  1  0.77151348  0.78646881  0.62997294  1
+  C  C7  1  1.11205660  0.95621646  0.69879412  1
+",-154.36585375
+6898,C-134191-3585-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.79152000
+_cell_length_b   3.37714000
+_cell_length_c   4.81174000
+_cell_angle_alpha   56.54254000
+_cell_angle_beta   61.61026000
+_cell_angle_gamma   72.96186000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.18050190
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.74686602  0.21785674  0.88340264  1
+  C  C1  1  0.71952696  0.25512161  0.36116111  1
+  C  C2  1  1.11531567  -0.06200799  0.35885974  1
+  C  C3  1  0.45173615  0.26727349  0.20154719  1
+  C  C4  1  0.26217646  0.76765212  1.07154969  1
+  C  C5  1  0.93655404  0.71745312  0.01332122  1
+  C  C6  1  0.47927078  0.23011701  0.72355789  1
+  C  C7  1  1.08341423  0.54715010  0.72599092  1
+",-154.226995
+6634,C-152573-9805-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43262000
+_cell_length_b   3.99950000
+_cell_length_c   9.49437000
+_cell_angle_alpha   76.65969000
+_cell_angle_beta   97.82721000
+_cell_angle_gamma   126.00333000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   72.71192711
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.49838469  0.15345731  0.92217183  1
+  C  C1  1  0.09750656  0.21891547  0.98904156  1
+  C  C2  1  0.29812420  1.01801479  0.78905324  1
+  C  C3  1  0.89682859  0.41740499  0.18933487  1
+  C  C4  1  0.69989237  0.95356127  0.72199150  1
+  C  C5  1  0.89743694  0.75294538  0.52226260  1
+  C  C6  1  0.29916705  0.35399240  0.12193475  1
+  C  C7  1  0.49567289  0.81718798  0.58942435  1
+  C  C8  1  0.69853490  0.61857723  0.38902531  1
+  C  C9  1  0.09978272  0.55328818  0.32219790  1
+",-154.46748399999998
+487,C-141074-4201-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46514000
+_cell_length_b   3.38878000
+_cell_length_c   5.26439000
+_cell_angle_alpha   88.31218000
+_cell_angle_beta   89.98730000
+_cell_angle_gamma   68.61340000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.92911256
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.09684664  0.40562490  0.95121382  1
+  C  C1  1  0.05708341  0.47894824  0.67667964  1
+  C  C2  1  0.91115349  0.77195883  0.15049338  1
+  C  C3  1  0.53761044  0.51894349  0.55050672  1
+  C  C4  1  0.50301961  0.58890301  0.27566090  1
+  C  C5  1  0.68893881  0.22199934  0.07681994  1
+",-154.1628675
+7449,C-176652-1615-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.06504000
+_cell_length_b   2.43024000
+_cell_length_c   5.89897000
+_cell_angle_alpha   79.92838000
+_cell_angle_beta   94.65954000
+_cell_angle_gamma   86.40231000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.98724833
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.21729507  0.29512805  0.86665610  1
+  C  C1  1  0.88379515  0.96183714  0.53329120  1
+  C  C2  1  0.55095820  0.62850919  0.19987068  1
+  C  C3  1  0.65820966  1.07232313  0.31230171  1
+  C  C4  1  0.99109517  0.40562084  0.64578725  1
+  C  C5  1  0.32486344  0.73896924  0.97905846  1
+",-154.45286883333333
+4944,C-189700-5976-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.19873000
+_cell_length_b   3.63227000
+_cell_length_c   3.36581000
+_cell_angle_alpha   84.46717000
+_cell_angle_beta   78.36334000
+_cell_angle_gamma   59.41550000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.28097326
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.10419434  0.17947611  0.37660547  1
+  C  C1  1  0.20395079  1.02479344  0.06931824  1
+  C  C2  1  0.70485393  0.58362699  0.56998739  1
+  C  C3  1  0.39460278  0.62068042  0.87604914  1
+  C  C4  1  0.70483402  -0.03572566  0.56993908  1
+  C  C5  1  0.39502781  0.23989629  0.87594608  1
+",-154.11622633333334
+1080,C-172943-9308-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48679000
+_cell_length_b   4.30493000
+_cell_length_c   5.55985000
+_cell_angle_alpha   104.94257000
+_cell_angle_beta   132.15173000
+_cell_angle_gamma   106.78396000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.59114362
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36887641  0.65214682  0.60647405  1
+  C  C1  1  1.03570032  0.23545481  0.52309399  1
+  C  C2  1  0.36903365  -0.09787852  0.85642732  1
+  C  C3  1  0.70236699  0.56878815  0.18976065  1
+  C  C4  1  -0.29779025  0.31881349  -0.06019262  1
+  C  C5  1  1.03554308  0.98548015  0.27314071  1
+",-154.54736383333332
+4337,C-28222-3619-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48783000
+_cell_length_b   3.60306000
+_cell_length_c   7.31238000
+_cell_angle_alpha   97.29410000
+_cell_angle_beta   80.20529000
+_cell_angle_gamma   110.21841000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   60.44637226
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.69717490  0.82310781  0.06517981  1
+  C  C1  1  0.30543161  0.62384898  0.64881661  1
+  C  C2  1  1.06214406  0.18456564  0.69487753  1
+  C  C3  1  0.89713178  0.39473199  0.23382905  1
+  C  C4  1  0.43730400  1.02502804  0.78628733  1
+  C  C5  1  0.93222498  0.78262151  0.55678153  1
+  C  C6  1  0.32806893  1.01179393  -0.00928378  1
+  C  C7  1  0.46592836  0.40737771  0.10853529  1
+  C  C8  1  -0.32990956  -0.02172291  0.27652883  1
+  C  C9  1  1.03957443  0.79153500  0.35125769  1
+",-154.20273500000002
+10014,C-145378-5350-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46433000
+_cell_length_b   6.50110000
+_cell_length_c   6.56914000
+_cell_angle_alpha   105.43293000
+_cell_angle_beta   67.86676000
+_cell_angle_gamma   67.81185000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   79.37954960
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71319478  0.27320487  0.05970611  1
+  C  C1  1  0.68344671  0.66911915  0.19503105  1
+  C  C2  1  1.22098103  0.02025813  0.80565285  1
+  C  C3  1  0.08354117  0.66258926  0.79918258  1
+  C  C4  1  0.25318717  0.88146710  0.41240468  1
+  C  C5  1  0.71482570  0.52861217  0.80144412  1
+  C  C6  1  0.85298821  0.88567254  0.80733906  1
+  C  C7  1  0.45035280  0.53493224  0.06191975  1
+  C  C8  1  0.22063957  0.27699842  0.54780560  1
+  C  C9  1  1.08216177  0.27098097  0.19295733  1
+  C  C10  1  0.85110066  0.27999087  0.41465124  1
+  C  C11  1  0.48589681  0.01536358  0.54561474  1
+",-154.17054333333334
+9692,C-172917-5417-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43704000
+_cell_length_b   4.22624000
+_cell_length_c   6.52397000
+_cell_angle_alpha   85.15854000
+_cell_angle_beta   100.75520000
+_cell_angle_gamma   89.98737000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   65.76908533
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.15091095  0.14202587  0.58243202  1
+  C  C1  1  0.65893979  0.98268225  0.59963874  1
+  C  C2  1  1.14651901  0.49540686  0.56658366  1
+  C  C3  1  0.69610809  0.63539289  0.66344363  1
+  C  C4  1  -0.13755268  0.23042539  0.97311506  1
+  C  C5  1  0.37230875  0.71865401  1.00448072  1
+  C  C6  1  0.36835041  0.07121302  0.98691260  1
+  C  C7  1  0.48295834  0.62824878  0.23404682  1
+  C  C8  1  1.03383223  0.59000909  0.33652600  1
+  C  C9  1  0.82408721  0.57735604  0.90895763  1
+",-154.27437
+3459,C-13929-1342-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44025000
+_cell_length_b   4.18938000
+_cell_length_c   7.27016000
+_cell_angle_alpha   89.34858000
+_cell_angle_beta   90.05429000
+_cell_angle_gamma   90.04348000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   74.31896604
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.16563845  0.42524160  0.64591199  1
+  C  C1  1  0.16397056  0.80256957  -0.02359831  1
+  C  C2  1  0.66567529  0.77492343  0.43590767  1
+  C  C3  1  0.66385028  0.64595398  0.96525077  1
+  C  C4  1  0.66457457  0.30062680  0.93415856  1
+  C  C5  1  0.16457806  0.14754805  0.00999654  1
+  C  C6  1  0.66561072  0.34827175  0.73099351  1
+  C  C7  1  1.16571466  0.64788625  0.49961284  1
+  C  C8  1  0.66528290  1.00788663  0.29546167  1
+  C  C9  1  0.16513181  0.09200094  0.21249916  1
+",-154.243572
+3037,C-73639-7493-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49936000
+_cell_length_b   4.26146000
+_cell_length_c   5.15211000
+_cell_angle_alpha   118.92661000
+_cell_angle_beta   90.08883000
+_cell_angle_gamma   90.00169000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.02847664
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.04996011  0.67765545  0.36455793  1
+  C  C1  1  -0.04903217  0.51201811  0.03544154  1
+  C  C2  1  0.45097752  0.89229492  0.82939066  1
+  C  C3  1  0.95097685  0.10318863  0.85629299  1
+  C  C4  1  0.45077622  0.59078794  0.90943267  1
+  C  C5  1  0.45026266  0.59860641  0.49047825  1
+  C  C6  1  0.45007547  0.29679239  0.57068332  1
+  C  C7  1  0.95011156  1.08614504  0.54383954  1
+",-154.24371125
+4868,C-136377-5342-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44334000
+_cell_length_b   6.48475000
+_cell_length_c   9.60135000
+_cell_angle_alpha   72.28362000
+_cell_angle_beta   88.14308000
+_cell_angle_gamma   61.55108000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   126.25804835
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.03524776  0.39598852  0.81170228  1
+  C  C1  1  0.28635372  0.63781744  0.17676477  1
+  C  C2  1  0.62805543  0.37942677  0.29273775  1
+  C  C3  1  0.22423410  0.65085289  0.60829359  1
+  C  C4  1  0.70144146  0.67413405  0.53459281  1
+  C  C5  1  0.28990163  0.16287823  0.80937466  1
+  C  C6  1  0.35487606  0.55381019  0.77652159  1
+  C  C7  1  0.92828787  0.04511919  0.77305875  1
+  C  C8  1  1.09441384  0.38582407  0.38366137  1
+  C  C9  1  0.65528235  0.04259828  0.24518376  1
+  C  C10  1  -0.14381009  0.13930839  0.60557476  1
+  C  C11  1  1.07124220  0.77143741  0.29065070  1
+  C  C12  1  0.71048740  0.66431554  0.38298538  1
+  C  C13  1  0.72496249  0.71222942  0.94765084  1
+  C  C14  1  0.28698265  0.20313860  0.53290745  1
+  C  C15  1  -0.01382369  0.16070861  0.24590050  1
+  C  C16  1  -0.24853067  0.67447708  0.09057256  1
+  C  C17  1  1.18639249  0.75257062  0.85848098  1
+",-154.12646055555555
+4119,C-177276-5156-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48274000
+_cell_length_b   3.54980000
+_cell_length_c   6.30795000
+_cell_angle_alpha   91.93518000
+_cell_angle_beta   90.03847000
+_cell_angle_gamma   69.63686000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   52.08579765
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.47606123  0.79292968  0.73994718  1
+  C  C1  1  0.66710624  0.41201343  0.59655258  1
+  C  C2  1  0.46663747  0.80996502  -0.01063957  1
+  C  C3  1  0.14609472  0.44725531  0.25910948  1
+  C  C4  1  0.84862418  0.05094486  0.73857109  1
+  C  C5  1  0.83828689  0.06876064  -0.01183581  1
+  C  C6  1  0.16529489  0.41441533  0.46758989  1
+  C  C7  1  0.64486318  0.44957103  0.13051087  1
+",-154.14514875
+453,C-28217-7112-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48196000
+_cell_length_b   3.69011000
+_cell_length_c   4.84299000
+_cell_angle_alpha   57.37366000
+_cell_angle_beta   75.12194000
+_cell_angle_gamma   70.32427000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.01667059
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.16979114  0.15904368  0.85821964  1
+  C  C1  1  0.20423236  0.45494196  0.49299562  1
+  C  C2  1  0.74801425  0.87137941  0.98919832  1
+  C  C3  1  0.62568344  0.74248709  0.36212478  1
+  C  C4  1  0.42845093  0.21535370  0.28648387  1
+  C  C5  1  0.94796978  0.39815896  0.06460167  1
+",-154.3119928333333
+7041,C-80195-4794-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43291000
+_cell_length_b   5.23709000
+_cell_length_c   5.20113000
+_cell_angle_alpha   66.08776000
+_cell_angle_beta   76.66993000
+_cell_angle_gamma   76.30757000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.17978901
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70375023  0.29498286  0.69896037  1
+  C  C1  1  0.12068591  0.37937932  0.78070063  1
+  C  C2  1  0.45347506  1.04340640  0.45091306  1
+  C  C3  1  0.37089764  0.62985877  1.02982073  1
+  C  C4  1  0.87049821  0.12695006  0.53367412  1
+  C  C5  1  0.20377000  0.79498069  0.19869370  1
+  C  C6  1  0.62062702  0.87667469  0.28358916  1
+  C  C7  1  0.95397183  0.54650363  0.94678432  1
+",-154.4625525
+7302,C-34627-4459-53,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47610000
+_cell_length_b   4.86181000
+_cell_length_c   5.39507000
+_cell_angle_alpha   55.42576000
+_cell_angle_beta   62.67608000
+_cell_angle_gamma   59.38060000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   44.67707339
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.62299810  0.12333828  0.29403967  1
+  C  C1  1  -0.00828289  0.75349271  0.29382637  1
+  C  C2  1  0.54479960  0.54558751  0.44893934  1
+  C  C3  1  0.24817805  0.50943462  0.78246162  1
+  C  C4  1  0.80089589  0.30176620  0.93740520  1
+  C  C5  1  1.17078715  0.93159399  0.93723636  1
+  C  C6  1  -0.12153557  0.87879226  0.78237998  1
+  C  C7  1  -0.08480692  0.17613583  0.44903146  1
+",-154.407275
+9387,C-170368-1522-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.39090000
+_cell_length_b   3.32645000
+_cell_length_c   6.56062000
+_cell_angle_alpha   119.11661000
+_cell_angle_beta   102.62985000
+_cell_angle_gamma   94.52600000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   61.57732709
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.85798511  0.83159512  0.85384359  1
+  C  C1  1  0.51883679  0.48948866  0.85363162  1
+  C  C2  1  0.14311215  1.24395131  0.08869851  1
+  C  C3  1  0.18859263  0.68340853  0.54445806  1
+  C  C4  1  0.75842556  0.93762515  0.29371546  1
+  C  C5  1  0.60459668  -0.00541763  0.68792341  1
+  C  C6  1  0.11484513  0.51402177  0.70698030  1
+  C  C7  1  0.46834830  0.54550213  1.08858443  1
+  C  C8  1  0.87752362  0.01953441  0.54449961  1
+  C  C9  1  0.05729404  0.26281705  0.29376521  1
+",-154.176972
+1823,C-136249-3748-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48404000
+_cell_length_b   4.77117000
+_cell_length_c   4.99756000
+_cell_angle_alpha   96.67390000
+_cell_angle_beta   89.99595000
+_cell_angle_gamma   74.93614000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.77875534
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.65910629  0.73969208  0.70349915  1
+  C  C1  1  0.46378569  0.13476404  0.46564258  1
+  C  C2  1  0.44438332  0.17720703  0.16822638  1
+  C  C3  1  0.63890891  0.78250253  0.40628838  1
+  C  C4  1  1.30134136  0.45716211  1.02872312  1
+  C  C5  1  0.07061164  -0.08337196  0.79107228  1
+  C  C6  1  0.16600051  0.72962029  0.23426260  1
+  C  C7  1  0.03249643  1.00031627  0.08050891  1
+  C  C8  1  -0.06217031  0.18737621  0.63791635  1
+  C  C9  1  0.79959767  0.46008231  0.84362075  1
+",-154.369639
+7223,C-189732-2937-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.37053000
+_cell_length_b   5.00375000
+_cell_length_c   5.05060000
+_cell_angle_alpha   80.73680000
+_cell_angle_beta   89.99087000
+_cell_angle_gamma   70.27394000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   79.00097083
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.57465698  0.29066098  0.03946387  1
+  C  C1  1  0.25974818  -0.13500085  0.17371709  1
+  C  C2  1  0.70955089  0.34958594  0.50453849  1
+  C  C3  1  0.61208075  0.80197211  -0.05093510  1
+  C  C4  1  -0.00093731  0.44082510  0.30644395  1
+  C  C5  1  0.02663395  0.70735776  0.37170877  1
+  C  C6  1  0.19358032  0.38315650  0.84153249  1
+  C  C7  1  0.54663269  0.93036116  0.39568334  1
+  C  C8  1  0.86911071  1.02332296  0.97540239  1
+  C  C9  1  0.30659254  0.59073143  0.62133928  1
+  C  C10  1  0.83720788  0.49028121  1.02009652  1
+  C  C11  1  0.03135477  0.14181241  0.72504065  1
+  C  C12  1  0.46202860  0.24071746  0.32626886  1
+  C  C13  1  0.38688845  0.86584773  0.67246851  1
+",-154.120535
+2959,C-106899-908-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.62845000
+_cell_length_b   3.94966000
+_cell_length_c   5.59485000
+_cell_angle_alpha   83.11921000
+_cell_angle_beta   117.94364000
+_cell_angle_gamma   104.85230000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.59659579
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.58493582  0.48615772  0.38076603  1
+  C  C1  1  0.43434647  0.69406336  1.13045169  1
+  C  C2  1  0.01025388  0.24379604  0.38064739  1
+  C  C3  1  1.16003883  1.03569886  0.63032921  1
+  C  C4  1  0.65980215  0.03590229  0.13021585  1
+  C  C5  1  0.93428585  0.69403292  0.63056435  1
+  C  C6  1  0.08374164  0.48615517  0.88009181  1
+  C  C7  1  0.50919016  0.24382025  0.88002806  1
+",-154.16792125
+1273,C-41273-2006-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.92145000
+_cell_length_b   3.62747000
+_cell_length_c   4.81345000
+_cell_angle_alpha   110.30459000
+_cell_angle_beta   72.29821000
+_cell_angle_gamma   87.35301000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.91380792
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.00663650  0.37177465  0.51170422  1
+  C  C1  1  0.81710548  0.77654459  0.70313002  1
+  C  C2  1  0.00661739  0.99024373  0.51177583  1
+  C  C3  1  0.31056654  0.33676478  0.20269250  1
+  C  C4  1  0.31061687  0.71804778  0.20251222  1
+  C  C5  1  0.50107630  -0.06812592  0.01140131  1
+",-154.12138016666668
+2175,C-40144-9743-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44804000
+_cell_length_b   3.49964000
+_cell_length_c   7.79775000
+_cell_angle_alpha   73.79396000
+_cell_angle_beta   81.03575000
+_cell_angle_gamma   69.49131000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   59.95961539
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.14414704  0.35725799  0.42966913  1
+  C  C1  1  0.10578615  0.65843968  0.63431925  1
+  C  C2  1  0.44297170  0.56249843  0.04408817  1
+  C  C3  1  0.68957685  0.40532117  0.72026857  1
+  C  C4  1  0.21999596  0.62422173  0.43303927  1
+  C  C5  1  -0.20280943  0.85335859  0.04405281  1
+  C  C6  1  1.06334363  1.06155118  0.30586665  1
+  C  C7  1  0.89478942  0.09561988  0.61512741  1
+  C  C8  1  0.64753652  0.28169582  0.91464301  1
+  C  C9  1  0.58914676  0.12546034  0.19002224  1
+",-154.08304900000002
+1995,C-72722-2079-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45842000
+_cell_length_b   3.39838000
+_cell_length_c   5.95681000
+_cell_angle_alpha   108.06262000
+_cell_angle_beta   78.10752000
+_cell_angle_gamma   68.75416000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.15280217
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.08738446  0.85285934  0.70586417  1
+  C  C1  1  1.04874134  0.17555056  0.10857667  1
+  C  C2  1  0.80435365  0.38908462  0.38433136  1
+  C  C3  1  0.27737442  0.31726453  0.51172021  1
+  C  C4  1  0.44150635  0.92319638  0.57792860  1
+  C  C5  1  0.66575330  1.06873307  -0.01825402  1
+",-154.14638483333331
+6362,C-92148-9593-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42135000
+_cell_length_b   6.65229000
+_cell_length_c   6.65339000
+_cell_angle_alpha   112.12960000
+_cell_angle_beta   82.61231000
+_cell_angle_gamma   91.47498000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   98.42073268
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.74330220  0.59085279  0.45065794  1
+  C  C1  1  0.39024248  0.39956997  0.10314625  1
+  C  C2  1  1.05239648  0.10306579  0.78160435  1
+  C  C3  1  0.11096265  0.86419122  0.74738510  1
+  C  C4  1  0.52903243  0.03182645  0.06689923  1
+  C  C5  1  0.63553130  0.16495933  0.48408791  1
+  C  C6  1  0.81695315  0.40045419  0.24386773  1
+  C  C7  1  0.50717017  0.17607472  0.92613508  1
+  C  C8  1  0.10536320  0.14922158  0.58106671  1
+  C  C9  1  0.03759674  0.88386116  -0.02031888  1
+  C  C10  1  0.20819035  0.67788266  0.54708961  1
+  C  C11  1  0.66068689  0.19500678  0.28056882  1
+  C  C12  1  0.44966093  0.58943861  1.03968654  1
+  C  C13  1  -0.03040766  0.68176656  1.01974092  1
+",-154.0781164285714
+9597,C-72701-1899-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49067000
+_cell_length_b   4.35392000
+_cell_length_c   3.59232000
+_cell_angle_alpha   84.28407000
+_cell_angle_beta   110.32802000
+_cell_angle_gamma   106.64406000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99906603
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.08519387  0.84649552  0.44648816  1
+  C  C1  1  0.52780758  0.47070170  0.70584810  1
+  C  C2  1  0.71464162  0.84665838  0.70546632  1
+  C  C3  1  0.00361853  0.05252055  0.07654514  1
+  C  C4  1  0.61056285  0.26481164  0.07680678  1
+  C  C5  1  -0.10287426  0.47043151  0.44669599  1
+",-154.1943575
+2375,C-157681-4063-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.32558000
+_cell_length_b   4.24173000
+_cell_length_c   4.70546000
+_cell_angle_alpha   108.92635000
+_cell_angle_beta   111.88355000
+_cell_angle_gamma   94.91499000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.62704276
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.17280021  0.89672473  1.10077468  1
+  C  C1  1  0.60950902  0.54216063  0.28187198  1
+  C  C2  1  0.52513953  -0.11495029  0.40545836  1
+  C  C3  1  0.17019613  0.27795541  0.18178587  1
+  C  C4  1  0.32740702  0.74089198  0.80750388  1
+  C  C5  1  -0.04061001  0.15890242  0.59585565  1
+  C  C6  1  0.73352454  0.63236425  1.00048720  1
+  C  C7  1  0.01807225  0.43453951  0.47579801  1
+  C  C8  1  0.82046102  0.29027582  0.87755299  1
+  C  C9  1  0.38729710  0.01648494  0.68772958  1
+",-154.161477
+1169,C-47652-4449-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43264000
+_cell_length_b   2.60255000
+_cell_length_c   9.64511000
+_cell_angle_alpha   108.02344000
+_cell_angle_beta   69.46699000
+_cell_angle_gamma   86.01091000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   53.27993382
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.73034362  0.23569013  0.42472764  1
+  C  C1  1  0.35338886  0.10589969  0.34321800  1
+  C  C2  1  0.60426732  0.83500200  0.17685659  1
+  C  C3  1  0.47701421  0.42943171  0.92930595  1
+  C  C4  1  0.47194570  0.47212552  0.59763261  1
+  C  C5  1  0.35911301  0.06731093  0.67487106  1
+  C  C6  1  0.22599557  0.69843589  0.09574921  1
+  C  C7  1  0.10000901  0.30143583  0.84780294  1
+",-154.1216725
+8204,C-76020-2605-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.43978000
+_cell_length_b   3.43727000
+_cell_length_c   4.17595000
+_cell_angle_alpha   100.24698000
+_cell_angle_beta   100.14546000
+_cell_angle_gamma   93.17242000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.63506666
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.19513737  0.73837725  0.64554325  1
+  C  C1  1  0.71549923  0.21665965  0.64575421  1
+  C  C2  1  0.41215106  0.91160816  0.41381859  1
+  C  C3  1  0.42313205  0.44598281  0.83494250  1
+  C  C4  1  0.52087802  0.54006086  0.21308770  1
+  C  C5  1  0.08624344  0.10866546  0.84670927  1
+  C  C6  1  0.18421895  0.20313886  0.22465840  1
+  C  C7  1  -0.10859082  0.43176965  0.41368168  1
+",-154.18459875
+399,C-96686-8751-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45083000
+_cell_length_b   4.52959000
+_cell_length_c   4.01985000
+_cell_angle_alpha   90.81713000
+_cell_angle_beta   89.99663000
+_cell_angle_gamma   105.65617000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.96500754
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53390859  1.07230336  0.22113433  1
+  C  C1  1  0.78839042  0.58360477  0.83668580  1
+  C  C2  1  0.84438398  0.69467913  0.53274992  1
+  C  C3  1  0.37371707  0.75385877  0.34582130  1
+  C  C4  1  0.10298649  0.21060015  0.15908418  1
+  C  C5  1  0.26027355  0.52671992  0.02530176  1
+",-154.25025916666667
+6945,C-136210-9760-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48669000
+_cell_length_b   6.20997000
+_cell_length_c   6.58981000
+_cell_angle_alpha   53.00022000
+_cell_angle_beta   79.12048000
+_cell_angle_gamma   78.43764000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   79.31913257
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.10364760  0.09925277  0.64325620  1
+  C  C1  1  0.47538139  -0.01406854  0.59733338  1
+  C  C2  1  0.83406037  0.40451663  0.46791571  1
+  C  C3  1  0.79956928  0.81257479  0.12414169  1
+  C  C4  1  -0.09340796  0.54319632  0.17869603  1
+  C  C5  1  1.12808807  0.07361432  0.20683629  1
+  C  C6  1  -0.21397900  1.08505359  0.88383527  1
+  C  C7  1  1.13790899  0.51668033  0.74285284  1
+  C  C8  1  0.55347760  0.14458831  0.28391089  1
+  C  C9  1  0.23478276  0.80367105  0.26242617  1
+  C  C10  1  0.20558101  0.21160764  0.91795303  1
+  C  C11  1  0.47997474  0.47217289  0.10202754  1
+  C  C12  1  0.55765276  0.62977022  0.78903887  1
+  C  C13  1  0.25433540  0.53017439  0.50256957  1
+",-154.27672
+3129,C-193936-350-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45344000
+_cell_length_b   4.05270000
+_cell_length_c   5.95910000
+_cell_angle_alpha   130.03915000
+_cell_angle_beta   101.85085000
+_cell_angle_gamma   89.99196000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.70241164
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55097474  0.90817002  0.98647568  1
+  C  C1  1  0.59754670  0.68481284  0.07714387  1
+  C  C2  1  0.02262347  0.03995184  -0.07187925  1
+  C  C3  1  0.29007011  0.75340703  0.46089291  1
+  C  C4  1  0.12654394  0.55351128  0.13579695  1
+  C  C5  1  0.86148703  -0.15930331  0.60339644  1
+",-154.23404333333335
+9783,C-41278-5784-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.95512000
+_cell_length_b   4.83792000
+_cell_length_c   5.94584000
+_cell_angle_alpha   62.87778000
+_cell_angle_beta   76.18121000
+_cell_angle_gamma   83.63578000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   73.46792812
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.91465633  0.71972025  0.13911590  1
+  C  C1  1  0.52392088  0.67249593  0.52930181  1
+  C  C2  1  0.88611317  0.19898301  0.17645195  1
+  C  C3  1  0.77025751  0.40203950  0.28834442  1
+  C  C4  1  0.52922081  0.37417401  0.52998200  1
+  C  C5  1  0.14677708  0.32520854  0.92224686  1
+  C  C6  1  0.17558811  0.84584620  0.88501693  1
+  C  C7  1  0.77084549  -0.11534298  0.28676177  1
+  C  C8  1  0.28885021  0.16072180  0.77405000  1
+  C  C9  1  0.29016691  0.64305093  0.77269776  1
+",-154.25618
+2912,C-136229-8372-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48756000
+_cell_length_b   4.30508000
+_cell_length_c   4.30466000
+_cell_angle_alpha   119.97890000
+_cell_angle_beta   106.78536000
+_cell_angle_gamma   106.79781000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.59700210
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.07446213  0.22633690  0.15401527  1
+  C  C1  1  0.17569573  0.97647943  0.90416047  1
+  C  C2  1  0.92553787  0.55967023  0.82068193  1
+  C  C3  1  0.17569573  0.64314610  0.23749380  1
+  C  C4  1  0.17569573  0.30981277  0.57082713  1
+  C  C5  1  0.92553787  0.89300357  0.48734860  1
+",-154.54453166666667
+1858,C-13653-5752-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48484000
+_cell_length_b   3.82419000
+_cell_length_c   5.22758000
+_cell_angle_alpha   98.87942000
+_cell_angle_beta   90.03470000
+_cell_angle_gamma   71.07719000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.36226157
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.77963203  0.61807824  -0.07766359  1
+  C  C1  1  -0.18329053  0.54366207  0.20185349  1
+  C  C2  1  1.05569740  0.06673975  0.42382805  1
+  C  C3  1  0.56431899  1.04596304  -0.02061186  1
+  C  C4  1  0.38981523  0.39590437  0.81657193  1
+  C  C5  1  0.27104115  0.63797040  0.36656503  1
+  C  C6  1  1.01882812  0.13992394  0.14407266  1
+  C  C7  1  0.44609500  0.28837599  0.53005040  1
+",-154.2248775
+1784,C-148228-7950-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43163000
+_cell_length_b   3.84239000
+_cell_length_c   6.50849000
+_cell_angle_alpha   72.02072000
+_cell_angle_beta   87.22773000
+_cell_angle_gamma   87.63731000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.75126737
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.14697749  0.97783305  0.81127352  1
+  C  C1  1  0.14699806  0.64590259  0.47877793  1
+  C  C2  1  0.64699079  0.14592307  0.72880486  1
+  C  C3  1  0.64698792  0.47767521  0.06109264  1
+  C  C4  1  0.64696888  0.47788813  0.56134572  1
+  C  C5  1  0.14700362  0.64574041  0.97863393  1
+  C  C6  1  0.64701322  0.14573504  0.22860230  1
+  C  C7  1  1.14698662  0.97773188  0.31116079  1
+",-154.468535
+2293,C-176637-1600-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47510000
+_cell_length_b   3.72206000
+_cell_length_c   4.24837000
+_cell_angle_alpha   115.97093000
+_cell_angle_beta   90.01215000
+_cell_angle_gamma   89.99260000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.18568669
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.82821559  0.45603228  0.51087550  1
+  C  C1  1  -0.17162222  0.86400738  0.51060380  1
+  C  C2  1  0.32846924  0.47536183  0.73343259  1
+  C  C3  1  0.82870144  0.02117410  0.23279796  1
+  C  C4  1  0.32869686  0.91043763  1.01147532  1
+  C  C5  1  0.32852509  0.06726788  0.73350154  1
+",-154.2860335
+4650,C-184031-5230-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49336000
+_cell_length_b   4.66798000
+_cell_length_c   7.58299000
+_cell_angle_alpha   89.63755000
+_cell_angle_beta   76.90048000
+_cell_angle_gamma   73.00773000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   82.03848467
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70600111  0.89576737  0.46395353  1
+  C  C1  1  -0.13811361  0.63329782  0.33874592  1
+  C  C2  1  -0.10833999  0.36397337  0.45097794  1
+  C  C3  1  0.31733434  0.29618253  0.92363037  1
+  C  C4  1  0.54446938  0.18340507  0.38957834  1
+  C  C5  1  0.70644268  0.88442348  0.66656281  1
+  C  C6  1  0.66236500  0.22611479  0.18862822  1
+  C  C7  1  0.53250042  0.19243352  0.74578565  1
+  C  C8  1  0.50294696  0.75896680  0.04332636  1
+  C  C9  1  0.46986856  0.58473097  0.21653156  1
+  C  C10  1  0.59030266  0.42092636  0.63973740  1
+  C  C11  1  0.13758480  0.64362912  0.93737132  1
+  C  C12  1  0.29112251  0.11361457  0.08506347  1
+  C  C13  1  1.27153209  0.71549563  0.73300120  1
+",-154.12540428571427
+179,C-92116-7433-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.02898000
+_cell_length_b   4.84014000
+_cell_length_c   6.86282000
+_cell_angle_alpha   97.03684000
+_cell_angle_beta   111.85332000
+_cell_angle_gamma   117.70903000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   102.60721069
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.11257324  0.30808890  0.40569368  1
+  C  C1  1  0.47560271  0.57351596  0.08979564  1
+  C  C2  1  1.39528330  0.66137463  0.26466524  1
+  C  C3  1  0.05307943  0.63226136  0.54576915  1
+  C  C4  1  1.07381194  0.34176647  0.26418390  1
+  C  C5  1  -0.02625721  0.72032191  0.72110999  1
+  C  C6  1  0.72263941  0.55379342  0.81180458  1
+  C  C7  1  0.56095505  0.98539401  0.40469096  1
+  C  C8  1  0.98675195  0.08451664  0.09035141  1
+  C  C9  1  0.37468268  -0.04801007  0.54627426  1
+  C  C10  1  0.21970251  0.06154677  0.81800184  1
+  C  C11  1  0.46237820  0.20939528  0.72042483  1
+  C  C12  1  0.22884571  0.23233566  0.99258712  1
+  C  C13  1  0.72725695  0.74003176  -0.00061908  1
+",-154.2201985714286
+9036,C-41294-4189-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43049000
+_cell_length_b   5.76438000
+_cell_length_c   6.27261000
+_cell_angle_alpha   56.93826000
+_cell_angle_beta   89.13371000
+_cell_angle_gamma   78.71875000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   71.77849187
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.13550367  0.58892228  0.29970659  1
+  C  C1  1  0.53672794  0.78730145  0.50072911  1
+  C  C2  1  0.73900249  0.38736529  0.10111544  1
+  C  C3  1  0.27417204  0.31906819  0.03552729  1
+  C  C4  1  1.06952615  0.72027676  0.43430101  1
+  C  C5  1  0.93981759  -0.01305598  0.70121640  1
+  C  C6  1  0.67057027  0.52003213  0.23480228  1
+  C  C7  1  0.34087057  0.18809950  0.90041312  1
+  C  C8  1  0.47274873  0.91852488  0.63569716  1
+  C  C9  1  0.87464668  1.11984190  -0.16513620  1
+",-154.467344
+9904,C-193911-8410-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48259000
+_cell_length_b   3.88482000
+_cell_length_c   6.18226000
+_cell_angle_alpha   89.86080000
+_cell_angle_beta   78.40042000
+_cell_angle_gamma   89.93202000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.40637242
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.86915856  0.52654972  0.43316213  1
+  C  C1  1  0.21428081  0.33248765  0.73776690  1
+  C  C2  1  0.52767605  0.82620554  0.11618520  1
+  C  C3  1  0.09047271  0.33261042  0.99048794  1
+  C  C4  1  0.43938259  0.52628562  0.29402589  1
+  C  C5  1  0.77831183  0.22683972  0.61195052  1
+  C  C6  1  0.21436325  0.72045727  0.73734437  1
+  C  C7  1  0.52801212  0.22646655  0.11657617  1
+  C  C8  1  0.77819288  0.82654378  0.61142304  1
+  C  C9  1  0.09040380  0.72066714  -0.00985927  1
+",-154.172695
+3727,C-145313-1627-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48292000
+_cell_length_b   3.79473000
+_cell_length_c   5.92952000
+_cell_angle_alpha   82.72821000
+_cell_angle_beta   102.06648000
+_cell_angle_gamma   90.02620000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   54.17473915
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.57915293  0.43543309  0.69247673  1
+  C  C1  1  0.24745345  1.07672708  0.02903026  1
+  C  C2  1  0.92519371  0.16542287  0.38136132  1
+  C  C3  1  0.16189529  0.81340198  0.85406875  1
+  C  C4  1  0.58606290  0.84492223  0.70107372  1
+  C  C5  1  0.49307621  0.17208635  0.51780961  1
+  C  C6  1  0.15550597  0.40328604  0.84626586  1
+  C  C7  1  0.81544294  0.08318595  0.16597295  1
+",-154.08224625
+8148,C-130528-4330-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.86649000
+_cell_length_b   4.08695000
+_cell_length_c   4.81793000
+_cell_angle_alpha   97.38960000
+_cell_angle_beta   107.21164000
+_cell_angle_gamma   119.94585000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.03722922
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.13486289  0.69550696  0.36867551  1
+  C  C1  1  0.58850271  0.42328951  0.06041946  1
+  C  C2  1  0.24536922  0.07694703  0.36883584  1
+  C  C3  1  0.64908215  0.48118482  0.55972309  1
+  C  C4  1  0.80455767  0.63761165  0.86937188  1
+  C  C5  1  0.20827060  0.04184944  0.06025912  1
+",-154.13833766666667
+64,C-192704-9198-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46519000
+_cell_length_b   6.81068000
+_cell_length_c   6.38392000
+_cell_angle_alpha   77.13322000
+_cell_angle_beta   89.52798000
+_cell_angle_gamma   76.63831000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   101.55810547
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.04252733  0.03898873  -0.03048845  1
+  C  C1  1  0.31205246  0.54541959  0.88949349  1
+  C  C2  1  0.07205148  0.97480939  0.75977235  1
+  C  C3  1  0.74269482  0.72339431  0.13645153  1
+  C  C4  1  0.93265320  0.53246485  0.31353687  1
+  C  C5  1  0.95235542  0.18258871  0.61226439  1
+  C  C6  1  0.64398964  0.82802386  0.49999389  1
+  C  C7  1  0.40892075  0.27358552  0.69302350  1
+  C  C8  1  0.35590875  0.34570920  0.04375159  1
+  C  C9  1  0.45570127  1.17559455  -0.06114125  1
+  C  C10  1  0.15273575  0.85874766  0.15788922  1
+  C  C11  1  0.89923479  0.17719073  0.37663706  1
+  C  C12  1  0.07735483  0.92917765  0.37582995  1
+  C  C13  1  0.27605672  0.31446414  0.27391337  1
+  C  C14  1  0.74220393  0.67031170  0.91421615  1
+  C  C15  1  0.34016066  0.50417183  0.65954210  1
+  C  C16  1  0.80365225  0.59141232  0.52600016  1
+  C  C17  1  -0.36177716  0.85899893  0.73189167  1
+",-154.20136166666668
+6682,C-34653-3008-56,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.28922000
+_cell_length_b   4.86416000
+_cell_length_c   7.53703000
+_cell_angle_alpha   87.74708000
+_cell_angle_beta   104.74762000
+_cell_angle_gamma   71.43974000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   109.59284605
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.23667183  0.70878954  0.52290625  1
+  C  C1  1  0.05728103  1.00149949  0.44313625  1
+  C  C2  1  0.36421013  -0.06962316  0.99092919  1
+  C  C3  1  0.19995489  0.72138356  0.90945206  1
+  C  C4  1  0.79292499  0.06991547  0.26239713  1
+  C  C5  1  -0.18533957  0.81149871  0.75385155  1
+  C  C6  1  0.78569630  0.57092709  0.26248472  1
+  C  C7  1  1.14654386  0.22689361  0.55565585  1
+  C  C8  1  0.57238969  0.12570160  0.71823112  1
+  C  C9  1  0.07472091  0.49911681  0.44043609  1
+  C  C10  1  -0.13499205  0.30436170  0.71344499  1
+  C  C11  1  0.65626622  -0.14446891  0.16828055  1
+  C  C12  1  0.29141571  0.20273514  0.87630363  1
+  C  C13  1  0.64901516  0.35663154  0.16830608  1
+  C  C14  1  0.62189013  0.61785885  0.67923106  1
+  C  C15  1  0.38119697  0.42828114  0.98832509  1
+",-154.248846875
+2142,C-172959-2703-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48166000
+_cell_length_b   4.21659000
+_cell_length_c   3.68856000
+_cell_angle_alpha   104.86465000
+_cell_angle_beta   109.64906000
+_cell_angle_gamma   89.99175000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.97600944
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70887053  0.50054146  0.76988704  1
+  C  C1  1  0.45333551  0.92918662  0.25536068  1
+  C  C2  1  0.25415274  0.00511942  0.85809364  1
+  C  C3  1  0.13068135  0.63153080  0.61355963  1
+  C  C4  1  0.67569419  0.13562364  0.70073156  1
+  C  C5  1  -0.06646002  0.70672725  0.21561656  1
+",-154.3097195
+8084,C-145329-3191-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43735000
+_cell_length_b   4.68849000
+_cell_length_c   5.73836000
+_cell_angle_alpha   52.25752000
+_cell_angle_beta   64.87669000
+_cell_angle_gamma   74.92634000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.94911936
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.80110137  0.67748764  0.67519304  1
+  C  C1  1  0.26064901  0.47503629  0.32146704  1
+  C  C2  1  0.14087167  0.78155482  0.78438756  1
+  C  C3  1  1.07054942  0.78914430  0.35138388  1
+  C  C4  1  0.14124236  0.16855061  0.09066075  1
+  C  C5  1  0.80117072  0.27271094  0.87741954  1
+  C  C6  1  0.93704570  0.47513366  0.14421099  1
+  C  C7  1  0.07036054  0.16100964  0.66524630  1
+",-154.166265
+4014,C-184078-4879-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48138000
+_cell_length_b   3.68849000
+_cell_length_c   4.83820000
+_cell_angle_alpha   111.42825000
+_cell_angle_beta   104.86335000
+_cell_angle_gamma   109.66992000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98942249
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.85212301  0.78070208  0.68872550  1
+  C  C1  1  0.86801643  1.02009766  0.48220782  1
+  C  C2  1  0.16617689  0.83851562  0.26065292  1
+  C  C3  1  0.18287379  0.07777653  0.05370196  1
+  C  C4  1  0.14227382  0.49306816  0.55766595  1
+  C  C5  1  -0.10867834  0.36484284  0.18401935  1
+",-154.31019849999998
+6815,C-130520-8193-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44014000
+_cell_length_b   5.56997000
+_cell_length_c   5.57456000
+_cell_angle_alpha   97.48027000
+_cell_angle_beta   70.05572000
+_cell_angle_gamma   70.06557000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   64.29795566
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.21627154  0.86596547  0.55456254  1
+  C  C1  1  0.62555796  0.24742772  0.03351941  1
+  C  C2  1  0.83277939  -0.01215963  0.10880167  1
+  C  C3  1  1.16138859  0.49261471  0.27848804  1
+  C  C4  1  0.56419791  0.97287000  0.66051998  1
+  C  C5  1  0.37542593  0.38191138  0.65472535  1
+  C  C6  1  0.51693359  0.66433583  0.29187894  1
+  C  C7  1  0.41086457  0.87030361  1.14358872  1
+  C  C8  1  0.26929156  0.23492053  0.86207106  1
+  C  C9  1  -0.04607494  0.41619290  0.53692209  1
+",-154.135048
+9103,C-73663-9884-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.40236000
+_cell_length_b   3.35077000
+_cell_length_c   4.58518000
+_cell_angle_alpha   68.53143000
+_cell_angle_beta   89.17041000
+_cell_angle_gamma   87.84467000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.61222055
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.74303341  0.21506767  0.37284793  1
+  C  C1  1  0.88481833  0.32803486  0.84810581  1
+  C  C2  1  0.24306373  0.72776587  0.34929813  1
+  C  C3  1  0.40927253  -0.04638857  0.56284612  1
+  C  C4  1  0.59676127  0.62740405  0.84850272  1
+  C  C5  1  0.58776437  0.64913794  0.16801397  1
+  C  C6  1  -0.10261767  -0.01399217  0.16769385  1
+  C  C7  1  1.07594131  0.28843114  0.56276017  1
+",-154.197985
+7526,C-145319-6278-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.35432000
+_cell_length_b   5.00131000
+_cell_length_c   6.52173000
+_cell_angle_alpha   67.33702000
+_cell_angle_beta   87.14444000
+_cell_angle_gamma   65.53078000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   91.10456695
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40507157  0.97446698  0.34008856  1
+  C  C1  1  0.66098069  0.85699959  0.58100994  1
+  C  C2  1  0.13344320  0.62980658  0.61067485  1
+  C  C3  1  1.05970935  0.29268305  0.32438056  1
+  C  C4  1  0.84667985  0.76036760  0.06871963  1
+  C  C5  1  0.83595080  0.33833913  0.51813246  1
+  C  C6  1  0.38429856  0.67382800  0.76723125  1
+  C  C7  1  0.25544898  0.55555851  0.24049970  1
+  C  C8  1  0.18343178  0.30546907  0.68367404  1
+  C  C9  1  0.66690854  0.34893434  0.97065474  1
+  C  C10  1  1.10411559  0.15111872  0.91442202  1
+  C  C11  1  0.68873736  0.48258743  0.13568934  1
+  C  C12  1  0.37148779  0.65557443  0.41128990  1
+  C  C13  1  0.01390926  0.89931138  0.85881773  1
+  C  C14  1  0.65637686  0.10332850  0.65504396  1
+  C  C15  1  0.50312382  0.06162240  0.08554496  1
+",-154.159161875
+1255,C-102903-5111-54,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.55683000
+_cell_length_b   4.59907000
+_cell_length_c   4.57642000
+_cell_angle_alpha   76.05176000
+_cell_angle_beta   89.99130000
+_cell_angle_gamma   73.98174000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   50.07254058
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71091118  0.37198278  0.36037659  1
+  C  C1  1  0.53786326  0.72037613  0.33368259  1
+  C  C2  1  0.70231351  0.39228322  0.84270160  1
+  C  C3  1  0.53646857  0.72479073  0.69551546  1
+  C  C4  1  0.79605492  0.20602900  0.65168918  1
+  C  C5  1  0.95982939  0.87771453  0.15929564  1
+  C  C6  1  0.78491156  0.22572964  0.13390775  1
+  C  C7  1  -0.03735598  -0.12652994  0.79803719  1
+",-154.15351125
+7597,C-126177-4900-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48535000
+_cell_length_b   3.85269000
+_cell_length_c   6.76473000
+_cell_angle_alpha   106.51534000
+_cell_angle_beta   100.59732000
+_cell_angle_gamma   90.04685000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   60.94567907
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.01566819  0.46158339  0.57922965  1
+  C  C1  1  0.79006564  0.98716488  0.17947367  1
+  C  C2  1  0.66225672  0.86945169  0.93113407  1
+  C  C3  1  -0.13363539  0.34375231  0.33058524  1
+  C  C4  1  0.36682510  0.56362616  0.33091841  1
+  C  C5  1  0.07274882  0.27926018  0.75542477  1
+  C  C6  1  0.29000981  0.76878230  0.17981028  1
+  C  C7  1  0.48456420  0.69350417  0.57913671  1
+  C  C8  1  0.57275611  0.05144389  0.75542515  1
+  C  C9  1  1.16197476  0.63664812  0.93114364  1
+",-154.112312
+1456,C-193960-2739-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.02735000
+_cell_length_b   4.04844000
+_cell_length_c   4.20699000
+_cell_angle_alpha   69.49161000
+_cell_angle_beta   103.14387000
+_cell_angle_gamma   71.25027000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.23644265
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.30826391  0.73827336  0.84978692  1
+  C  C1  1  0.63827034  0.40325079  0.18255532  1
+  C  C2  1  0.64108783  0.40504155  0.51629401  1
+  C  C3  1  0.30545756  0.73655957  0.51598425  1
+  C  C4  1  0.97185716  1.07003021  0.84912257  1
+  C  C5  1  0.97503249  0.07187693  0.18296303  1
+",-154.43723966666667
+5837,C-106098-9884-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.46375000
+_cell_length_b   5.46389000
+_cell_length_c   7.70381000
+_cell_angle_alpha   103.36215000
+_cell_angle_beta   74.53066000
+_cell_angle_gamma   74.23196000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C20
+_cell_volume   127.78032911
+_cell_formula_units_Z   20
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.16775429  0.25777355  0.53329634  1
+  C  C1  1  0.67045092  0.53869129  0.53730391  1
+  C  C2  1  0.94449858  0.89020631  0.67788004  1
+  C  C3  1  1.12322180  0.59795635  0.87131017  1
+  C  C4  1  -0.03055108  0.69556178  0.49080180  1
+  C  C5  1  0.15399116  0.16936066  0.93726446  1
+  C  C6  1  0.60216081  0.69353173  0.26891748  1
+  C  C7  1  0.46619305  0.52368708  0.37921198  1
+  C  C8  1  0.79093005  0.83416333  0.37097560  1
+  C  C9  1  1.32746965  0.72053500  0.72789297  1
+  C  C10  1  0.51626996  0.90302345  0.83026580  1
+  C  C11  1  0.71807246  0.13046886  0.07046476  1
+  C  C12  1  0.69704233  -0.15253699  -0.01521448  1
+  C  C13  1  0.48314457  0.72951926  0.11476659  1
+  C  C14  1  0.05342753  0.32232246  0.81041141  1
+  C  C15  1  -0.37646478  0.23507371  0.27429662  1
+  C  C16  1  0.35646998  0.31043076  1.04196559  1
+  C  C17  1  0.76639497  1.09387837  0.38509660  1
+  C  C18  1  0.34423932  0.54529225  1.01117597  1
+  C  C19  1  0.96408741  0.16604990  0.66732660  1
+",-154.0681645
+1933,C-172967-546-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.62592000
+_cell_length_b   4.17466000
+_cell_length_c   4.18631000
+_cell_angle_alpha   120.20285000
+_cell_angle_beta   71.50637000
+_cell_angle_gamma   99.48027000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   37.61295645
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.27817776  0.10413395  0.04758998  1
+  C  C1  1  0.40292404  0.44062952  1.01223452  1
+  C  C2  1  1.08684754  0.43998331  0.76513354  1
+  C  C3  1  1.27979676  0.77764440  0.38408678  1
+  C  C4  1  0.21073771  0.10346615  0.39250749  1
+  C  C5  1  0.21210379  0.77698548  0.72918839  1
+",-154.133024
+3935,C-56495-4082-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.54568000
+_cell_length_b   4.82662000
+_cell_length_c   4.38769000
+_cell_angle_alpha   101.00110000
+_cell_angle_beta   69.59020000
+_cell_angle_gamma   108.65051000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.68259008
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55847714  1.04985465  0.36812325  1
+  C  C1  1  0.99296244  0.86511871  0.25038974  1
+  C  C2  1  0.44707649  0.11344865  0.73361470  1
+  C  C3  1  0.31656130  0.58335892  0.71428015  1
+  C  C4  1  0.68885205  0.57994610  0.38874311  1
+  C  C5  1  0.77308198  0.32415907  0.20938765  1
+  C  C6  1  1.01284364  0.29829190  0.85198463  1
+  C  C7  1  0.23233936  0.83933971  0.89306688  1
+",-154.12734625
+1116,C-157697-2818-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49089000
+_cell_length_b   3.59279000
+_cell_length_c   4.35933000
+_cell_angle_alpha   84.28203000
+_cell_angle_beta   106.60941000
+_cell_angle_gamma   110.34808000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.05201509
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.05571250  0.37935399  0.76769108  1
+  C  C1  1  0.58027473  1.01004705  0.18602496  1
+  C  C2  1  0.86886839  0.37956334  0.39224575  1
+  C  C3  1  0.68700637  0.63939975  0.76803196  1
+  C  C4  1  -0.02614088  0.00994004  -0.02615265  1
+  C  C5  1  0.49889789  0.63932444  0.39218861  1
+",-154.20047583333334
+2831,C-136219-6599-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43002000
+_cell_length_b   3.45848000
+_cell_length_c   5.36095000
+_cell_angle_alpha   90.63244000
+_cell_angle_beta   74.59008000
+_cell_angle_gamma   86.12468000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.31562286
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.39579436  0.29028641  0.75704871  1
+  C  C1  1  0.17283431  0.84716764  0.20161831  1
+  C  C2  1  1.06244721  0.62353240  0.42383195  1
+  C  C3  1  0.83957550  0.18053310  0.86814873  1
+  C  C4  1  0.72921329  0.95695177  0.09036272  1
+  C  C5  1  0.50623255  0.51372538  0.53493059  1
+",-154.4361365
+94,C-184054-4402-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51515000
+_cell_length_b   4.19407000
+_cell_length_c   8.19482000
+_cell_angle_alpha   75.20953000
+_cell_angle_beta   81.24868000
+_cell_angle_gamma   90.00318000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   82.53904566
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.60399951  0.13510852  0.17600150  1
+  C  C1  1  0.69398598  0.09715566  -0.00732820  1
+  C  C2  1  0.41280282  0.44003136  0.56506423  1
+  C  C3  1  0.41262114  0.80418341  0.56526014  1
+  C  C4  1  0.60497274  0.50311015  0.17558555  1
+  C  C5  1  0.06183804  0.96298756  0.26116047  1
+  C  C6  1  0.24011095  0.27209275  0.89874805  1
+  C  C7  1  0.69428056  0.72341847  0.99255463  1
+  C  C8  1  0.06242211  0.58948057  0.26078176  1
+  C  C9  1  1.32720010  0.20230870  0.72888385  1
+  C  C10  1  0.32719749  0.87942109  0.72881201  1
+  C  C11  1  -0.03330331  0.49050029  0.45592538  1
+  C  C12  1  0.24020070  0.64143932  0.89875856  1
+  C  C13  1  0.96646849  0.86173434  0.45628577  1
+",-154.1194807142857
+1330,C-152563-2721-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44742000
+_cell_length_b   4.75608000
+_cell_length_c   5.65387000
+_cell_angle_alpha   84.76031000
+_cell_angle_beta   62.51918000
+_cell_angle_gamma   82.28565000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.82517684
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.88633276  0.15519871  0.82767824  1
+  C  C1  1  0.16593444  0.61658412  0.90553435  1
+  C  C2  1  0.55224658  0.64831416  0.60553984  1
+  C  C3  1  0.63775489  0.43288574  0.98978230  1
+  C  C4  1  0.71370918  0.39448252  0.45042810  1
+  C  C5  1  0.56392688  0.15193484  0.65219425  1
+  C  C6  1  0.46831107  -0.00949138  0.28828454  1
+  C  C7  1  0.39643119  0.32644805  0.28080606  1
+  C  C8  1  0.78037191  0.91332715  0.46585293  1
+  C  C9  1  -0.16099221  0.90545539  1.01400778  1
+",-154.108241
+5158,C-148221-4721-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47402000
+_cell_length_b   3.53044000
+_cell_length_c   10.23690000
+_cell_angle_alpha   81.81959000
+_cell_angle_beta   96.94239000
+_cell_angle_gamma   110.54238000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   82.63242343
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76518435  0.52219940  0.25259456  1
+  C  C1  1  0.87563404  0.41466709  0.58724070  1
+  C  C2  1  0.38748153  0.35988504  0.66687892  1
+  C  C3  1  -0.02152059  0.86167029  0.34291018  1
+  C  C4  1  0.84833173  0.08168807  0.85963990  1
+  C  C5  1  0.36696385  0.18726603  0.79304145  1
+  C  C6  1  0.80007585  0.86546418  0.98144945  1
+  C  C7  1  0.66047989  1.07463183  0.49697193  1
+  C  C8  1  1.25417514  0.57878447  0.17302756  1
+  C  C9  1  0.03207861  0.81409844  0.49925424  1
+  C  C10  1  0.28078813  0.75855082  1.04772983  1
+  C  C11  1  0.60825716  1.12247335  0.34055308  1
+",-154.1757591666667
+4273,C-72705-6142-51,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43176000
+_cell_length_b   3.99464000
+_cell_length_c   4.60697000
+_cell_angle_alpha   96.33085000
+_cell_angle_beta   74.95678000
+_cell_angle_gamma   90.50249000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.94574681
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.32522867  0.16129208  0.34053581  1
+  C  C1  1  -0.00693948  0.49199033  0.00543286  1
+  C  C2  1  0.77200988  1.04720386  0.44959260  1
+  C  C3  1  0.43966501  0.37879121  0.11488316  1
+  C  C4  1  0.65881095  0.82739659  0.67367513  1
+  C  C5  1  0.10548367  0.71439063  0.78311224  1
+",-154.45171233333335
+2900,C-13933-5578-41,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47927000
+_cell_length_b   3.55564000
+_cell_length_c   5.73664000
+_cell_angle_alpha   81.41564000
+_cell_angle_beta   77.52029000
+_cell_angle_gamma   45.84022000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.42218327
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.93834652  -0.02892873  0.46269213  1
+  C  C1  1  1.05667141  -0.02698352  0.22570942  1
+  C  C2  1  0.62853373  0.97235650  0.08244487  1
+  C  C3  1  0.36605497  0.97168377  0.60670778  1
+  C  C4  1  0.20785188  0.47290414  0.92167761  1
+  C  C5  1  0.78660270  0.47116064  0.76719529  1
+",-154.28662599999998
+9359,C-170338-1408-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.19841000
+_cell_length_b   4.19996000
+_cell_length_c   3.96271000
+_cell_angle_alpha   52.85417000
+_cell_angle_beta   54.21435000
+_cell_angle_gamma   60.00371000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.00190891
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.15292006  -0.03493474  0.88059707  1
+  C  C1  1  0.84638602  0.29904395  -0.11930168  1
+  C  C2  1  0.51364010  0.63170157  0.88078003  1
+  C  C3  1  0.18039681  0.29843836  0.88051062  1
+  C  C4  1  1.17987309  0.63247745  -0.11964145  1
+  C  C5  1  0.51306304  0.96567342  0.88078461  1
+",-154.39313983333332
+5827,C-157715-9420-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43147000
+_cell_length_b   4.04878000
+_cell_length_c   4.66865000
+_cell_angle_alpha   85.30697000
+_cell_angle_beta   71.84509000
+_cell_angle_gamma   93.13449000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.36976923
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.34129765  0.23381516  0.67358755  1
+  C  C1  1  0.89553513  1.12161822  0.56294604  1
+  C  C2  1  0.67577055  0.56926343  1.00546245  1
+  C  C3  1  0.23003802  0.45701869  0.89473385  1
+  C  C4  1  0.56154726  0.78698187  0.23033639  1
+  C  C5  1  0.00751919  -0.10002616  0.34077192  1
+",-154.4610845
+2147,C-96713-4638-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.71331000
+_cell_length_b   5.13506000
+_cell_length_c   5.10141000
+_cell_angle_alpha   41.69720000
+_cell_angle_beta   111.52130000
+_cell_angle_gamma   112.17827000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.36381265
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.21493006  0.18167747  0.91282860  1
+  C  C1  1  -0.09310327  0.52808824  0.25905860  1
+  C  C2  1  0.40525191  0.96907943  0.31697775  1
+  C  C3  1  0.71638909  1.12389480  0.47157091  1
+  C  C4  1  0.90677621  0.91146622  0.87562880  1
+  C  C5  1  0.21505020  0.56497454  0.52932925  1
+",-154.08600049999998
+6348,C-107764-2694-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48337000
+_cell_length_b   4.32535000
+_cell_length_c   5.01122000
+_cell_angle_alpha   109.51419000
+_cell_angle_beta   94.43452000
+_cell_angle_gamma   113.28588000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.21981921
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.33906583  0.79758222  0.97897128  1
+  C  C1  1  0.33592642  0.98078475  0.50442941  1
+  C  C2  1  0.12959593  0.40776340  0.97892406  1
+  C  C3  1  0.65684544  0.74972665  0.50447067  1
+  C  C4  1  0.74253489  0.70129278  0.78754805  1
+  C  C5  1  0.53446287  0.31224033  0.78785192  1
+  C  C6  1  0.21514859  0.36025126  0.26322816  1
+  C  C7  1  0.53766574  0.12940321  0.26339415  1
+",-154.06673125
+3607,C-72736-7953-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47787000
+_cell_length_b   2.47835000
+_cell_length_c   6.31180000
+_cell_angle_alpha   90.00720000
+_cell_angle_beta   101.32104000
+_cell_angle_gamma   120.02816000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.68385524
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.44580435  0.60696438  0.62347990  1
+  C  C1  1  0.05600222  -0.08796456  0.54036396  1
+  C  C2  1  -0.00040325  0.38308822  -0.04599130  1
+  C  C3  1  0.61117003  0.68935543  0.87059717  1
+  C  C4  1  0.88779315  0.82796261  0.28935152  1
+  C  C5  1  1.16535360  0.46621873  0.20510825  1
+",-154.52789816666666
+8203,C-170869-294-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.77825000
+_cell_length_b   3.74533000
+_cell_length_c   6.06089000
+_cell_angle_alpha   94.46136000
+_cell_angle_beta   110.58045000
+_cell_angle_gamma   80.23172000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.17420265
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.23163636  0.22343644  0.76689306  1
+  C  C1  1  0.38007597  0.91205216  0.91451947  1
+  C  C2  1  0.76990564  0.59827164  0.30441612  1
+  C  C3  1  0.22808341  0.59967946  0.76660544  1
+  C  C4  1  0.62065812  0.91081600  0.15638704  1
+  C  C5  1  1.00020593  0.09217023  0.53580496  1
+  C  C6  1  -0.22627352  0.22183222  0.30484734  1
+  C  C7  1  1.00125800  0.73007545  0.53571267  1
+",-154.0724275
+8926,C-57113-4466-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.51766000
+_cell_length_b   3.31823000
+_cell_length_c   6.09686000
+_cell_angle_alpha   90.00358000
+_cell_angle_beta   90.05293000
+_cell_angle_gamma   90.01305000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   71.16498644
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.59919908  0.81789311  0.20639560  1
+  C  C1  1  -0.09548013  0.31792077  0.43828720  1
+  C  C2  1  0.59856148  0.98351911  0.43812522  1
+  C  C3  1  0.40488783  0.48345541  0.70652996  1
+  C  C4  1  0.75161441  0.65113435  0.58975017  1
+  C  C5  1  0.75185297  1.15111873  1.05389633  1
+  C  C6  1  0.25165789  0.15106225  0.55389330  1
+  C  C7  1  0.90504724  0.48351144  0.20656810  1
+  C  C8  1  0.25181313  0.65111747  0.08975682  1
+  C  C9  1  0.09871751  0.98348722  0.93814690  1
+  C  C10  1  0.40467458  0.31789316  -0.06174209  1
+  C  C11  1  1.09903691  0.81782698  0.70641168  1
+",-154.41245999999998
+8462,C-28213-8691-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45520000
+_cell_length_b   6.07332000
+_cell_length_c   7.45685000
+_cell_angle_alpha   81.50588000
+_cell_angle_beta   131.22497000
+_cell_angle_gamma   101.71791000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   81.87220169
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.26715448  0.11090799  -0.00379746  1
+  C  C1  1  0.88019127  0.48046284  0.96090605  1
+  C  C2  1  0.58641678  0.07655891  0.41414274  1
+  C  C3  1  0.46345614  0.82857509  0.41584697  1
+  C  C4  1  0.90423763  0.77591649  0.14954313  1
+  C  C5  1  1.02526572  0.38821731  0.30577419  1
+  C  C6  1  0.53846348  0.41303974  0.55682172  1
+  C  C7  1  0.61130487  0.22680812  0.88926216  1
+  C  C8  1  0.82769747  0.15443864  0.26557601  1
+  C  C9  1  1.14981110  0.85615441  1.00248478  1
+  C  C10  1  0.81084174  0.66566807  0.62993794  1
+  C  C11  1  0.63712502  0.68483584  0.78833563  1
+  C  C12  1  0.69590455  0.53112051  0.10632939  1
+  C  C13  1  0.09821464  0.26484031  0.62387973  1
+",-154.13461071428574
+3247,C-92111-7590-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47594000
+_cell_length_b   3.72317000
+_cell_length_c   4.25097000
+_cell_angle_alpha   63.99603000
+_cell_angle_beta   89.99576000
+_cell_angle_gamma   89.99452000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.21977111
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53164486  0.88238158  0.39927572  1
+  C  C1  1  0.03146173  0.49395589  0.17665395  1
+  C  C2  1  0.03173509  0.90275367  0.17648157  1
+  C  C3  1  1.03169115  0.33749008  0.89838876  1
+  C  C4  1  0.53146909  0.29118353  0.39903570  1
+  C  C5  1  0.53163888  0.44779795  0.67727329  1
+",-154.29355
+3867,C-90843-1323-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44349000
+_cell_length_b   3.54631000
+_cell_length_c   10.11116000
+_cell_angle_alpha   77.64889000
+_cell_angle_beta   76.01236000
+_cell_angle_gamma   69.53377000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   78.84157330
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53362889  0.27258977  0.27860068  1
+  C  C1  1  0.39408644  0.23913713  0.42753819  1
+  C  C2  1  1.11187140  0.35666505  0.65449802  1
+  C  C3  1  0.86320427  0.69559006  0.73447841  1
+  C  C4  1  0.06927620  0.54626180  0.10550315  1
+  C  C5  1  0.14315480  0.56941371  0.51130009  1
+  C  C6  1  0.42822273  0.69020372  0.17485744  1
+  C  C7  1  0.50577727  0.84440485  0.51447748  1
+  C  C8  1  0.18049099  0.12102251  0.20835553  1
+  C  C9  1  0.19472313  0.59723312  0.95496975  1
+  C  C10  1  0.31282519  0.92442765  0.66975290  1
+  C  C11  1  0.74854760  0.62629485  0.88598304  1
+",-154.070675
+7617,C-113066-6557-50,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48793000
+_cell_length_b   4.97519000
+_cell_length_c   4.30558000
+_cell_angle_alpha   125.30974000
+_cell_angle_beta   90.02941000
+_cell_angle_gamma   89.95986000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.49010731
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70483481  0.75304065  0.15289086  1
+  C  C1  1  0.20483302  0.75281884  0.65262085  1
+  C  C2  1  1.20480015  0.62810379  -0.09717666  1
+  C  C3  1  0.20496000  0.25310767  0.65283210  1
+  C  C4  1  0.70491890  0.12804308  0.40275965  1
+  C  C5  1  0.70479192  0.62775426  0.40254839  1
+  C  C6  1  0.20491711  0.12782127  0.90248963  1
+  C  C7  1  0.70495177  0.25275813  0.15255715  1
+",-154.5504675
+7611,C-53801-6753-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46990000
+_cell_length_b   4.08635000
+_cell_length_c   6.13051000
+_cell_angle_alpha   87.60406000
+_cell_angle_beta   101.66723000
+_cell_angle_gamma   89.99396000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   60.54077529
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.07051629  0.95869184  0.62477621  1
+  C  C1  1  0.26093587  0.16297310  0.00165679  1
+  C  C2  1  0.38341981  0.14536265  0.24699762  1
+  C  C3  1  0.57970193  0.80395821  0.64276006  1
+  C  C4  1  0.72623871  0.34805024  0.93376704  1
+  C  C5  1  0.60204847  0.45103542  0.68203173  1
+  C  C6  1  0.32065375  0.82569578  0.12471621  1
+  C  C7  1  0.91975435  0.31990990  0.31834001  1
+  C  C8  1  0.04778910  0.31431874  0.57502236  1
+  C  C9  1  0.82136202  0.61967690  0.12598306  1
+",-154.153291
+4841,C-90863-258-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.44178000
+_cell_length_b   3.98139000
+_cell_length_c   4.60808000
+_cell_angle_alpha   97.05669000
+_cell_angle_beta   108.27826000
+_cell_angle_gamma   114.60812000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.25172562
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.21597235  0.32898624  0.36690773  1
+  C  C1  1  0.40589498  0.47224153  0.17992914  1
+  C  C2  1  0.65841056  0.90419663  0.32317154  1
+  C  C3  1  0.50193714  0.08727965  0.81407548  1
+  C  C4  1  1.17903128  0.41002105  0.84463783  1
+  C  C5  1  0.62328461  0.23725237  0.17676631  1
+  C  C6  1  0.11954228  0.71368672  0.73259923  1
+  C  C7  1  -0.00147096  0.56392947  0.37008130  1
+  C  C8  1  0.96339140  0.89709449  0.22366739  1
+  C  C9  1  0.44258636  0.39110892  0.70228543  1
+  C  C10  1  0.78653023  0.04435879  0.69951169  1
+  C  C11  1  0.83495156  0.75677452  0.84730193  1
+",-154.093945
+4925,C-72736-7953-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48359000
+_cell_length_b   4.04335000
+_cell_length_c   8.22457000
+_cell_angle_alpha   89.98200000
+_cell_angle_beta   72.35964000
+_cell_angle_gamma   90.00340000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   78.70766554
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40100669  0.80952855  0.58871694  1
+  C  C1  1  0.25787443  0.07249025  0.73600273  1
+  C  C2  1  0.61344030  0.57148431  0.88252001  1
+  C  C3  1  0.35437173  0.77984503  0.14254614  1
+  C  C4  1  0.75776376  0.30933732  0.73606694  1
+  C  C5  1  0.92736993  -0.06684081  0.06977235  1
+  C  C6  1  0.90010076  0.57141767  0.58953892  1
+  C  C7  1  0.42851040  0.44911581  0.06790280  1
+  C  C8  1  0.16331380  0.77974199  0.32898852  1
+  C  C9  1  1.08735811  0.44890749  0.40391941  1
+  C  C10  1  0.59027741  0.93292273  0.40166721  1
+  C  C11  1  0.11287578  0.80962940  0.88323085  1
+  C  C12  1  0.64804396  0.27770941  0.34297826  1
+  C  C13  1  -0.13285795  0.27780384  0.12874761  1
+",-154.34247642857144
+6267,C-75997-4752-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48431000
+_cell_length_b   3.82259000
+_cell_length_c   5.22587000
+_cell_angle_alpha   81.18566000
+_cell_angle_beta   89.97794000
+_cell_angle_gamma   71.05017000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.31871713
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.80507652  0.20220433  0.11412401  1
+  C  C1  1  0.56647036  0.67964405  0.33705667  1
+  C  C2  1  0.76843026  0.27603667  0.39353230  1
+  C  C3  1  0.13995891  0.53139653  0.72229558  1
+  C  C4  1  0.02046723  0.77393457  0.17232122  1
+  C  C5  1  0.31439265  0.18175893  0.55864952  1
+  C  C6  1  0.52973057  0.75371774  0.61656357  1
+  C  C7  1  0.19495919  0.42424538  0.00913783  1
+",-154.221985
+5052,C-193915-3332-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47918000
+_cell_length_b   2.56443000
+_cell_length_c   5.72593000
+_cell_angle_alpha   88.66171000
+_cell_angle_beta   77.55713000
+_cell_angle_gamma   89.94139000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.53858141
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.67145791  1.15242607  0.59744843  1
+  C  C1  1  0.24808098  0.16039584  0.44319874  1
+  C  C2  1  0.32715571  0.67006644  0.28250016  1
+  C  C3  1  0.89947892  0.66870337  0.13798361  1
+  C  C4  1  0.01950250  0.64297449  0.90303880  1
+  C  C5  1  0.59214858  0.64218828  0.75794596  1
+",-154.28412283333333
+9427,C-136235-2385-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.36076000
+_cell_length_b   5.37519000
+_cell_length_c   4.79107000
+_cell_angle_alpha   102.15895000
+_cell_angle_beta   133.83224000
+_cell_angle_gamma   81.13500000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   61.02941605
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.41915921  0.55120043  0.12989938  1
+  C  C1  1  0.14287482  0.96487001  0.18466393  1
+  C  C2  1  0.10954107  0.24837143  0.25276461  1
+  C  C3  1  0.77833420  0.55427917  0.82504218  1
+  C  C4  1  0.60344404  0.40673157  0.44676127  1
+  C  C5  1  0.60210797  0.38480672  0.93851027  1
+  C  C6  1  0.10225781  0.24231373  0.56455336  1
+  C  C7  1  0.56255537  0.82480597  0.19080774  1
+  C  C8  1  0.58844966  0.82794970  0.87077145  1
+  C  C9  1  0.13777276  0.94412276  0.50931601  1
+",-154.24671800000002
+3228,C-184080-2077-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48675000
+_cell_length_b   3.95398000
+_cell_length_c   5.94116000
+_cell_angle_alpha   104.54411000
+_cell_angle_beta   89.97515000
+_cell_angle_gamma   90.00794000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   56.54481505
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.56980874  0.58985137  0.28592854  1
+  C  C1  1  0.56925361  0.79511457  0.54776450  1
+  C  C2  1  1.07002535  0.18330899  0.95505612  1
+  C  C3  1  0.06987219  0.38729543  0.21665703  1
+  C  C4  1  0.06945160  0.08011109  0.30839914  1
+  C  C5  1  0.06953122  0.37309378  0.75435773  1
+  C  C6  1  0.56953151  0.60733411  0.74882290  1
+  C  C7  1  0.56959950  0.89768543  0.19453721  1
+  C  C8  1  1.06933736  0.03472236  0.55355984  1
+  C  C9  1  0.56985212  0.94390418  -0.05069261  1
+",-154.32894
+3115,C-56479-4760-57,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48470000
+_cell_length_b   4.08780000
+_cell_length_c   4.67640000
+_cell_angle_alpha   96.69789000
+_cell_angle_beta   105.44686000
+_cell_angle_gamma   89.98716000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.44619551
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76503929  0.18361766  0.33711325  1
+  C  C1  1  0.28020239  0.71007669  0.36586464  1
+  C  C2  1  0.04886776  0.42221589  0.90927100  1
+  C  C3  1  0.70751935  0.82805833  0.22181526  1
+  C  C4  1  -0.06292730  0.11613133  0.67885058  1
+  C  C5  1  0.43819099  0.88966003  0.68072558  1
+  C  C6  1  0.22086669  0.35420528  0.25100319  1
+  C  C7  1  0.54790114  0.64741459  0.90694319  1
+",-154.36725625
+9858,C-184037-2665-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49720000
+_cell_length_b   5.62768000
+_cell_length_c   6.33972000
+_cell_angle_alpha   70.40601000
+_cell_angle_beta   96.13064000
+_cell_angle_gamma   78.51875000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   80.78975731
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.98313713  0.80345171  0.76950630  1
+  C  C1  1  0.55269512  0.49058655  0.12486082  1
+  C  C2  1  0.08265297  0.49200529  0.47647431  1
+  C  C3  1  0.52249691  0.64620714  0.49081386  1
+  C  C4  1  0.40116719  0.91925653  0.31657625  1
+  C  C5  1  0.28696673  -0.03077571  1.08189457  1
+  C  C6  1  0.13332300  0.39847323  0.27356557  1
+  C  C7  1  0.16083934  0.22646156  0.67222178  1
+  C  C8  1  0.26171349  0.77097848  1.00479299  1
+  C  C9  1  0.42989027  0.11755376  0.39361275  1
+  C  C10  1  0.70477395  0.08537317  0.62929081  1
+  C  C11  1  1.16876264  0.24230564  0.90797503  1
+  C  C12  1  0.52854994  0.66215787  0.72678801  1
+  C  C13  1  0.60840021  0.39644329  -0.07738163  1
+",-154.10108
+7292,C-107734-9364-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.18021000
+_cell_length_b   4.16431000
+_cell_length_c   3.61131000
+_cell_angle_alpha   103.19967000
+_cell_angle_beta   103.44622000
+_cell_angle_gamma   71.49187000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.15941387
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.02413035  0.60653090  0.76221685  1
+  C  C1  1  1.02413035  0.10653090  0.26221685  1
+  C  C2  1  0.35646548  0.43821900  -0.06879976  1
+  C  C3  1  0.52414729  0.10652937  0.76221874  1
+  C  C4  1  0.85644854  -0.06177947  0.93119835  1
+  C  C5  1  0.85644854  0.43822053  0.43119835  1
+  C  C6  1  0.52414729  0.60652937  0.26221874  1
+  C  C7  1  0.35646548  -0.06178100  0.43120024  1
+",-154.43970125
+5485,C-73663-9884-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46759000
+_cell_length_b   6.91215000
+_cell_length_c   6.20734000
+_cell_angle_alpha   96.24343000
+_cell_angle_beta   101.29886000
+_cell_angle_gamma   96.49708000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   102.22024813
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.03386650  0.72004924  0.26008033  1
+  C  C1  1  0.20575226  0.01982341  0.48736402  1
+  C  C2  1  0.44721936  0.96569322  0.90029715  1
+  C  C3  1  0.61311242  0.70429123  0.40989126  1
+  C  C4  1  0.79447673  0.66916875  0.80147828  1
+  C  C5  1  0.71979183  0.91434838  0.55551412  1
+  C  C6  1  0.72924199  0.56366422  0.58504163  1
+  C  C7  1  0.61957899  0.17174703  1.01963145  1
+  C  C8  1  0.22258495  0.24192434  0.52972184  1
+  C  C9  1  0.74190815  0.34575185  0.54512842  1
+  C  C10  1  0.10398835  0.94138364  0.24597969  1
+  C  C11  1  0.83188130  0.58846127  0.02469764  1
+  C  C12  1  0.16680169  0.27951925  1.02161373  1
+  C  C13  1  0.57468924  0.99442471  0.13944310  1
+  C  C14  1  0.85867879  0.88318339  0.79169075  1
+  C  C15  1  0.28047514  0.47041267  1.02300369  1
+",-154.107240625
+6297,C-136253-4158-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.27292000
+_cell_length_b   3.63533000
+_cell_length_c   3.26803000
+_cell_angle_alpha   75.44020000
+_cell_angle_beta   99.15162000
+_cell_angle_gamma   104.59222000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.23016252
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63745935  0.14085263  0.41807408  1
+  C  C1  1  0.36905979  0.75904569  0.36383186  1
+  C  C2  1  0.22074679  0.52243598  0.79030382  1
+  C  C3  1  0.00859420  0.75876355  0.00320620  1
+  C  C4  1  0.95504336  1.14065256  0.73464673  1
+  C  C5  1  0.58247181  0.52271810  0.15215691  1
+",-154.20266949999998
+3826,C-76058-7769-51,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.31862000
+_cell_length_b   3.31874000
+_cell_length_c   5.02772000
+_cell_angle_alpha   68.16248000
+_cell_angle_beta   68.17542000
+_cell_angle_gamma   82.75166000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.71127542
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.13557653  0.44172893  1.02840443  1
+  C  C1  1  0.42327305  0.44060847  0.19506722  1
+  C  C2  1  0.76655233  -0.21831038  0.51202247  1
+  C  C3  1  0.31144719  0.61604862  0.67859378  1
+  C  C4  1  0.78131722  0.08358106  0.19468915  1
+  C  C5  1  -0.04150110  0.96932237  0.67819754  1
+  C  C6  1  0.78203980  0.79408729  1.02887319  1
+  C  C7  1  1.12307278  0.42381124  0.51266921  1
+",-154.16776125
+6903,C-152589-5332-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44851000
+_cell_length_b   5.01439000
+_cell_length_c   4.76270000
+_cell_angle_alpha   92.12017000
+_cell_angle_beta   97.92200000
+_cell_angle_gamma   88.03023000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.85238169
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.07431542  0.32380355  0.93882388  1
+  C  C1  1  0.44476769  1.00043891  0.26135871  1
+  C  C2  1  0.88317620  0.77805544  0.76871505  1
+  C  C3  1  0.38237150  -0.04682314  0.76524899  1
+  C  C4  1  0.53148029  0.69991833  0.22977986  1
+  C  C5  1  0.74789429  0.59247637  0.51870938  1
+  C  C6  1  0.35536205  0.14031028  0.52536442  1
+  C  C7  1  0.43800243  0.15478838  1.00743260  1
+  C  C8  1  0.97305595  0.61516716  0.04590450  1
+  C  C9  1  0.84563721  0.31705724  0.60345101  1
+",-154.108959
+7571,C-170342-4227-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44938000
+_cell_length_b   5.22809000
+_cell_length_c   5.96714000
+_cell_angle_alpha   67.15797000
+_cell_angle_beta   65.76860000
+_cell_angle_gamma   89.99650000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   63.05225943
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55398959  0.06645034  0.58251932  1
+  C  C1  1  0.55101739  1.04038389  1.08741600  1
+  C  C2  1  0.43986179  0.73127572  0.19826103  1
+  C  C3  1  0.21431156  0.49602054  0.92353557  1
+  C  C4  1  1.12389129  0.52050467  0.51315964  1
+  C  C5  1  0.10513600  0.18210722  1.03526552  1
+  C  C6  1  0.66562457  0.37598450  0.47145210  1
+  C  C7  1  1.00451387  0.92523392  0.63407918  1
+  C  C8  1  -0.01965642  0.58609314  0.15705456  1
+  C  C9  1  -0.10869933  0.61161187  0.74608567  1
+",-154.20229899999998
+10121,C-106837-6296-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.39831000
+_cell_length_b   3.39849000
+_cell_length_c   4.11447000
+_cell_angle_alpha   101.47783000
+_cell_angle_beta   101.48425000
+_cell_angle_gamma   93.86448000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.35170514
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.26887102  0.68697953  0.53837743  1
+  C  C1  1  0.32451573  0.74224562  0.19368937  1
+  C  C2  1  0.46190371  0.35939025  0.98401228  1
+  C  C3  1  0.94186931  0.87769528  0.98322079  1
+  C  C4  1  0.68216985  0.09823441  0.19709681  1
+  C  C5  1  0.91285864  0.32956352  0.53510389  1
+  C  C6  1  0.13367868  0.07015716  0.74927237  1
+  C  C7  1  0.65184895  0.54987152  0.74848606  1
+",-154.3267825
+5610,C-193954-5904-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.51685000
+_cell_length_b   3.51627000
+_cell_length_c   3.31838000
+_cell_angle_alpha   89.99997000
+_cell_angle_beta   90.00001000
+_cell_angle_gamma   120.00407000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.53652823
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.95154469  0.98840805  0.73846946  1
+  C  C1  1  0.95158190  0.29337904  0.07310609  1
+  C  C2  1  0.48753520  0.75642004  0.57314540  1
+  C  C3  1  0.25585400  0.29307064  0.40580228  1
+  C  C4  1  0.48750038  0.06128928  0.23848317  1
+  C  C5  1  0.18336533  0.75681325  0.90582610  1
+",-154.40923566666666
+9856,C-130505-1819-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.96951000
+_cell_length_b   3.35406000
+_cell_length_c   4.85356000
+_cell_angle_alpha   84.03494000
+_cell_angle_beta   65.21126000
+_cell_angle_gamma   90.30640000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   72.94027912
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.68243835  1.04283591  0.79098924  1
+  C  C1  1  0.57003740  0.93372904  1.10535219  1
+  C  C2  1  0.53166932  0.89897842  0.62467710  1
+  C  C3  1  0.92347585  0.29044703  0.57671468  1
+  C  C4  1  0.68059839  0.04553555  0.31005692  1
+  C  C5  1  0.16462564  0.53417773  0.54839368  1
+  C  C6  1  0.27468455  0.64600071  0.75324244  1
+  C  C7  1  0.16377522  0.53607647  0.06672142  1
+  C  C8  1  0.31222961  0.68390260  0.23397842  1
+  C  C9  1  0.92217627  0.29076195  0.28020681  1
+",-154.243039
+3664,C-113050-8539-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51838000
+_cell_length_b   3.31649000
+_cell_length_c   8.64345000
+_cell_angle_alpha   88.63518000
+_cell_angle_beta   106.92409000
+_cell_angle_gamma   94.73937000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   68.82899283
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53258233  -0.06306510  0.14599690  1
+  C  C1  1  0.40020692  0.70524957  0.98622538  1
+  C  C2  1  0.18581760  0.44032529  0.29824042  1
+  C  C3  1  0.35976598  0.06543018  0.71911502  1
+  C  C4  1  0.51793888  0.06506336  0.87739306  1
+  C  C5  1  0.47809409  0.42564477  0.61028722  1
+  C  C6  1  1.02415951  0.70575486  0.61025476  1
+  C  C7  1  0.69200973  0.69191313  0.29824334  1
+  C  C8  1  0.83681097  -0.06272983  0.45047305  1
+  C  C9  1  -0.14609635  0.42515429  -0.01381423  1
+  C  C10  1  0.04102828  0.19479002  0.14593873  1
+  C  C11  1  0.34553046  0.19501047  0.45045604  1
+",-154.14119666666667
+9105,C-13911-8164-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43269000
+_cell_length_b   3.95568000
+_cell_length_c   4.65572000
+_cell_angle_alpha   96.05619000
+_cell_angle_beta   103.13378000
+_cell_angle_gamma   87.54357000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.37805909
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.83294041  0.91522128  0.39158422  1
+  C  C1  1  0.49900162  0.58047096  0.72427667  1
+  C  C2  1  0.38721777  -0.19768349  0.50191271  1
+  C  C3  1  0.71928395  0.13233242  0.16610497  1
+  C  C4  1  1.05308699  0.46779550  0.83421774  1
+  C  C5  1  0.16509935  0.24522083  1.05600799  1
+",-154.45940983333332
+5355,C-145333-1039-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44257000
+_cell_length_b   4.19675000
+_cell_length_c   6.31783000
+_cell_angle_alpha   73.26297000
+_cell_angle_beta   78.86727000
+_cell_angle_gamma   90.03711000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   60.74337688
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.37939578  0.23912028  0.20092764  1
+  C  C1  1  -0.06703746  0.35439892  0.09524306  1
+  C  C2  1  0.72315155  -0.13479344  0.50944491  1
+  C  C3  1  0.06826423  0.18505112  0.80867780  1
+  C  C4  1  0.27703905  -0.01908508  0.40426814  1
+  C  C5  1  0.05250025  0.51336248  0.84747462  1
+  C  C6  1  0.59850144  0.70565851  0.75668101  1
+  C  C7  1  0.57455216  1.03333141  0.79660343  1
+",-154.19944625
+957,C-41302-4393-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42635000
+_cell_length_b   4.22096000
+_cell_length_c   4.22085000
+_cell_angle_alpha   89.08296000
+_cell_angle_beta   89.99049000
+_cell_angle_gamma   89.98341000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.22240712
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.57991185  0.16238038  0.44328675  1
+  C  C1  1  1.07920110  1.07532097  -0.05222102  1
+  C  C2  1  0.08034335  0.66724437  0.35717402  1
+  C  C3  1  0.58041140  0.51113998  0.38367207  1
+  C  C4  1  0.07989390  0.01563222  0.29653410  1
+  C  C5  1  0.57926209  0.10171297  0.79168038  1
+",-154.30869516666667
+5053,C-96669-7803-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46808000
+_cell_length_b   3.37168000
+_cell_length_c   5.77015000
+_cell_angle_alpha   82.35731000
+_cell_angle_beta   115.29050000
+_cell_angle_gamma   111.39522000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.40775084
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.34251904  0.81358035  0.19423412  1
+  C  C1  1  0.73604359  0.19671935  0.39721170  1
+  C  C2  1  0.10985298  0.89400930  0.92015511  1
+  C  C3  1  0.27486832  0.02353004  0.52223225  1
+  C  C4  1  0.51258668  0.94643847  0.79674709  1
+  C  C5  1  0.87950358  0.63953489  0.31895123  1
+",-154.14736966666666
+7689,C-172917-5417-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.52016000
+_cell_length_b   4.80996000
+_cell_length_c   5.47692000
+_cell_angle_alpha   47.43855000
+_cell_angle_beta   46.64693000
+_cell_angle_gamma   58.65183000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.36281002
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.52828759  0.28686004  0.63415875  1
+  C  C1  1  0.85983267  0.95729271  0.63342993  1
+  C  C2  1  0.62069833  0.61215006  0.02188474  1
+  C  C3  1  0.99015571  0.24429127  1.02127977  1
+  C  C4  1  -0.23371299  0.63180702  0.24562394  1
+  C  C5  1  0.39764817  -0.00013150  0.24631838  1
+",-154.23274866666665
+9824,C-148248-8795-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47980000
+_cell_length_b   2.57993000
+_cell_length_c   8.10972000
+_cell_angle_alpha   71.80844000
+_cell_angle_beta   89.95675000
+_cell_angle_gamma   89.89522000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.29031125
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.82554165  0.48221515  0.19112024  1
+  C  C1  1  0.82539515  0.47124081  0.69110972  1
+  C  C2  1  0.82557912  0.08724761  0.57098984  1
+  C  C3  1  0.32544837  0.19958163  0.96772657  1
+  C  C4  1  0.32550211  0.37674660  0.29430978  1
+  C  C5  1  0.32568585  0.19198494  0.46771776  1
+  C  C6  1  0.32532178  0.36931922  0.79427061  1
+  C  C7  1  0.82539027  0.09787375  1.07101088  1
+",-154.175345
+7431,C-90837-7402-61,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49032000
+_cell_length_b   3.86617000
+_cell_length_c   7.54079000
+_cell_angle_alpha   99.16905000
+_cell_angle_beta   109.30444000
+_cell_angle_gamma   89.97457000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.53875265
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.04752303  0.29508897  0.12537096  1
+  C  C1  1  0.20875445  0.95004329  0.78543875  1
+  C  C2  1  0.88454695  0.50284111  0.96277577  1
+  C  C3  1  0.71061518  0.19306202  0.78742647  1
+  C  C4  1  0.77860940  1.01988324  0.35210190  1
+  C  C5  1  -0.45110105  0.40120767  0.62502975  1
+  C  C6  1  1.04219894  0.63624771  0.61849531  1
+  C  C7  1  0.55424361  0.06018697  0.13188732  1
+  C  C8  1  0.82166794  0.67708998  0.39848738  1
+  C  C9  1  0.24634061  0.49342265  0.32306797  1
+  C  C10  1  0.35398448  0.20307051  0.42744020  1
+  C  C11  1  0.38650356  0.74591887  -0.03520968  1
+",-154.33213166666667
+9870,C-152593-8124-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47495000
+_cell_length_b   4.30286000
+_cell_length_c   8.29497000
+_cell_angle_alpha   106.61211000
+_cell_angle_beta   108.35965000
+_cell_angle_gamma   85.30921000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   80.33706019
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.90470371  0.32541939  0.71683724  1
+  C  C1  1  0.14408435  0.26106467  0.12173087  1
+  C  C2  1  -0.03842594  0.63023004  0.12185454  1
+  C  C3  1  0.65182804  0.85282713  0.43054516  1
+  C  C4  1  -0.32284974  0.21776819  0.50155809  1
+  C  C5  1  1.39032405  0.81802035  0.69625272  1
+  C  C6  1  0.57304774  0.68514335  0.23724975  1
+  C  C7  1  0.67560050  0.75981091  -0.03463294  1
+  C  C8  1  0.21046855  0.71932513  0.50125777  1
+  C  C9  1  0.76262005  0.32286238  0.23846385  1
+  C  C10  1  1.08558184  0.35115789  0.43385431  1
+  C  C11  1  0.12265918  -0.02644342  0.96439646  1
+  C  C12  1  -0.04577867  0.01270265  0.77315685  1
+  C  C13  1  0.46544485  0.53296134  0.77700472  1
+",-154.107055
+2638,C-40140-2962-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45452000
+_cell_length_b   5.35685000
+_cell_length_c   4.59520000
+_cell_angle_alpha   84.47799000
+_cell_angle_beta   105.55288000
+_cell_angle_gamma   89.99885000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.91645966
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.41800380  0.57191195  -0.04356815  1
+  C  C1  1  0.46473033  0.28872751  1.04914837  1
+  C  C2  1  0.67938505  0.92483672  0.47674865  1
+  C  C3  1  -0.11789054  0.20384252  0.88443717  1
+  C  C4  1  0.13250663  0.77404240  0.38597023  1
+  C  C5  1  0.96092323  0.71851458  0.04193168  1
+  C  C6  1  0.62118325  0.19583345  0.36103044  1
+  C  C7  1  0.84961863  0.94457476  0.81557267  1
+  C  C8  1  0.24146653  0.53746184  0.60579056  1
+  C  C9  1  0.73249590  0.37164055  0.58836778  1
+",-154.206389
+1884,C-90806-1928-53,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47382000
+_cell_length_b   4.80318000
+_cell_length_c   4.80260000
+_cell_angle_alpha   61.95006000
+_cell_angle_beta   104.92728000
+_cell_angle_gamma   75.08009000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.60393733
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.90918251  0.73919719  0.50881542  1
+  C  C1  1  0.24279950  0.15583297  0.59233536  1
+  C  C2  1  0.90928067  0.92644460  0.69569567  1
+  C  C3  1  0.90893267  0.23928648  0.00897736  1
+  C  C4  1  0.24272988  0.65590596  1.09220271  1
+  C  C5  1  -0.09072807  0.42650418  0.19584416  1
+  C  C6  1  0.24246680  0.84317237  0.27899394  1
+  C  C7  1  0.24227995  0.34315424  0.77916148  1
+",-154.51910875
+9143,C-170892-2455-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43855000
+_cell_length_b   4.69120000
+_cell_length_c   4.68755000
+_cell_angle_alpha   112.75475000
+_cell_angle_beta   74.89015000
+_cell_angle_gamma   105.11620000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   46.96418535
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.08489814  0.02883829  0.38180091  1
+  C  C1  1  0.58508449  0.20624399  0.55908581  1
+  C  C2  1  0.43313326  0.26113034  0.91957995  1
+  C  C3  1  0.92986376  0.68576168  0.35209694  1
+  C  C4  1  0.24111764  0.99995106  1.03770273  1
+  C  C5  1  0.73822583  0.56614018  0.61206898  1
+  C  C6  1  0.98445480  0.47401453  0.02812957  1
+  C  C7  1  0.18763789  0.67610404  0.82520401  1
+",-154.1641875
+9916,C-126167-1633-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47505000
+_cell_length_b   3.72054000
+_cell_length_c   4.24260000
+_cell_angle_alpha   64.15394000
+_cell_angle_beta   89.97420000
+_cell_angle_gamma   89.97410000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.16003814
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.38308600  0.17624744  1.01500689  1
+  C  C1  1  -0.11681973  0.22159203  0.51450446  1
+  C  C2  1  0.38328393  0.33289854  0.29327140  1
+  C  C3  1  0.88323790  0.78724925  0.79215761  1
+  C  C4  1  0.38310014  0.76725869  0.01568508  1
+  C  C5  1  0.88317555  0.37825135  0.79257767  1
+",-154.28719433333333
+1696,C-41318-6901-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42975000
+_cell_length_b   3.02351000
+_cell_length_c   6.12977000
+_cell_angle_alpha   98.60893000
+_cell_angle_beta   75.99472000
+_cell_angle_gamma   95.18767000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.13167869
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.80199689  0.11093475  0.74635451  1
+  C  C1  1  0.13530449  0.44392710  0.07967728  1
+  C  C2  1  0.46866487  0.77755286  0.41302432  1
+  C  C3  1  0.69177160  0.33582783  0.96753330  1
+  C  C4  1  1.02513160  0.66923201  0.30083979  1
+  C  C5  1  0.35846775  1.00291735  0.63420211  1
+",-154.44257483333334
+8744,C-96678-2884-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45462000
+_cell_length_b   6.16330000
+_cell_length_c   7.54564000
+_cell_angle_alpha   125.94173000
+_cell_angle_beta   80.65863000
+_cell_angle_gamma   101.56376000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   90.40170294
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.00702700  -0.03978954  0.73500753  1
+  C  C1  1  0.69220150  0.24374641  0.65632043  1
+  C  C2  1  0.58184683  0.76354728  0.38754016  1
+  C  C3  1  0.88951060  0.92366519  0.92560657  1
+  C  C4  1  0.24697808  0.28824170  0.59086160  1
+  C  C5  1  0.56835087  0.13977050  0.79231304  1
+  C  C6  1  0.96517122  0.24928378  0.10580077  1
+  C  C7  1  0.89297788  0.32516959  0.33079636  1
+  C  C8  1  0.03753063  0.77276039  0.48662074  1
+  C  C9  1  0.31915982  0.82312760  0.96422283  1
+  C  C10  1  0.34536641  0.31460623  0.41788985  1
+  C  C11  1  0.20950719  0.71593930  1.07957429  1
+  C  C12  1  0.53942173  0.33318061  0.04178636  1
+  C  C13  1  0.64007305  0.64255166  0.14513457  1
+",-154.23140714285714
+469,C-73637-6506-63,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44660000
+_cell_length_b   4.17197000
+_cell_length_c   9.43034000
+_cell_angle_alpha   106.86077000
+_cell_angle_beta   67.14654000
+_cell_angle_gamma   89.98927000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   84.19005200
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.30644591  0.87801252  0.18124715  1
+  C  C1  1  0.29284842  0.28839574  0.52703331  1
+  C  C2  1  0.44681224  0.54632884  0.42429985  1
+  C  C3  1  0.34098519  0.21612820  0.16048356  1
+  C  C4  1  1.04335793  0.54033900  0.69374314  1
+  C  C5  1  0.61535041  0.08247503  0.97859089  1
+  C  C6  1  0.44438407  0.68134020  0.75971585  1
+  C  C7  1  0.23018720  0.96833568  0.90222884  1
+  C  C8  1  -0.20256822  0.72551455  0.18718623  1
+  C  C9  1  0.88222314  0.75177931  0.46714131  1
+  C  C10  1  0.82842893  0.08483102  0.50305843  1
+  C  C11  1  0.73511019  0.41379022  0.23073423  1
+",-154.190545
+6479,C-126163-8054-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43654000
+_cell_length_b   7.68537000
+_cell_length_c   6.63813000
+_cell_angle_alpha   53.50413000
+_cell_angle_beta   84.62563000
+_cell_angle_gamma   75.74572000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   96.62869552
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.05125473  0.09876645  0.54658921  1
+  C  C1  1  -0.16623553  0.69934521  0.16702772  1
+  C  C2  1  0.21784248  0.31529071  0.64753064  1
+  C  C3  1  0.28016844  0.77458201  0.44181820  1
+  C  C4  1  1.04621670  0.42976217  0.76772155  1
+  C  C5  1  -0.36464625  0.12163653  0.13738881  1
+  C  C6  1  -0.21253004  1.24385268  0.61417177  1
+  C  C7  1  0.88662151  0.64490328  0.99152567  1
+  C  C8  1  0.45115335  0.56717390  0.71910327  1
+  C  C9  1  0.41782906  0.62251655  0.90307487  1
+  C  C10  1  0.30429771  0.72040698  0.25660903  1
+  C  C11  1  0.51770781  0.02725905  0.51328671  1
+  C  C12  1  0.68601022  0.91211133  0.39354982  1
+  C  C13  1  1.09445967  0.22087506  0.02439004  1
+",-154.26382214285715
+8861,C-170372-5246-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48127000
+_cell_length_b   3.68794000
+_cell_length_c   4.89738000
+_cell_angle_alpha   66.93636000
+_cell_angle_beta   59.47946000
+_cell_angle_gamma   70.35330000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98310974
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.77734363  0.55783984  0.03859781  1
+  C  C1  1  0.09026064  0.07322552  0.46735275  1
+  C  C2  1  0.07396210  0.51872081  0.26098134  1
+  C  C3  1  0.79913279  0.91611240  0.33672449  1
+  C  C4  1  0.05127071  0.15987717  0.96329133  1
+  C  C5  1  0.76134673  1.00355256  0.83216958  1
+",-154.30904666666666
+8360,C-106857-1903-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48471000
+_cell_length_b   4.67883000
+_cell_length_c   5.84254000
+_cell_angle_alpha   136.01992000
+_cell_angle_beta   77.69261000
+_cell_angle_gamma   105.42026000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.44397744
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79342431  0.67961230  0.37151279  1
+  C  C1  1  0.33662643  -0.06453203  0.54129372  1
+  C  C2  1  0.12168198  0.04211968  0.07803302  1
+  C  C3  1  0.27986743  0.17582489  0.89711408  1
+  C  C4  1  0.00852546  0.57280455  0.83582425  1
+  C  C5  1  0.50745325  0.34498920  0.60993529  1
+  C  C6  1  0.85222417  0.43865985  0.01582609  1
+  C  C7  1  0.62294838  0.27046926  0.30373136  1
+",-154.36606375
+4471,C-102891-3492-9,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44024000
+_cell_length_b   4.18208000
+_cell_length_c   6.49778000
+_cell_angle_alpha   74.23478000
+_cell_angle_beta   79.24611000
+_cell_angle_gamma   89.93137000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   62.61046576
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.29066574  0.32261966  0.64496094  1
+  C  C1  1  0.77006359  0.79829643  0.69733372  1
+  C  C2  1  1.06572621  0.36326758  1.08371225  1
+  C  C3  1  0.62073422  0.35845738  -0.02251337  1
+  C  C4  1  0.27740481  0.96040657  0.68411778  1
+  C  C5  1  0.95965763  0.39505212  0.29748630  1
+  C  C6  1  0.74505089  0.43595722  0.73611681  1
+  C  C7  1  0.40537110  0.39939474  0.40395217  1
+",-154.2406025
+6482,C-141033-8048-54,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42651000
+_cell_length_b   4.22466000
+_cell_length_c   4.22511000
+_cell_angle_alpha   91.58400000
+_cell_angle_beta   90.02095000
+_cell_angle_gamma   89.99927000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.29580831
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.81374606  0.12909951  0.32905811  1
+  C  C1  1  0.31365531  0.28535248  0.35413987  1
+  C  C2  1  0.31336056  0.69427806  0.76418699  1
+  C  C3  1  0.31359451  0.63446037  0.41503623  1
+  C  C4  1  0.81347271  0.71993299  0.92055866  1
+  C  C5  1  0.81345416  0.77994479  0.26929205  1
+",-154.3131225
+9442,C-92124-4005-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48563000
+_cell_length_b   4.71067000
+_cell_length_c   6.15567000
+_cell_angle_alpha   84.10923000
+_cell_angle_beta   101.63999000
+_cell_angle_gamma   121.86887000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   59.95221028
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76414685  0.72595754  0.21434065  1
+  C  C1  1  0.81055531  0.10228155  0.55713390  1
+  C  C2  1  0.68729676  0.21331861  0.08497020  1
+  C  C3  1  0.38866531  0.23200881  0.45382149  1
+  C  C4  1  0.44154762  0.73362801  0.55606376  1
+  C  C5  1  0.73164884  0.91693050  0.77169045  1
+  C  C6  1  0.75944086  0.60296521  0.45293439  1
+  C  C7  1  0.09211699  0.61857581  0.08427874  1
+  C  C8  1  0.29826483  0.91574778  0.90625850  1
+  C  C9  1  0.14547593  0.10704318  0.21484462  1
+",-154.251117
+1972,C-136214-3679-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.26665000
+_cell_length_b   3.27920000
+_cell_length_c   4.23793000
+_cell_angle_alpha   123.96073000
+_cell_angle_beta   95.21756000
+_cell_angle_gamma   99.17045000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.26276510
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.65550025  0.58125999  0.46172212  1
+  C  C1  1  0.29370560  0.22020185  0.46200598  1
+  C  C2  1  0.71134803  0.46648979  1.08029668  1
+  C  C3  1  0.02731983  0.78419990  1.08061394  1
+  C  C4  1  0.08230640  0.67016515  0.69918660  1
+  C  C5  1  0.44336068  1.03102922  0.69888008  1
+",-154.204218
+9776,C-34629-5612-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.58530000
+_cell_length_b   3.40063000
+_cell_length_c   4.68668000
+_cell_angle_alpha   45.61167000
+_cell_angle_beta   104.54480000
+_cell_angle_gamma   89.08218000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.56978788
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.68136705  0.36877632  0.12809417  1
+  C  C1  1  0.96714891  1.23057869  0.45476424  1
+  C  C2  1  0.96667912  0.22410933  0.75203705  1
+  C  C3  1  0.68106967  0.37054973  0.79319025  1
+  C  C4  1  0.28557564  0.24667528  0.43044081  1
+  C  C5  1  0.49076700  -0.03396612  0.86543301  1
+  C  C6  1  0.28566558  0.89237881  0.09431692  1
+  C  C7  1  0.46753732  0.97837236  0.35328764  1
+",-154.20025
+2050,C-157703-910-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45247000
+_cell_length_b   4.54525000
+_cell_length_c   6.08521000
+_cell_angle_alpha   50.01777000
+_cell_angle_beta   101.62091000
+_cell_angle_gamma   74.36525000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.12325154
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.14375174  0.73912430  1.00260832  1
+  C  C1  1  0.36372958  0.66229379  0.94098937  1
+  C  C2  1  0.82168100  0.93158041  0.12944384  1
+  C  C3  1  0.39288196  0.47178881  0.81268729  1
+  C  C4  1  0.73259816  0.60340309  0.62379516  1
+  C  C5  1  0.48138584  0.80048070  0.31822442  1
+",-154.25071383333332
+1948,C-176687-5509-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43237000
+_cell_length_b   3.20338000
+_cell_length_c   6.41675000
+_cell_angle_alpha   70.76935000
+_cell_angle_beta   79.14274000
+_cell_angle_gamma   67.11063000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.38644286
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.29133465  0.31062285  0.42267130  1
+  C  C1  1  0.62431677  0.31139477  0.75607575  1
+  C  C2  1  0.06574907  0.31704731  0.86630845  1
+  C  C3  1  0.39902256  0.31668404  0.19994912  1
+  C  C4  1  0.73396206  0.31286214  0.53392135  1
+  C  C5  1  0.95626079  0.31501250  0.08848284  1
+",-154.462066
+6048,C-152599-7664-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47625000
+_cell_length_b   4.25647000
+_cell_length_c   5.94183000
+_cell_angle_alpha   110.94408000
+_cell_angle_beta   102.04096000
+_cell_angle_gamma   89.98852000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.01280603
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.39045788  -0.01252713  0.70989677  1
+  C  C1  1  0.87159454  0.46809371  0.66919898  1
+  C  C2  1  0.83582916  0.77512228  0.59846505  1
+  C  C3  1  0.53368434  0.13099803  0.99467502  1
+  C  C4  1  0.01422822  0.60923208  0.95415067  1
+  C  C5  1  0.33060670  0.25363407  0.58784179  1
+  C  C6  1  0.70407245  0.77522652  0.33215198  1
+  C  C7  1  0.07379956  0.99697305  0.07542261  1
+  C  C8  1  0.56937221  0.50872033  0.06604909  1
+  C  C9  1  0.20342545  -0.00962404  0.33176244  1
+",-154.391623
+8177,C-79942-3138-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44599000
+_cell_length_b   7.66318000
+_cell_length_c   6.88077000
+_cell_angle_alpha   62.51525000
+_cell_angle_beta   83.43661000
+_cell_angle_gamma   78.08956000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   111.92659710
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.46157829  0.09963669  0.68792345  1
+  C  C1  1  0.53091778  -0.04856785  0.27450192  1
+  C  C2  1  0.68144349  0.57866445  0.28898378  1
+  C  C3  1  0.19729748  0.47226609  0.41805717  1
+  C  C4  1  0.31563652  0.70445416  0.73441374  1
+  C  C5  1  -0.00920675  0.01740096  0.31864597  1
+  C  C6  1  0.24073316  0.68325435  0.96068188  1
+  C  C7  1  0.50247234  0.32652704  -0.01110034  1
+  C  C8  1  0.98370221  0.03501113  0.79769937  1
+  C  C9  1  0.37962949  0.24401871  0.44948189  1
+  C  C10  1  1.09412645  0.85888424  0.01826415  1
+  C  C11  1  0.56504310  0.37544506  0.77373802  1
+  C  C12  1  -0.07180086  0.20715655  0.34168536  1
+  C  C13  1  0.58915701  0.81931979  0.16514742  1
+  C  C14  1  0.87836266  0.66333304  0.66248551  1
+  C  C15  1  0.78072812  0.56478055  0.07477555  1
+  C  C16  1  0.94370636  0.35155046  0.09563898  1
+  C  C17  1  1.05802045  0.46461777  0.64237358  1
+",-154.09478222222222
+4333,C-28228-7733-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45377000
+_cell_length_b   5.78112000
+_cell_length_c   5.36585000
+_cell_angle_alpha   144.67845000
+_cell_angle_beta   89.99847000
+_cell_angle_gamma   102.21785000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.95491509
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.88969059  0.27413203  0.92903768  1
+  C  C1  1  0.72794506  -0.04861959  0.41544133  1
+  C  C2  1  1.28581042  1.06399774  0.84984677  1
+  C  C3  1  0.26221216  1.01207690  0.07378713  1
+  C  C4  1  0.75951875  0.00681726  0.19455574  1
+  C  C5  1  0.12295692  0.74043546  0.33466755  1
+",-154.11818633333334
+313,C-9601-1359-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43217000
+_cell_length_b   3.85891000
+_cell_length_c   6.86254000
+_cell_angle_alpha   73.94891000
+_cell_angle_beta   111.03015000
+_cell_angle_gamma   89.82835000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.39836358
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.42343851  0.55240746  0.69916689  1
+  C  C1  1  0.17167252  0.80515200  0.94788449  1
+  C  C2  1  0.50405286  0.13904320  0.28082856  1
+  C  C3  1  0.75323900  -0.10960618  1.03019906  1
+  C  C4  1  0.92160798  0.05552927  0.19771268  1
+  C  C5  1  0.67359191  0.30226798  0.44923663  1
+  C  C6  1  0.25561592  0.38665557  0.53196341  1
+  C  C7  1  1.00481200  0.63811551  0.78131169  1
+",-154.46115
+7980,C-47623-476-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.41992000
+_cell_length_b   3.41810000
+_cell_length_c   7.22960000
+_cell_angle_alpha   109.90328000
+_cell_angle_beta   109.92664000
+_cell_angle_gamma   87.86798000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   74.40828056
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.00780118  0.69570254  0.22851979  1
+  C  C1  1  0.59251361  0.57733981  0.88844771  1
+  C  C2  1  0.66219071  0.31424770  0.41805034  1
+  C  C3  1  0.44659983  0.91069213  0.01401272  1
+  C  C4  1  0.02075810  0.00532744  0.68382660  1
+  C  C5  1  0.92500040  0.42943155  1.01367450  1
+  C  C6  1  0.71175465  -0.00942365  0.22857181  1
+  C  C7  1  0.59002218  0.07196580  0.55248962  1
+  C  C8  1  0.33815554  0.32222882  0.67712768  1
+  C  C9  1  0.10542546  0.08963759  -0.08585156  1
+  C  C10  1  0.33024839  0.64624408  0.41806736  1
+  C  C11  1  1.08706316  0.57484759  0.55244283  1
+",-154.2057825
+9146,C-176641-3686-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48143000
+_cell_length_b   3.68824000
+_cell_length_c   4.21608000
+_cell_angle_alpha   75.21372000
+_cell_angle_beta   90.05895000
+_cell_angle_gamma   109.64033000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98516700
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.39795138  0.63597929  0.80411130  1
+  C  C1  1  0.59892446  1.03390630  0.87956097  1
+  C  C2  1  0.81941723  0.47868852  0.67337707  1
+  C  C3  1  0.07927295  -0.00522118  0.10180336  1
+  C  C4  1  0.85810219  0.54946445  0.30813359  1
+  C  C5  1  0.27991370  0.39317152  0.17705270  1
+",-154.308622
+6744,C-189703-1540-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48816000
+_cell_length_b   4.75902000
+_cell_length_c   7.40044000
+_cell_angle_alpha   60.20605000
+_cell_angle_beta   59.67508000
+_cell_angle_gamma   58.45834000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   61.15333638
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.73043137  0.40184057  0.78969599  1
+  C  C1  1  0.48608569  -0.00651284  0.22516219  1
+  C  C2  1  0.11135198  1.02238668  0.78945247  1
+  C  C3  1  0.59689197  0.85196248  0.91268198  1
+  C  C4  1  0.36385799  0.15544536  0.53290195  1
+  C  C5  1  -0.00245907  0.44940839  0.91308148  1
+  C  C6  1  1.11828116  0.06087579  0.09230857  1
+  C  C7  1  0.09217334  0.06683283  0.43974849  1
+  C  C8  1  0.45333060  0.70532900  0.43951944  1
+  C  C9  1  -0.00565893  0.52391635  0.53297685  1
+",-154.14752800000002
+8607,C-142851-2202-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46623000
+_cell_length_b   6.03250000
+_cell_length_c   10.28700000
+_cell_angle_alpha   85.53458000
+_cell_angle_beta   80.60905000
+_cell_angle_gamma   86.88606000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C22
+_cell_volume   150.40090549
+_cell_formula_units_Z   22
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.44341983  0.64808208  0.74781386  1
+  C  C1  1  -0.03527049  0.99250360  0.71024281  1
+  C  C2  1  0.58450144  0.95502290  0.42809870  1
+  C  C3  1  0.50605775  0.61390473  -0.01087949  1
+  C  C4  1  0.74937302  0.55434120  0.19849466  1
+  C  C5  1  0.45773877  0.88599112  0.73514750  1
+  C  C6  1  0.66541680  0.08192112  0.30545623  1
+  C  C7  1  0.38356533  0.51059098  0.87090703  1
+  C  C8  1  0.49244475  0.56035234  0.61259775  1
+  C  C9  1  0.86306518  0.41463033  0.92705950  1
+  C  C10  1  1.03705893  0.63458709  0.53580649  1
+  C  C11  1  1.29854172  0.51710902  0.12758332  1
+  C  C12  1  0.97212807  -0.02518723  -0.00348630  1
+  C  C13  1  0.86847192  0.21734851  0.02911901  1
+  C  C14  1  0.13003303  0.55608414  0.40078693  1
+  C  C15  1  1.20796614  0.12958835  0.24240484  1
+  C  C16  1  -0.51525662  0.31914045  0.63502481  1
+  C  C17  1  0.67569249  0.54853563  0.33300249  1
+  C  C18  1  0.51200143  0.86178147  0.98977153  1
+  C  C19  1  0.05936848  0.86598501  0.47488309  1
+  C  C20  1  0.30438442  0.25393316  0.11248823  1
+  C  C21  1  -0.02224578  0.21565249  0.65975412  1
+",-154.07384363636365
+6012,C-34606-3915-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.28370000
+_cell_length_b   3.36682000
+_cell_length_c   7.02651000
+_cell_angle_alpha   111.54309000
+_cell_angle_beta   81.89366000
+_cell_angle_gamma   94.24714000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   71.51279029
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.04450009  0.58327524  0.33673395  1
+  C  C1  1  0.17602554  -0.07696271  -0.12147779  1
+  C  C2  1  0.39463224  0.74082348  0.65835573  1
+  C  C3  1  0.84537441  0.23802798  0.88064521  1
+  C  C4  1  0.74615619  0.27541139  0.34176614  1
+  C  C5  1  0.75515631  0.07666507  0.66027855  1
+  C  C6  1  0.15511611  0.91323702  0.53244188  1
+  C  C7  1  0.47659900  0.18342575  0.01680152  1
+  C  C8  1  0.50940315  0.27901224  0.54497549  1
+  C  C9  1  0.61654526  0.94892217  0.14480987  1
+  C  C10  1  -0.01961733  0.67439844  0.00353246  1
+  C  C11  1  0.27591193  0.60741932  0.14218458  1
+",-154.2107875
+9969,C-141065-1801-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48754000
+_cell_length_b   2.48750000
+_cell_length_c   6.57846000
+_cell_angle_alpha   79.04839000
+_cell_angle_beta   112.28340000
+_cell_angle_gamma   120.04927000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.60348068
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.58136931  0.66489181  0.57355222  1
+  C  C1  1  -0.08563683  -0.00158156  0.23983938  1
+  C  C2  1  0.24774558  0.33187851  0.90664545  1
+  C  C3  1  -0.00214206  0.33161598  0.65657887  1
+  C  C4  1  0.66423421  0.99860268  0.98967210  1
+  C  C5  1  0.33124035  0.66507605  0.32338494  1
+",-154.53806083333333
+4488,C-130542-9068-49,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.89313000
+_cell_length_b   3.63566000
+_cell_length_c   4.81596000
+_cell_angle_alpha   112.12850000
+_cell_angle_beta   96.62734000
+_cell_angle_gamma   106.46941000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.56932659
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.44532598  0.98239008  0.31911680  1
+  C  C1  1  0.45631957  0.64040509  0.62949211  1
+  C  C2  1  0.45244290  0.04591504  0.82030988  1
+  C  C3  1  0.44930043  0.19705017  0.12920899  1
+  C  C4  1  0.45613044  0.26021162  0.63026053  1
+  C  C5  1  0.44542299  0.60243330  0.31985408  1
+",-154.111122
+5082,C-189734-3200-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43095000
+_cell_length_b   3.10923000
+_cell_length_c   7.49207000
+_cell_angle_alpha   116.57868000
+_cell_angle_beta   113.20017000
+_cell_angle_gamma   96.56096000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.54399242
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.30604757  0.85118574  -0.00548306  1
+  C  C1  1  0.63891935  -0.03753463  0.54962847  1
+  C  C2  1  0.30609085  0.18461134  0.66119843  1
+  C  C3  1  0.63897607  0.29566790  0.21629288  1
+  C  C4  1  0.30619789  0.51773992  0.32790303  1
+  C  C5  1  0.63885628  0.62919203  0.88292555  1
+",-154.45767433333333
+10028,C-80168-1847-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47598000
+_cell_length_b   4.86189000
+_cell_length_c   4.79374000
+_cell_angle_alpha   67.90231000
+_cell_angle_beta   89.99132000
+_cell_angle_gamma   59.38587000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   44.66973855
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87932411  -0.11055922  1.00430252  1
+  C  C1  1  0.50965378  0.25882307  0.00425566  1
+  C  C2  1  0.43264239  0.83656355  0.84942957  1
+  C  C3  1  0.17676941  0.59222294  0.33774727  1
+  C  C4  1  0.54577492  0.22291992  0.33786659  1
+  C  C5  1  0.25359216  1.01530516  0.49234294  1
+  C  C6  1  0.62341373  0.64529975  0.49222668  1
+  C  C7  1  0.80152400  0.46655244  0.84933166  1
+",-154.40593625
+7206,C-56508-2-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43200000
+_cell_length_b   6.41451000
+_cell_length_c   5.79351000
+_cell_angle_alpha   102.71160000
+_cell_angle_beta   90.42693000
+_cell_angle_gamma   79.10496000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   86.51992267
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76704172  0.12415909  0.14347529  1
+  C  C1  1  1.20002051  0.13042370  0.64463120  1
+  C  C2  1  0.54373281  0.56922642  1.14325664  1
+  C  C3  1  0.10017004  0.45758240  0.14380252  1
+  C  C4  1  0.64393483  0.24102440  0.64276820  1
+  C  C5  1  0.86686473  0.79698944  0.64456845  1
+  C  C6  1  -0.02260827  0.57477693  0.64307901  1
+  C  C7  1  0.53398433  0.46318850  0.64406515  1
+  C  C8  1  0.87750185  -0.09791475  0.14281588  1
+  C  C9  1  0.31044190  0.90822211  0.64333482  1
+  C  C10  1  0.43341523  0.79144634  0.14457567  1
+  C  C11  1  0.21078431  0.23535212  1.14215328  1
+",-154.45631749999998
+9923,C-50241-8788-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48561000
+_cell_length_b   4.01050000
+_cell_length_c   10.35493000
+_cell_angle_alpha   95.48624000
+_cell_angle_beta   83.11626000
+_cell_angle_gamma   89.99106000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   102.00294012
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55727454  1.01908695  0.54284770  1
+  C  C1  1  0.41392909  0.88143792  0.83046849  1
+  C  C2  1  0.32075593  0.44769069  0.01799133  1
+  C  C3  1  0.74767970  0.82607849  0.16994209  1
+  C  C4  1  0.46344200  0.58553636  0.72995841  1
+  C  C5  1  0.96366445  0.35903428  0.72940797  1
+  C  C6  1  0.13468103  0.63993573  0.39070518  1
+  C  C7  1  0.81411995  0.93201410  1.03202771  1
+  C  C8  1  0.53372398  0.68835546  0.59160667  1
+  C  C9  1  0.24956604  0.58816776  0.16602572  1
+  C  C10  1  0.34642417  0.77758137  0.96874013  1
+  C  C11  1  0.06437833  0.53356099  0.52847628  1
+  C  C12  1  0.03838178  0.20721020  0.58122736  1
+  C  C13  1  0.69337798  0.11655062  0.28246443  1
+  C  C14  1  0.63284364  0.87778777  0.39466309  1
+  C  C15  1  0.84048749  0.26010904  -0.02034172  1
+  C  C16  1  -0.08660176  0.10989872  0.83140043  1
+  C  C17  1  0.19533066  0.35113755  0.27830345  1
+",-154.3431838888889
+3040,C-92156-5607-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47804000
+_cell_length_b   4.12622000
+_cell_length_c   7.06679000
+_cell_angle_alpha   114.24738000
+_cell_angle_beta   110.49648000
+_cell_angle_gamma   90.00726000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   60.82960336
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.61929503  0.58140933  0.22994395  1
+  C  C1  1  0.85569732  0.61963291  0.96672368  1
+  C  C2  1  0.03964110  0.71798564  0.65276554  1
+  C  C3  1  0.34438366  0.39966060  0.95554369  1
+  C  C4  1  0.50696949  0.21724502  0.61912611  1
+  C  C5  1  0.11585883  0.79811581  0.22644859  1
+  C  C6  1  0.27349534  0.19073997  0.38404625  1
+  C  C7  1  0.78089939  0.41523709  0.39159547  1
+  C  C8  1  0.08874722  0.10204155  0.70112017  1
+  C  C9  1  0.63098930  0.62613537  0.74453154  1
+",-154.134084
+8481,C-176633-3584-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48147000
+_cell_length_b   3.69045000
+_cell_length_c   4.84429000
+_cell_angle_alpha   57.37352000
+_cell_angle_beta   75.11494000
+_cell_angle_gamma   70.32433000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.02184076
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87967356  1.04258560  0.40833528  1
+  C  C1  1  0.39901189  0.22546197  1.18662258  1
+  C  C2  1  0.20195289  0.69866202  0.11088288  1
+  C  C3  1  0.65679050  0.28188906  0.61473715  1
+  C  C4  1  1.07860308  0.56956401  0.48375350  1
+  C  C5  1  0.62347048  0.98624255  0.98005241  1
+",-154.31370666666666
+10104,C-96709-3568-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.58953000
+_cell_length_b   4.39767000
+_cell_length_c   4.69164000
+_cell_angle_alpha   121.69265000
+_cell_angle_beta   109.43054000
+_cell_angle_gamma   86.29746000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   58.86415942
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.86233447  1.03292244  0.21702682  1
+  C  C1  1  0.52274151  0.20536179  0.33305010  1
+  C  C2  1  0.30533026  0.49120224  0.84305577  1
+  C  C3  1  0.72161093  0.63828294  0.95680768  1
+  C  C4  1  1.11054859  0.12496249  1.04056459  1
+  C  C5  1  0.07976949  0.74710356  0.70701498  1
+  C  C6  1  0.08814954  0.47926544  1.06561052  1
+  C  C7  1  0.27416642  0.11342270  0.50937853  1
+  C  C8  1  0.29692538  -0.24080034  0.48445459  1
+  C  C9  1  0.66319821  0.60012064  0.59305462  1
+",-154.15427400000002
+6078,C-113048-91-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48755000
+_cell_length_b   4.06228000
+_cell_length_c   4.69332000
+_cell_angle_alpha   74.01791000
+_cell_angle_beta   90.01634000
+_cell_angle_gamma   90.01605000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.59343928
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.42477673  0.23048981  0.16324555  1
+  C  C1  1  -0.07551918  0.66595450  0.74051014  1
+  C  C2  1  0.42548341  0.89737047  1.09413431  1
+  C  C3  1  0.42457192  0.23837238  0.51159669  1
+  C  C4  1  0.92474253  0.46416631  0.51612444  1
+  C  C5  1  0.42464365  0.88994546  0.74594566  1
+  C  C6  1  0.92475356  0.43147948  0.04886782  1
+  C  C7  1  -0.07430381  0.69608198  0.20823180  1
+",-154.36007875
+4159,C-136225-3934-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47419000
+_cell_length_b   4.23359000
+_cell_length_c   5.99446000
+_cell_angle_alpha   89.99984000
+_cell_angle_beta   114.36778000
+_cell_angle_gamma   89.99836000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.19659256
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.95505584  0.24840884  0.20914370  1
+  C  C1  1  0.43509774  0.75181002  0.18895917  1
+  C  C2  1  0.08627417  0.22829745  0.84284647  1
+  C  C3  1  0.58618340  0.44919913  0.84279932  1
+  C  C4  1  0.84946147  0.57982541  0.10300102  1
+  C  C5  1  0.32352791  0.57986619  0.58201980  1
+  C  C6  1  0.73661898  0.75169527  0.49509498  1
+  C  C7  1  0.82235269  0.09155691  0.58062266  1
+  C  C8  1  0.35089907  0.09164523  1.10455109  1
+  C  C9  1  1.21839444  0.24832155  0.47635480  1
+",-154.354793
+2657,C-189722-5605-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45467000
+_cell_length_b   5.67596000
+_cell_length_c   4.13211000
+_cell_angle_alpha   127.39462000
+_cell_angle_beta   90.04765000
+_cell_angle_gamma   102.34475000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.04322163
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.53526531  0.57745062  0.08107839  1
+  C  C1  1  0.10858665  0.72471768  0.17952742  1
+  C  C2  1  0.80512995  0.12517498  0.26421016  1
+  C  C3  1  0.36370775  0.23880801  0.86401295  1
+  C  C4  1  0.27539111  1.06283376  0.39412567  1
+  C  C5  1  0.83195703  0.17605657  0.99387001  1
+",-154.15692266666667
+4726,C-13909-5753-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.53617000
+_cell_length_b   2.45571000
+_cell_length_c   6.44800000
+_cell_angle_alpha   89.43431000
+_cell_angle_beta   80.38593000
+_cell_angle_gamma   87.62124000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.56045257
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.09062213  0.46077363  0.48639596  1
+  C  C1  1  0.96733899  0.46054177  0.70794333  1
+  C  C2  1  0.90648406  -0.03973723  0.81501816  1
+  C  C3  1  0.25236112  0.96091369  0.14895775  1
+  C  C4  1  0.14765008  0.96115246  0.37990212  1
+  C  C5  1  0.79571893  0.96027418  0.04557488  1
+",-154.08890766666667
+6821,C-126143-7642-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.51539000
+_cell_length_b   3.51380000
+_cell_length_c   3.32158000
+_cell_angle_alpha   90.00762000
+_cell_angle_beta   90.00501000
+_cell_angle_gamma   60.03887000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.54641994
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.93836210  0.93681017  1.06171312  1
+  C  C1  1  0.93831921  0.63297859  0.39580230  1
+  C  C2  1  0.47462260  0.16914265  0.89589888  1
+  C  C3  1  0.24271720  0.63268890  0.72789897  1
+  C  C4  1  0.17062102  0.16907447  0.22807647  1
+  C  C5  1  0.47478347  -0.13524697  0.56176767  1
+",-154.40810333333334
+4655,C-102915-7408-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48801000
+_cell_length_b   4.30468000
+_cell_length_c   4.30405000
+_cell_angle_alpha   80.41820000
+_cell_angle_beta   73.20470000
+_cell_angle_gamma   90.00066000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.45819691
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.12394329  0.76942239  0.37267809  1
+  C  C1  1  0.87411116  0.01946534  0.87269383  1
+  C  C2  1  1.06113749  1.08186838  0.49779224  1
+  C  C3  1  0.37403742  0.51945435  0.87269943  1
+  C  C4  1  0.31113892  0.83190882  0.99776689  1
+  C  C5  1  0.56096096  0.58186121  0.49778514  1
+  C  C6  1  0.81109473  0.33190233  0.99781268  1
+  C  C7  1  0.62407663  0.26942068  0.37271469  1
+",-154.54602375
+10140,C-40126-7915-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.51659000
+_cell_length_b   3.31976000
+_cell_length_c   3.51798000
+_cell_angle_alpha   90.00038000
+_cell_angle_beta   59.94420000
+_cell_angle_gamma   89.99724000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.54740913
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.26448183  0.34594955  0.72332940  1
+  C  C1  1  0.72890536  0.84594860  0.18725447  1
+  C  C2  1  0.03294997  0.51353976  0.18716651  1
+  C  C3  1  -0.03927614  0.01348688  0.72344819  1
+  C  C4  1  0.26486001  0.67877435  0.41918551  1
+  C  C5  1  0.72893258  0.17882597  0.49109192  1
+",-154.4097745
+8497,C-142789-7601-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47988000
+_cell_length_b   2.47958000
+_cell_length_c   9.23517000
+_cell_angle_alpha   89.97438000
+_cell_angle_beta   66.24290000
+_cell_angle_gamma   59.95688000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.51695429
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.00682895  0.34902454  0.30579210  1
+  C  C1  1  0.16061046  0.26538584  0.55439149  1
+  C  C2  1  0.53229604  0.57934298  0.86903906  1
+  C  C3  1  0.37010127  0.16038007  0.11743606  1
+  C  C4  1  0.53488393  0.07797903  0.36842642  1
+  C  C5  1  1.16196632  0.76472415  0.05483559  1
+  C  C6  1  0.70245318  0.99413874  0.61709074  1
+  C  C7  1  0.32406874  0.18362674  0.80640204  1
+",-154.53717375
+4622,C-107748-2637-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44315000
+_cell_length_b   5.38552000
+_cell_length_c   8.20295000
+_cell_angle_alpha   56.23964000
+_cell_angle_beta   73.18071000
+_cell_angle_gamma   63.30140000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   80.04952413
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71718705  1.28350075  0.92950385  1
+  C  C1  1  0.90140275  0.59011341  0.43962210  1
+  C  C2  1  0.54510105  0.59598329  0.79185951  1
+  C  C3  1  0.40049563  0.26666763  0.26365806  1
+  C  C4  1  0.28785212  0.11542501  0.02750090  1
+  C  C5  1  0.19540002  0.25016277  0.48830824  1
+  C  C6  1  -0.23247528  1.08167593  0.58596447  1
+  C  C7  1  0.57808540  0.77535112  0.07618078  1
+  C  C8  1  0.07903727  0.09935457  0.25141286  1
+  C  C9  1  1.28486951  0.75187332  0.39484725  1
+  C  C10  1  -0.05717498  0.76856351  0.72223767  1
+  C  C11  1  0.19610596  0.61385680  0.11987190  1
+",-154.15718916666663
+8275,C-141055-6281-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44503000
+_cell_length_b   5.19907000
+_cell_length_c   5.46538000
+_cell_angle_alpha   114.56144000
+_cell_angle_beta   90.00323000
+_cell_angle_gamma   89.99633000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   63.18887030
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.99247601  0.86672497  0.57564570  1
+  C  C1  1  0.49259563  0.20108748  0.19691231  1
+  C  C2  1  0.49269036  0.51121809  0.30772068  1
+  C  C3  1  -0.00905999  0.17676071  0.68755968  1
+  C  C4  1  0.49264119  0.72250871  0.61910177  1
+  C  C5  1  0.99268483  0.65594737  0.26397268  1
+  C  C6  1  0.49220639  0.63175463  0.85329918  1
+  C  C7  1  0.99234895  0.05936191  0.14249030  1
+  C  C8  1  0.49041634  0.31787310  0.74012520  1
+  C  C9  1  -0.00759702  0.74493413  1.02894528  1
+",-154.194254
+5382,C-80178-6213-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.37650000
+_cell_length_b   3.50912000
+_cell_length_c   6.56709000
+_cell_angle_alpha   80.71537000
+_cell_angle_beta   97.65029000
+_cell_angle_gamma   93.37956000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   76.05167797
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64699261  0.53630711  0.11040043  1
+  C  C1  1  0.73747676  0.59245914  0.89031557  1
+  C  C2  1  0.00946141  0.66341499  0.22658845  1
+  C  C3  1  0.42708218  -0.27637141  0.54329571  1
+  C  C4  1  0.76294366  0.40449764  0.54950798  1
+  C  C5  1  1.08925788  -0.07663788  0.87381067  1
+  C  C6  1  0.98330000  0.33818633  0.77915973  1
+  C  C7  1  0.33712912  0.66856679  0.76340331  1
+  C  C8  1  -0.48997376  0.16224680  0.22160861  1
+  C  C9  1  0.31018377  0.85746192  0.10378578  1
+  C  C10  1  0.06643010  0.59487023  0.42701393  1
+  C  C11  1  0.56724727  0.09682676  0.43189303  1
+",-154.06614249999998
+7039,C-13655-7913-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.57741000
+_cell_length_b   4.24451000
+_cell_length_c   4.64805000
+_cell_angle_alpha   81.85263000
+_cell_angle_beta   101.49041000
+_cell_angle_gamma   104.40548000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   48.03508643
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.70570693  0.13974359  0.40173461  1
+  C  C1  1  0.99993345  0.10131897  -0.05758295  1
+  C  C2  1  0.40103058  0.62515544  0.15530681  1
+  C  C3  1  0.61552310  0.78145937  0.43127328  1
+  C  C4  1  0.90873536  0.74305324  0.97187887  1
+  C  C5  1  0.78855743  0.60467969  0.68545355  1
+  C  C6  1  0.21441607  0.25819633  0.21820973  1
+  C  C7  1  -0.17475453  0.27759536  0.68828199  1
+",-154.157245
+8976,C-13919-5282-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.40790000
+_cell_length_b   4.57565000
+_cell_length_c   6.87016000
+_cell_angle_alpha   103.12378000
+_cell_angle_beta   107.67782000
+_cell_angle_gamma   59.31594000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   87.43930021
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.66330882  0.53364097  0.80047228  1
+  C  C1  1  1.00692425  0.28816585  0.36171257  1
+  C  C2  1  0.39888472  0.02419449  0.07741118  1
+  C  C3  1  0.02359164  0.96680008  0.37634477  1
+  C  C4  1  1.02506039  -0.03952525  0.56942106  1
+  C  C5  1  0.60826409  0.42608524  0.98393503  1
+  C  C6  1  0.20770233  0.75654971  0.03504529  1
+  C  C7  1  1.02119368  0.37522843  0.17055929  1
+  C  C8  1  0.04965576  0.24549947  0.70250152  1
+  C  C9  1  0.85074759  0.79834305  0.84065896  1
+  C  C10  1  0.07301100  0.41969048  0.55530985  1
+  C  C11  1  0.13573559  0.69254405  0.67586804  1
+  C  C12  1  0.46508217  0.13519493  0.89275342  1
+  C  C13  1  0.95640146  0.76290070  0.18599564  1
+",-154.08300357142858
+3837,C-145331-9653-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.75391000
+_cell_length_b   3.74882000
+_cell_length_c   5.69782000
+_cell_angle_alpha   89.98679000
+_cell_angle_beta   89.56732000
+_cell_angle_gamma   89.90289000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   58.82203414
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.02929662  0.95186544  -0.02567082  1
+  C  C1  1  0.02974773  0.57730581  0.51190721  1
+  C  C2  1  0.02947693  0.26346162  0.12120451  1
+  C  C3  1  0.02968130  0.95226174  0.51212466  1
+  C  C4  1  1.02946894  0.57719799  -0.02552828  1
+  C  C5  1  0.02940265  0.26367918  0.36397620  1
+  C  C6  1  1.02966647  0.08241870  0.74328162  1
+  C  C7  1  1.02960736  0.44670191  0.74323422  1
+",-154.07520125
+964,C-104312-1953-56,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49325000
+_cell_length_b   4.49805000
+_cell_length_c   9.73766000
+_cell_angle_alpha   83.62861000
+_cell_angle_beta   82.64105000
+_cell_angle_gamma   90.00413000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   107.62578074
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.44459928  -0.27816161  0.27141192  1
+  C  C1  1  0.90089917  0.65298736  0.35675359  1
+  C  C2  1  0.67659006  1.13932653  0.80755948  1
+  C  C3  1  0.63262952  0.85089059  0.89405594  1
+  C  C4  1  0.29037604  0.75516464  0.58043313  1
+  C  C5  1  0.28916407  1.10178081  0.58331735  1
+  C  C6  1  0.83473310  0.77881583  0.49149687  1
+  C  C7  1  0.48901875  0.02713539  0.18014114  1
+  C  C8  1  0.44295027  0.28419746  0.27382866  1
+  C  C9  1  0.83379123  0.12469584  0.49360484  1
+  C  C10  1  0.22119781  0.57023709  0.71671408  1
+  C  C11  1  0.08338570  0.36564281  -0.00646817  1
+  C  C12  1  1.03479223  0.05630845  0.09030411  1
+  C  C13  1  -0.37396676  0.36264784  0.90826423  1
+  C  C14  1  0.08769339  0.80958138  0.98513782  1
+  C  C15  1  0.89955767  0.31454973  0.35865214  1
+  C  C16  1  0.21944647  0.22203559  0.71999695  1
+  C  C17  1  0.68019611  0.61829667  0.80091853  1
+",-154.09762555555554
+946,C-152597-8815-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47174000
+_cell_length_b   4.50196000
+_cell_length_c   7.27581000
+_cell_angle_alpha   88.75257000
+_cell_angle_beta   99.80891000
+_cell_angle_gamma   123.28450000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   66.43866383
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.04783004  0.52872647  0.57075559  1
+  C  C1  1  0.37153600  0.22758091  0.81821054  1
+  C  C2  1  0.38685832  0.15496739  -0.00430410  1
+  C  C3  1  0.41899498  0.90023087  0.56761325  1
+  C  C4  1  0.93160363  1.14507396  0.10549780  1
+  C  C5  1  0.41001447  0.99010112  0.37114888  1
+  C  C6  1  0.33060926  0.46694504  0.26083290  1
+  C  C7  1  -0.17932396  0.23435855  0.70383294  1
+  C  C8  1  0.72838984  0.86624382  0.25687628  1
+  C  C9  1  0.79861151  0.37798836  0.37339731  1
+",-154.07046
+1438,C-152587-3980-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.61151000
+_cell_length_b   4.64580000
+_cell_length_c   3.67770000
+_cell_angle_alpha   113.35732000
+_cell_angle_beta   89.91574000
+_cell_angle_gamma   105.21905000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   39.26065178
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.00001890  0.49138830  0.44061075  1
+  C  C1  1  0.28746497  0.04716022  0.53159587  1
+  C  C2  1  0.40333072  0.27933322  0.33516130  1
+  C  C3  1  0.11497351  0.72413008  0.86960552  1
+  C  C4  1  0.11558455  0.72444710  0.24494059  1
+  C  C5  1  0.28704684  0.04710509  0.90667727  1
+",-154.09579716666667
+5643,C-130544-211-40,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48201000
+_cell_length_b   4.39656000
+_cell_length_c   7.32381000
+_cell_angle_alpha   114.15580000
+_cell_angle_beta   89.99388000
+_cell_angle_gamma   124.38230000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.28010732
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.02080366  0.23453182  0.11795155  1
+  C  C1  1  0.14815765  0.86253972  0.50717226  1
+  C  C2  1  0.57827045  0.79261996  0.93612465  1
+  C  C3  1  0.83790624  0.55235506  0.93613152  1
+  C  C4  1  1.21009706  0.92378018  0.31260027  1
+  C  C5  1  -0.04033160  0.17335351  0.31268665  1
+  C  C6  1  0.32913107  0.54385752  0.68795809  1
+  C  C7  1  0.40880628  0.62322902  0.50712062  1
+  C  C8  1  0.58908201  0.30389217  0.68797591  1
+  C  C9  1  0.76048848  0.47423784  0.11797668  1
+",-154.299647
+1466,C-47646-615-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45083000
+_cell_length_b   5.42115000
+_cell_length_c   7.61552000
+_cell_angle_alpha   82.84700000
+_cell_angle_beta   95.18125000
+_cell_angle_gamma   89.69438000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   99.97044464
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.19461748  0.46520023  1.00304670  1
+  C  C1  1  0.26343105  0.42289734  0.72084211  1
+  C  C2  1  0.81743494  0.57268484  0.16616414  1
+  C  C3  1  0.40771894  -0.06740840  1.04410566  1
+  C  C4  1  -0.34094812  1.00505689  0.42634059  1
+  C  C5  1  0.33815082  0.97564165  0.86834546  1
+  C  C6  1  0.24446246  0.67784040  0.61210667  1
+  C  C7  1  0.94626154  -0.13681216  0.14403231  1
+  C  C8  1  0.28446375  0.44582399  0.91498977  1
+  C  C9  1  0.20993035  0.64104289  0.42042869  1
+  C  C10  1  0.71367294  0.50501320  0.35850271  1
+  C  C11  1  0.11971820  0.90678103  0.33768814  1
+  C  C12  1  0.80072225  1.01293860  0.76195235  1
+  C  C13  1  0.70475319  0.26110454  0.46817975  1
+  C  C14  1  0.74019593  0.83896657  0.61758239  1
+  C  C15  1  0.75653765  0.28247219  0.66433996  1
+",-154.082499375
+1629,C-150703-3455-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.49245000
+_cell_length_b   5.51996000
+_cell_length_c   7.57098000
+_cell_angle_alpha   95.26047000
+_cell_angle_beta   88.02566000
+_cell_angle_gamma   94.26276000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   103.39752054
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.67119723  0.20926421  0.42184720  1
+  C  C1  1  0.71601279  0.41278521  0.09329897  1
+  C  C2  1  0.15748645  0.81331829  0.07680551  1
+  C  C3  1  0.65517902  0.66366834  1.01528492  1
+  C  C4  1  0.77549458  0.46833466  0.49413426  1
+  C  C5  1  0.15771859  0.16933563  0.30912237  1
+  C  C6  1  1.06218823  1.02156090  0.64756860  1
+  C  C7  1  1.14843896  0.84820045  0.78770257  1
+  C  C8  1  0.21983427  0.39273407  0.21001797  1
+  C  C9  1  0.88276538  0.25821607  0.76072598  1
+  C  C10  1  0.64462760  0.68750778  0.81060915  1
+  C  C11  1  0.07268491  0.89685993  0.26735416  1
+  C  C12  1  0.75405097  0.18795086  0.94914234  1
+  C  C13  1  0.21418194  1.02207737  -0.04359098  1
+  C  C14  1  0.50911867  0.81864490  0.37060789  1
+  C  C15  1  0.57398692  0.00480939  0.53340749  1
+  C  C16  1  0.74296202  0.46213037  0.69351021  1
+  C  C17  1  0.32339827  0.56272547  0.39882799  1
+",-154.10672666666667
+1089,C-72724-7897-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48322000
+_cell_length_b   6.63667000
+_cell_length_c   5.70003000
+_cell_angle_alpha   59.64995000
+_cell_angle_beta   77.44123000
+_cell_angle_gamma   90.00912000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   78.44688837
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.38209100  0.66483042  0.69883444  1
+  C  C1  1  0.97373375  0.72317681  0.51507952  1
+  C  C2  1  0.55761656  0.23917861  0.34719596  1
+  C  C3  1  0.57192307  0.49491726  0.31877047  1
+  C  C4  1  0.39579592  0.06498508  0.67204866  1
+  C  C5  1  0.12765746  0.20896950  0.20892887  1
+  C  C6  1  0.30338990  0.78542396  0.85580239  1
+  C  C7  1  0.85259726  0.33797246  0.76353210  1
+  C  C8  1  0.29216029  0.38474842  0.88326920  1
+  C  C9  1  0.11658777  0.95402008  0.23626194  1
+  C  C10  1  0.00105233  0.51644497  0.46189929  1
+  C  C11  1  0.68833537  0.93265118  0.09309701  1
+  C  C12  1  0.83731003  0.11143394  0.79169819  1
+  C  C13  1  0.71199429  0.72651361  0.03984275  1
+",-154.37573
+9311,C-157695-2388-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42888000
+_cell_length_b   4.86961000
+_cell_length_c   5.88397000
+_cell_angle_alpha   52.75849000
+_cell_angle_beta   89.96799000
+_cell_angle_gamma   60.13586000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.24622344
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.56852853  0.50201044  0.79429566  1
+  C  C1  1  0.93670152  0.63399934  0.22846111  1
+  C  C2  1  0.64803114  0.92237694  0.87972532  1
+  C  C3  1  0.85740427  0.21361943  0.73433188  1
+  C  C4  1  0.56832983  0.50221157  0.38563179  1
+  C  C5  1  -0.06291339  0.63384909  0.81959385  1
+",-154.31101883333335
+7393,C-177244-4718-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48536000
+_cell_length_b   4.78093000
+_cell_length_c   4.68036000
+_cell_angle_alpha   92.25451000
+_cell_angle_beta   74.60031000
+_cell_angle_gamma   121.35379000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.45614742
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.03673836  0.64138420  0.18675979  1
+  C  C1  1  0.78830662  0.17748707  0.75749948  1
+  C  C2  1  0.51295684  0.40341069  0.76002146  1
+  C  C3  1  0.99681579  0.11558362  0.21580579  1
+  C  C4  1  0.45054505  0.99692944  0.07106090  1
+  C  C5  1  -0.06459000  0.70953244  0.52731714  1
+  C  C6  1  0.66003602  -0.06442529  0.52940346  1
+  C  C7  1  0.40943103  0.47159773  0.10099878  1
+",-154.36625125
+7290,C-80148-5004-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48446000
+_cell_length_b   4.67759000
+_cell_length_c   4.08790000
+_cell_angle_alpha   83.29644000
+_cell_angle_beta   89.99697000
+_cell_angle_gamma   105.46714000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.44897092
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.43760714  0.39000465  0.17725680  1
+  C  C1  1  0.72143301  0.96278122  0.93819597  1
+  C  C2  1  -0.21938053  0.07689359  0.58255420  1
+  C  C3  1  -0.06150380  0.39166982  0.40313353  1
+  C  C4  1  0.54938009  0.62061040  -0.12869337  1
+  C  C5  1  0.04840762  0.61804117  0.64521684  1
+  C  C6  1  1.20782436  0.93271340  0.46480879  1
+  C  C7  1  0.26555700  1.04878925  0.10903944  1
+",-154.36743125
+4615,C-177224-1603-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43224000
+_cell_length_b   4.20390000
+_cell_length_c   6.11490000
+_cell_angle_alpha   72.57863000
+_cell_angle_beta   76.22108000
+_cell_angle_gamma   89.79598000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.78430218
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.79100872  0.22083321  0.81338725  1
+  C  C1  1  0.40960274  0.64605955  0.31495826  1
+  C  C2  1  0.29101539  0.72084759  0.81338509  1
+  C  C3  1  0.90916241  0.47898571  0.31480906  1
+  C  C4  1  0.90959075  0.14601796  0.31495479  1
+  C  C5  1  0.40915855  0.97903027  0.31480227  1
+  C  C6  1  0.29057405  0.05378002  0.81329605  1
+  C  C7  1  0.79056218  0.55377458  0.81329553  1
+",-154.45941375
+310,C-176646-2657-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48294000
+_cell_length_b   3.84001000
+_cell_length_c   3.75075000
+_cell_angle_alpha   89.94344000
+_cell_angle_beta   89.98654000
+_cell_angle_gamma   89.97086000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.76155696
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64347650  0.69515070  0.68898314  1
+  C  C1  1  0.14355203  -0.00998708  0.18528987  1
+  C  C2  1  0.14345506  0.69547036  0.91741408  1
+  C  C3  1  1.14360183  0.40114095  0.18567248  1
+  C  C4  1  0.64352621  0.98978242  0.42073495  1
+  C  C5  1  0.64356747  0.40091456  0.42105769  1
+",-154.16278033333333
+8401,C-107764-2694-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.36085000
+_cell_length_b   4.18980000
+_cell_length_c   5.20521000
+_cell_angle_alpha   102.33314000
+_cell_angle_beta   118.39390000
+_cell_angle_gamma   104.23226000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.61372521
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.28590674  -0.00996315  0.47247024  1
+  C  C1  1  0.53010162  0.70638184  1.00118750  1
+  C  C2  1  0.07829639  0.54430422  0.70943331  1
+  C  C3  1  0.77253252  0.23207362  0.71546017  1
+  C  C4  1  -0.01913626  0.99461407  0.16187050  1
+  C  C5  1  0.97887799  0.67917172  0.47899684  1
+  C  C6  1  0.07713009  0.22950275  0.02703176  1
+  C  C7  1  0.52640921  0.51996902  0.18825327  1
+",-154.19538
+5324,C-189726-6424-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44389000
+_cell_length_b   4.13218000
+_cell_length_c   10.58338000
+_cell_angle_alpha   80.56818000
+_cell_angle_beta   90.00005000
+_cell_angle_gamma   89.99836000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   105.43241011
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87371891  0.80698066  -0.00836955  1
+  C  C1  1  0.87364224  0.36483994  0.14488466  1
+  C  C2  1  0.87359957  0.17941616  0.76232776  1
+  C  C3  1  0.87363116  0.47011896  0.39731776  1
+  C  C4  1  0.37363979  0.62893567  0.57536643  1
+  C  C5  1  0.37361180  0.32072534  -0.05415961  1
+  C  C6  1  0.37365876  0.70309404  0.70924358  1
+  C  C7  1  0.87365498  -0.11659005  0.72943568  1
+  C  C8  1  0.37368576  -0.03421078  -0.01341431  1
+  C  C9  1  0.37358361  0.34864252  0.79385559  1
+  C  C10  1  0.37365968  1.42095750  0.33817318  1
+  C  C11  1  -0.12637029  0.44891535  0.00223191  1
+  C  C12  1  0.37364985  0.36623642  0.20966121  1
+  C  C13  1  0.87363158  0.57903246  0.51731801  1
+",-154.24225857142855
+4974,C-130561-7361-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.34283000
+_cell_length_b   3.94475000
+_cell_length_c   4.13499000
+_cell_angle_alpha   73.19958000
+_cell_angle_beta   100.35837000
+_cell_angle_gamma   120.90860000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.75371137
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71746753  0.83876652  0.11761580  1
+  C  C1  1  0.68369226  0.10946978  0.81027369  1
+  C  C2  1  0.33732186  0.45613558  0.11836862  1
+  C  C3  1  0.27910325  0.89520314  0.61785402  1
+  C  C4  1  1.12243065  0.05243408  0.30997624  1
+  C  C5  1  0.06623135  0.49118170  0.80904823  1
+",-154.12947416666665
+7441,C-90827-1320-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44011000
+_cell_length_b   5.17131000
+_cell_length_c   7.37012000
+_cell_angle_alpha   74.78962000
+_cell_angle_beta   84.71408000
+_cell_angle_gamma   83.87123000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   89.03006584
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.86327702  0.50659360  0.58535906  1
+  C  C1  1  0.78113606  0.11070985  0.88931170  1
+  C  C2  1  0.78815152  0.90691466  0.77449948  1
+  C  C3  1  0.55458232  0.42123195  0.13136320  1
+  C  C4  1  0.24459813  0.28796103  0.87456598  1
+  C  C5  1  0.32832507  0.52446714  0.69222565  1
+  C  C6  1  0.10021988  0.38191476  0.05025243  1
+  C  C7  1  0.84833397  0.92995596  1.08573772  1
+  C  C8  1  0.30909365  0.79201557  0.74372011  1
+  C  C9  1  0.36147272  0.82220367  0.16036765  1
+  C  C10  1  0.43578346  0.54531313  0.29400490  1
+  C  C11  1  -0.08790110  0.50629248  0.40592512  1
+",-154.08948999999998
+5378,C-136208-4716-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47764000
+_cell_length_b   2.47882000
+_cell_length_c   6.77777000
+_cell_angle_alpha   89.97517000
+_cell_angle_beta   111.39159000
+_cell_angle_gamma   120.04985000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.68062713
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.38004841  1.03352027  0.38309519  1
+  C  C1  1  1.04569687  0.86593628  0.13222412  1
+  C  C2  1  -0.17542379  -0.24390217  0.46709176  1
+  C  C3  1  0.26732976  0.47693023  1.04873289  1
+  C  C4  1  0.93729485  0.31268788  0.80145406  1
+  C  C5  1  0.15892775  0.92368183  0.71796283  1
+",-154.53558033333334
+326,C-150731-2921-62,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50155000
+_cell_length_b   8.16478000
+_cell_length_c   6.71764000
+_cell_angle_alpha   104.74968000
+_cell_angle_beta   72.83119000
+_cell_angle_gamma   115.50924000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C20
+_cell_volume   117.01198090
+_cell_formula_units_Z   20
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.54816939  0.21623144  0.08167534  1
+  C  C1  1  0.40170047  0.90549116  0.78724827  1
+  C  C2  1  0.33215255  0.21688384  0.79487415  1
+  C  C3  1  0.84631969  0.61624666  -0.05800804  1
+  C  C4  1  0.63949750  0.51927180  0.41008277  1
+  C  C5  1  0.14838100  0.82199903  0.99395846  1
+  C  C6  1  0.70424734  0.33835232  0.62263343  1
+  C  C7  1  0.58271344  0.03897765  0.30634322  1
+  C  C8  1  0.62935176  0.87115861  0.12833532  1
+  C  C9  1  0.45811936  0.50969443  0.08008105  1
+  C  C10  1  0.25771139  0.15606650  0.29941966  1
+  C  C11  1  0.12156983  0.87751715  0.43529249  1
+  C  C12  1  0.94680417  0.54793902  0.71911289  1
+  C  C13  1  0.30656575  0.57753948  0.30261481  1
+  C  C14  1  0.53935486  0.78395963  0.32480681  1
+  C  C15  1  0.23499787  0.31471020  0.02550265  1
+  C  C16  1  0.89516114  0.83780391  0.66089923  1
+  C  C17  1  0.62362727  0.62486118  0.62868946  1
+  C  C18  1  0.63763753  0.11054592  0.84243747  1
+  C  C19  1  0.31313926  0.32475257  0.47839286  1
+",-154.1212055
+4407,C-126163-8054-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46845000
+_cell_length_b   3.37684000
+_cell_length_c   5.22632000
+_cell_angle_alpha   90.72213000
+_cell_angle_beta   89.97404000
+_cell_angle_gamma   111.39596000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.55829917
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.83415762  0.20445199  0.28888497  1
+  C  C1  1  0.87619078  0.28559902  0.01465045  1
+  C  C2  1  0.46484415  0.46276785  0.89011916  1
+  C  C3  1  0.68891504  -0.09259187  0.81288055  1
+  C  C4  1  0.27633193  0.08287609  0.68796570  1
+  C  C5  1  0.30926479  1.15488883  0.41300507  1
+",-154.15492883333334
+7151,C-189734-3200-20,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47098000
+_cell_length_b   3.35780000
+_cell_length_c   5.17931000
+_cell_angle_alpha   86.51627000
+_cell_angle_beta   89.72427000
+_cell_angle_gamma   68.87283000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.00368529
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.99995367  0.89511028  0.69889440  1
+  C  C1  1  0.04333261  0.80854092  0.42537734  1
+  C  C2  1  0.43394501  0.03225172  0.09516511  1
+  C  C3  1  0.84979677  0.20175146  0.21932205  1
+  C  C4  1  0.62748309  0.63954626  0.30112616  1
+  C  C5  1  0.47039515  0.95398156  0.82064175  1
+",-154.13529966666667
+9674,C-41298-1814-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.59263000
+_cell_length_b   4.35295000
+_cell_length_c   2.48988000
+_cell_angle_alpha   73.37590000
+_cell_angle_beta   69.68323000
+_cell_angle_gamma   84.29314000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98937407
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.73593363  0.34202737  0.38980606  1
+  C  C1  1  0.47587841  0.34180730  0.02069159  1
+  C  C2  1  0.47636316  -0.03416193  1.20781005  1
+  C  C3  1  0.10587588  0.76008063  0.49611777  1
+  C  C4  1  0.73628608  0.96604353  0.57763869  1
+  C  C5  1  0.10550753  0.54765870  0.10322863  1
+",-154.19430466666668
+8460,C-176644-8612-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.86039000
+_cell_length_b   4.20391000
+_cell_length_c   4.20487000
+_cell_angle_alpha   59.97710000
+_cell_angle_beta   89.30444000
+_cell_angle_gamma   94.37833000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.57654939
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.94022481  1.03187873  0.66031761  1
+  C  C1  1  -0.05992496  0.03185600  0.32691945  1
+  C  C2  1  -0.05989638  0.36514830  0.66033060  1
+  C  C3  1  -0.05981433  0.36519379  0.99370110  1
+  C  C4  1  0.94005572  0.69847328  0.32691310  1
+  C  C5  1  0.94032074  0.69856240  0.99354705  1
+",-154.38718566666668
+2717,C-13893-8599-10,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42635000
+_cell_length_b   4.22440000
+_cell_length_c   6.37489000
+_cell_angle_alpha   130.25441000
+_cell_angle_beta   112.35393000
+_cell_angle_gamma   89.94274000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.25852981
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.44562129  0.29704266  0.16898134  1
+  C  C1  1  0.51147657  0.42857485  0.73474425  1
+  C  C2  1  0.85543895  0.29725102  0.57828966  1
+  C  C3  1  0.50594307  1.00870953  0.22935994  1
+  C  C4  1  -0.07925477  0.42851861  0.14389976  1
+  C  C5  1  0.86063210  0.71701943  0.08362175  1
+",-154.31109566666666
+9243,C-136255-5449-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43240000
+_cell_length_b   3.02514000
+_cell_length_c   6.40321000
+_cell_angle_alpha   78.68754000
+_cell_angle_beta   100.79399000
+_cell_angle_gamma   110.66875000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.86869945
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.45959383  0.83437797  0.47596263  1
+  C  C1  1  0.23533385  0.83236564  0.03092389  1
+  C  C2  1  0.79302683  0.83515136  0.14233278  1
+  C  C3  1  1.12635932  0.83532754  0.80877214  1
+  C  C4  1  -0.09809914  -0.16840775  0.36455375  1
+  C  C5  1  0.56856837  0.83141607  0.69811438  1
+",-154.43318466666668
+2089,C-152558-909-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44609000
+_cell_length_b   3.35259000
+_cell_length_c   9.89633000
+_cell_angle_alpha   105.77384000
+_cell_angle_beta   75.68159000
+_cell_angle_gamma   111.57408000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   71.63816936
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76309105  0.09204436  0.77907883  1
+  C  C1  1  0.44568162  0.00505704  0.55243449  1
+  C  C2  1  0.33200136  1.08615964  0.70695380  1
+  C  C3  1  0.29579825  0.03297054  0.21472962  1
+  C  C4  1  0.17681751  0.10343788  0.36899349  1
+  C  C5  1  0.86836645  0.03245847  0.14272278  1
+  C  C6  1  0.71193505  0.31910314  0.44190289  1
+  C  C7  1  0.90795335  -0.21196959  0.48039495  1
+  C  C8  1  0.02729775  1.05183842  -0.00395425  1
+  C  C9  1  0.61056901  1.07671270  0.92591340  1
+",-154.241031
+1257,C-40104-915-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.80872000
+_cell_length_b   4.80943000
+_cell_length_c   7.32477000
+_cell_angle_alpha   131.13268000
+_cell_angle_beta   81.76194000
+_cell_angle_gamma   105.77401000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   71.63186951
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.33131049  -0.05298783  0.23751146  1
+  C  C1  1  0.33780642  0.43094266  0.72129951  1
+  C  C2  1  0.32941954  0.56429134  0.10108489  1
+  C  C3  1  0.32648865  0.45388244  0.23681105  1
+  C  C4  1  0.33113258  0.07449487  0.11125571  1
+  C  C5  1  0.33290710  0.78770369  0.47903692  1
+  C  C6  1  0.33221895  0.32003804  0.85713021  1
+  C  C7  1  0.33158626  0.80994530  0.84703596  1
+  C  C8  1  1.33290098  1.09722578  0.47920186  1
+  C  C9  1  0.33241284  0.93780331  0.72077322  1
+",-154.198809
+4567,C-40126-7915-11,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48082000
+_cell_length_b   4.83704000
+_cell_length_c   4.21844000
+_cell_angle_alpha   47.45262000
+_cell_angle_beta   89.93874000
+_cell_angle_gamma   75.07605000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.95384703
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.68404449  0.87196517  0.49488897  1
+  C  C1  1  0.13702484  -0.03953515  0.91079039  1
+  C  C2  1  0.46006460  0.31805103  0.25540445  1
+  C  C3  1  0.71540991  0.80379596  0.19831006  1
+  C  C4  1  -0.05982768  0.35776666  0.43763309  1
+  C  C5  1  0.26223064  0.71539353  0.78232644  1
+",-154.30713216666666
+9259,C-80164-8806-15,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43957000
+_cell_length_b   4.14914000
+_cell_length_c   8.31861000
+_cell_angle_alpha   82.70678000
+_cell_angle_beta   98.49168000
+_cell_angle_gamma   90.00441000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   82.59014006
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87953887  0.11726155  -0.05024042  1
+  C  C1  1  0.53920824  -0.06710519  0.27310929  1
+  C  C2  1  0.36105430  0.62058179  0.91216575  1
+  C  C3  1  0.37264073  0.96570331  -0.06492194  1
+  C  C4  1  0.73356899  0.50149770  0.66371049  1
+  C  C5  1  1.27076222  0.57018052  0.73514552  1
+  C  C6  1  -0.00530869  0.46961848  0.18209491  1
+  C  C7  1  0.51546761  0.64030615  0.22216627  1
+  C  C8  1  0.05108021  0.11648227  0.29846545  1
+  C  C9  1  0.89966662  0.45121702  0.99130851  1
+  C  C10  1  0.13209025  0.22986869  0.46356805  1
+  C  C11  1  0.66413496  0.32042622  0.52723459  1
+",-154.2298525
+9441,C-172967-546-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.38080000
+_cell_length_b   2.46827000
+_cell_length_c   5.23201000
+_cell_angle_alpha   89.97504000
+_cell_angle_beta   89.62504000
+_cell_angle_gamma   111.49248000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.62278995
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.19096512  0.96462179  0.59795167  1
+  C  C1  1  0.93424450  0.33571567  0.19873030  1
+  C  C2  1  0.88653961  0.81170725  0.07419018  1
+  C  C3  1  0.01360794  0.37580955  0.47293795  1
+  C  C4  1  0.63641844  0.18929541  0.67432432  1
+  C  C5  1  0.81287368  0.77753414  0.79956299  1
+",-154.15370883333333
+3736,C-113050-8539-60,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48606000
+_cell_length_b   4.83466000
+_cell_length_c   6.67428000
+_cell_angle_alpha   80.17213000
+_cell_angle_beta   89.87202000
+_cell_angle_gamma   59.05795000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.44582019
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.10319784  0.74069501  0.84451645  1
+  C  C1  1  0.52939798  0.31207520  0.54944531  1
+  C  C2  1  0.54896093  0.29207901  0.16749201  1
+  C  C3  1  0.10786494  0.23504157  0.86096254  1
+  C  C4  1  0.73447120  1.10851271  0.77518245  1
+  C  C5  1  0.75345980  0.59051324  0.77291182  1
+  C  C6  1  0.18318799  0.65908549  1.09972046  1
+  C  C7  1  0.75123284  0.09017988  0.39276189  1
+  C  C8  1  0.53125453  0.81036684  0.17029859  1
+  C  C9  1  0.80168262  0.53957295  0.54890151  1
+  C  C10  1  0.17663805  0.16545509  0.08135862  1
+  C  C11  1  0.47814208  0.86269411  0.39364964  1
+",-154.39686
+2394,C-41290-3170-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.67002000
+_cell_length_b   4.88744000
+_cell_length_c   4.88941000
+_cell_angle_alpha   59.60740000
+_cell_angle_beta   98.14250000
+_cell_angle_gamma   75.99929000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   69.65374208
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.89380483  0.36481184  0.70313951  1
+  C  C1  1  0.34549503  0.43092555  0.21757174  1
+  C  C2  1  0.36982136  0.92395904  0.72511290  1
+  C  C3  1  0.85579160  0.65232187  0.41718318  1
+  C  C4  1  0.43446600  0.89707351  0.24484571  1
+  C  C5  1  0.31362407  0.12121170  0.87615172  1
+  C  C6  1  0.50120988  0.38969289  0.74924272  1
+  C  C7  1  0.40874166  0.58570673  0.90519869  1
+  C  C8  1  0.37612747  0.09489637  0.39506729  1
+  C  C9  1  0.24889899  0.62817260  0.37237994  1
+",-154.14167600000002
+5602,C-9594-832-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48743000
+_cell_length_b   4.06129000
+_cell_length_c   4.69837000
+_cell_angle_alpha   73.99397000
+_cell_angle_beta   89.98827000
+_cell_angle_gamma   89.98288000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.62370913
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.87875292  0.31684818  0.03810248  1
+  C  C1  1  0.87880378  0.30856024  0.69062360  1
+  C  C2  1  0.37887639  0.08247273  0.68628303  1
+  C  C3  1  0.87895327  0.65708805  0.45550118  1
+  C  C4  1  0.37900706  0.85035190  0.99367332  1
+  C  C5  1  0.37886217  0.88146825  0.46100331  1
+  C  C6  1  0.87903441  0.64912947  1.10823158  1
+  C  C7  1  0.37882780  0.11557929  0.15264079  1
+",-154.3697825
+643,C-56493-1674-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46324000
+_cell_length_b   4.56765000
+_cell_length_c   8.29785000
+_cell_angle_alpha   100.73328000
+_cell_angle_beta   93.19142000
+_cell_angle_gamma   90.89605000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   91.55310276
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.17755608  -0.00912340  0.27021723  1
+  C  C1  1  0.62353160  1.06360857  0.03602646  1
+  C  C2  1  0.62416558  0.75894608  0.95918799  1
+  C  C3  1  0.65421955  0.48957158  0.25756448  1
+  C  C4  1  1.06651233  0.32990242  0.85579523  1
+  C  C5  1  1.12001860  0.60045568  0.99608575  1
+  C  C6  1  -0.01686809  0.41236620  0.69158824  1
+  C  C7  1  0.59967772  0.84662374  0.78842388  1
+  C  C8  1  0.18024175  -0.25700062  0.51297747  1
+  C  C9  1  0.68293464  0.55825156  0.44469101  1
+  C  C10  1  0.57440590  0.16262047  0.88012054  1
+  C  C11  1  0.65949156  0.14536287  0.20951324  1
+  C  C12  1  0.76450240  0.25584812  0.52191721  1
+  C  C13  1  0.14800295  0.62772015  0.19035752  1
+  C  C14  1  0.09883598  0.73149400  0.69271087  1
+  C  C15  1  0.23008055  0.05537149  0.46096777  1
+",-154.084536875
+9795,C-41276-8743-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.40103000
+_cell_length_b   4.17366000
+_cell_length_c   4.50241000
+_cell_angle_alpha   93.70870000
+_cell_angle_beta   113.25639000
+_cell_angle_gamma   104.49676000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   55.87927856
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.43132776  0.48613026  -0.01952530  1
+  C  C1  1  0.49462563  0.18734045  0.81990801  1
+  C  C2  1  1.03825225  0.92243644  0.76277276  1
+  C  C3  1  0.65890017  0.92485584  0.45137616  1
+  C  C4  1  0.61899109  0.27306577  0.52598781  1
+  C  C5  1  0.80189149  0.78936109  0.19566163  1
+  C  C6  1  0.20245365  0.65977655  0.39407423  1
+  C  C7  1  1.07858289  0.57449436  0.68818072  1
+  C  C8  1  0.89539613  0.05756945  1.01849882  1
+  C  C9  1  0.26556963  0.36096249  0.23339096  1
+",-154.288686
+5949,C-170894-4901-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46546000
+_cell_length_b   3.21216000
+_cell_length_c   7.38406000
+_cell_angle_alpha   97.98978000
+_cell_angle_beta   99.56346000
+_cell_angle_gamma   67.31266000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   53.02239566
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.13407185  0.92765208  0.29995033  1
+  C  C1  1  0.01731124  0.32600608  0.45997706  1
+  C  C2  1  -0.08616633  0.97484400  0.90928021  1
+  C  C3  1  0.25852377  0.99917195  0.61806803  1
+  C  C4  1  0.37813308  0.60139288  0.45804077  1
+  C  C5  1  0.47249726  -0.04327751  0.00889501  1
+  C  C6  1  0.80730909  0.00776766  0.72605585  1
+  C  C7  1  0.58320165  0.92021656  0.19196624  1
+",-154.26245375
+3061,C-157672-8945-44,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.89459000
+_cell_length_b   3.63752000
+_cell_length_c   4.81679000
+_cell_angle_alpha   112.13040000
+_cell_angle_beta   87.15495000
+_cell_angle_gamma   72.01667000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.88540103
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.07524156  0.07986766  0.95431970  1
+  C  C1  1  0.07390395  0.70010233  0.95517995  1
+  C  C2  1  1.06520758  0.73766083  0.26410722  1
+  C  C3  1  0.06758028  0.14310680  0.45519557  1
+  C  C4  1  0.06355199  0.35793558  0.26481231  1
+  C  C5  1  1.07160383  0.29464411  0.76407676  1
+",-154.13010116666666
+3413,C-136377-5342-56,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43136000
+_cell_length_b   6.01702000
+_cell_length_c   10.81960000
+_cell_angle_alpha   68.03739000
+_cell_angle_beta   71.62030000
+_cell_angle_gamma   100.57032000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   130.88846900
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.13974358  0.95787790  0.35198845  1
+  C  C1  1  0.69910604  0.73722274  0.24001232  1
+  C  C2  1  0.39931730  -0.07704139  0.83250947  1
+  C  C3  1  1.18233797  0.81290400  0.27639862  1
+  C  C4  1  0.62263419  0.03337812  0.38852638  1
+  C  C5  1  1.03333803  0.40466142  0.57287157  1
+  C  C6  1  0.73235354  0.58884022  0.16631932  1
+  C  C7  1  0.47269051  0.62504764  0.68503659  1
+  C  C8  1  0.80629382  0.29218160  1.01808615  1
+  C  C9  1  0.51628870  0.48029803  0.60929669  1
+  C  C10  1  0.58421413  0.18035640  0.46302412  1
+  C  C11  1  0.28882345  0.36736276  0.05481256  1
+  C  C12  1  -0.08360896  0.84737551  0.79614877  1
+  C  C13  1  -0.15112220  0.14718900  0.94249653  1
+  C  C14  1  0.24969991  0.51360019  0.12976408  1
+  C  C15  1  0.36591126  0.07165088  0.90602495  1
+  C  C16  1  0.95530947  0.70043711  0.72163457  1
+  C  C17  1  0.06730995  0.25607646  0.49929646  1
+",-154.4665238888889
+9004,C-90858-8157-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.62222000
+_cell_length_b   2.47140000
+_cell_length_c   7.68765000
+_cell_angle_alpha   89.99799000
+_cell_angle_beta   89.01078000
+_cell_angle_gamma   90.06781000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   49.81277475
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.41106378  0.45618378  0.02181572  1
+  C  C1  1  0.37668840  0.95609578  0.74628581  1
+  C  C2  1  0.89735041  -0.04350228  0.24601058  1
+  C  C3  1  0.40756000  -0.04386233  0.91802340  1
+  C  C4  1  -0.09811723  0.45647630  0.14224509  1
+  C  C5  1  -0.11491050  0.45629110  0.52207738  1
+  C  C6  1  0.37427275  0.45616412  0.64253479  1
+  C  C7  1  0.89068629  -0.04362087  0.41822252  1
+",-154.18952125
+4073,C-72699-8017-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.24047000
+_cell_length_b   4.23840000
+_cell_length_c   4.52676000
+_cell_angle_alpha   100.71981000
+_cell_angle_beta   93.82415000
+_cell_angle_gamma   115.83184000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   70.93986851
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.60024943  0.81489236  0.33909333  1
+  C  C1  1  0.64235441  0.73033722  0.01175701  1
+  C  C2  1  0.38886305  0.40495590  -0.14684890  1
+  C  C3  1  0.23734773  0.45923994  0.34661778  1
+  C  C4  1  0.93833278  0.84926799  0.54514168  1
+  C  C5  1  0.61720528  0.17842065  0.43581848  1
+  C  C6  1  0.92063811  0.48553324  0.44592291  1
+  C  C7  1  0.15037773  0.25976242  0.02946330  1
+  C  C8  1  0.89735618  0.93364652  0.87257453  1
+  C  C9  1  0.30094719  0.20502196  0.53623547  1
+",-154.091869
+5790,C-152563-2721-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46153000
+_cell_length_b   4.22075000
+_cell_length_c   5.56577000
+_cell_angle_alpha   98.93554000
+_cell_angle_beta   89.47222000
+_cell_angle_gamma   89.33056000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.11633701
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.05731322  0.15582153  -0.03275026  1
+  C  C1  1  0.34671453  0.78343940  0.20947900  1
+  C  C2  1  0.45649161  0.12859815  0.32735738  1
+  C  C3  1  0.17814225  0.62854171  0.71771644  1
+  C  C4  1  0.58673021  0.10580273  0.59294351  1
+  C  C5  1  0.69751418  0.73502881  0.58304301  1
+  C  C6  1  0.83514316  0.63187363  0.30612371  1
+  C  C7  1  0.94763738  0.28229060  0.23097546  1
+  C  C8  1  0.21391534  0.83124048  -0.04252105  1
+  C  C9  1  0.09299622  0.26451256  0.72580040  1
+",-154.07012600000002
+7089,C-80199-6032-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43277000
+_cell_length_b   4.20204000
+_cell_length_c   6.07210000
+_cell_angle_alpha   69.32351000
+_cell_angle_beta   81.09648000
+_cell_angle_gamma   89.99110000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.27489829
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.45211903  0.59810746  0.63396118  1
+  C  C1  1  0.45219241  0.26543247  0.63399691  1
+  C  C2  1  1.20007133  0.69421791  0.13440417  1
+  C  C3  1  0.19998547  1.02693749  0.13439273  1
+  C  C4  1  0.95219675  0.76541236  0.63398503  1
+  C  C5  1  0.70006320  0.19424239  0.13441658  1
+  C  C6  1  0.69998981  0.52691738  0.13438085  1
+  C  C7  1  0.95211089  0.09813195  0.63397358  1
+",-154.4534175
+4637,C-113030-1519-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.43495000
+_cell_length_b   4.91519000
+_cell_length_c   4.17984000
+_cell_angle_alpha   43.47219000
+_cell_angle_beta   100.13482000
+_cell_angle_gamma   100.82151000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   47.60652497
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.07869197  0.57716069  0.52879926  1
+  C  C1  1  -0.01926670  0.48223232  0.24575655  1
+  C  C2  1  0.61045437  0.59020455  0.93635955  1
+  C  C3  1  0.41555903  -0.08606540  0.18009298  1
+  C  C4  1  1.08988305  0.11134080  0.41574123  1
+  C  C5  1  0.30641181  0.28493318  1.01014540  1
+  C  C6  1  0.31781927  0.81910791  -0.10304646  1
+  C  C7  1  0.78650421  0.80601965  0.48948998  1
+",-154.183725
+2138,C-53824-8786-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48077000
+_cell_length_b   4.21449000
+_cell_length_c   3.68942000
+_cell_angle_alpha   104.68488000
+_cell_angle_beta   70.37176000
+_cell_angle_gamma   90.02190000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99286386
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.29130827  0.45936666  0.20530927  1
+  C  C1  1  0.61191741  0.16170784  0.56610135  1
+  C  C2  1  0.09287324  0.38428029  0.60349203  1
+  C  C3  1  0.86978101  0.59054723  0.04853179  1
+  C  C4  1  0.41119891  1.08704528  0.96459506  1
+  C  C5  1  0.83300836  0.95579798  0.12143609  1
+",-154.307802
+9991,C-170908-5383-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.41147000
+_cell_length_b   3.60519000
+_cell_length_c   7.14054000
+_cell_angle_alpha   72.61974000
+_cell_angle_beta   70.27558000
+_cell_angle_gamma   70.02766000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   53.72816784
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.10355869  0.64541339  0.52154376  1
+  C  C1  1  0.04920774  1.00457237  0.19370386  1
+  C  C2  1  0.71668109  0.56056643  0.74482682  1
+  C  C3  1  0.13410513  0.51800699  0.84926707  1
+  C  C4  1  0.68383660  0.72455171  0.19756712  1
+  C  C5  1  0.57266201  0.48200109  0.42671577  1
+  C  C6  1  -0.03602111  0.41942512  0.07033290  1
+  C  C7  1  0.80149823  0.06696179  0.40566350  1
+",-154.06623125
+6124,C-56491-7685-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47619000
+_cell_length_b   4.79457000
+_cell_length_c   4.18444000
+_cell_angle_alpha   64.09083000
+_cell_angle_beta   89.96723000
+_cell_angle_gamma   89.98948000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   44.68545737
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.01028534  0.58521571  0.71533055  1
+  C  C1  1  0.98935542  0.91866337  0.04871184  1
+  C  C2  1  0.48985025  0.43041451  0.66239921  1
+  C  C3  1  0.98984410  0.58523788  0.08476518  1
+  C  C4  1  0.48954411  1.07322037  0.84102742  1
+  C  C5  1  0.48947690  0.07326145  0.47097248  1
+  C  C6  1  0.48993525  0.43041323  0.29237197  1
+  C  C7  1  0.98931391  0.91868758  0.41807864  1
+",-154.40485125
+5226,C-57113-4466-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48907000
+_cell_length_b   5.55971000
+_cell_length_c   4.97525000
+_cell_angle_alpha   132.15475000
+_cell_angle_beta   120.03617000
+_cell_angle_gamma   63.41094000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.51277944
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.96655842  0.52573755  0.71042721  1
+  C  C1  1  0.34187786  0.40073700  0.46053383  1
+  C  C2  1  -0.15831845  0.90102923  0.46054975  1
+  C  C3  1  0.46636212  0.02602978  0.71044313  1
+  C  C4  1  0.46646949  1.02584622  0.21021960  1
+  C  C5  1  0.84186062  0.90077803  0.96032915  1
+  C  C6  1  0.34177049  0.40092057  0.96075735  1
+  C  C7  1  0.96637936  0.52598876  0.21064780  1
+",-154.54941125
+6361,C-57131-7379-55,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43099000
+_cell_length_b   4.20567000
+_cell_length_c   6.14308000
+_cell_angle_alpha   66.35996000
+_cell_angle_beta   94.64014000
+_cell_angle_gamma   90.12833000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.31599124
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71436187  0.48588350  0.50678016  1
+  C  C1  1  0.71649198  0.51777393  1.00739541  1
+  C  C2  1  0.21436187  -0.01411650  0.50678016  1
+  C  C3  1  0.21649198  1.01777393  0.00739541  1
+  C  C4  1  0.21676186  0.34980957  0.00867442  1
+  C  C5  1  0.71463176  0.81791915  0.50805917  1
+  C  C6  1  0.21463176  0.31791915  0.50805917  1
+  C  C7  1  0.71676186  -0.15019043  0.00867442  1
+",-154.45393875
+8678,C-145333-1039-12,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48590000
+_cell_length_b   4.14667000
+_cell_length_c   6.67655000
+_cell_angle_alpha   101.37294000
+_cell_angle_beta   89.99586000
+_cell_angle_gamma   89.99391000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.47187357
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.12052562  0.69777980  0.88381161  1
+  C  C1  1  0.62048635  0.24827812  1.04009824  1
+  C  C2  1  0.62055856  0.47085671  0.88323206  1
+  C  C3  1  1.12060649  0.74876211  0.65923329  1
+  C  C4  1  0.12054474  0.97027403  0.26279296  1
+  C  C5  1  1.12048919  0.02142447  0.03931114  1
+  C  C6  1  0.62049065  0.45150332  0.26541092  1
+  C  C7  1  0.12062311  0.39373641  0.57168946  1
+  C  C8  1  0.62058693  0.81898056  0.33304837  1
+  C  C9  1  0.62063594  0.26746546  0.65704736  1
+  C  C10  1  0.12050740  0.32500255  0.35145696  1
+  C  C11  1  0.62059943  -0.10048153  0.58739843  1
+",-154.4006125
+4979,C-34609-1384-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.60452000
+_cell_length_b   6.63591000
+_cell_length_c   7.09262000
+_cell_angle_alpha   95.96116000
+_cell_angle_beta   116.73003000
+_cell_angle_gamma   107.17334000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   100.49972241
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.51882042  0.54558605  0.83228591  1
+  C  C1  1  0.07941422  0.35097549  0.67591246  1
+  C  C2  1  0.11446167  0.17066685  -0.02340186  1
+  C  C3  1  0.59205167  0.75234592  0.79562393  1
+  C  C4  1  0.52041932  0.64287325  0.42629754  1
+  C  C5  1  0.84078696  0.30343746  0.08759250  1
+  C  C6  1  -0.11400712  0.16873960  0.74399487  1
+  C  C7  1  0.87807966  0.51692294  1.03706141  1
+  C  C8  1  0.95948572  -0.06537293  -0.02191840  1
+  C  C9  1  0.49048705  0.05422360  0.37978514  1
+  C  C10  1  0.23355184  0.69312186  0.21267684  1
+  C  C11  1  1.22824335  0.89772554  0.18441001  1
+  C  C12  1  0.52283596  -0.01322743  0.56257164  1
+  C  C13  1  0.22628315  0.38314103  0.34745012  1
+  C  C14  1  0.28131109  0.75488796  0.56023277  1
+  C  C15  1  0.76474275  0.29714170  0.43304223  1
+",-154.147190625
+349,C-40122-8937-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48887000
+_cell_length_b   3.60243000
+_cell_length_c   8.12747000
+_cell_angle_alpha   102.97306000
+_cell_angle_beta   107.86599000
+_cell_angle_gamma   110.21675000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   60.46341112
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.52672918  0.77938639  0.48988306  1
+  C  C1  1  0.53296323  -0.03269333  0.90462957  1
+  C  C2  1  0.55739687  0.18131890  0.32128638  1
+  C  C3  1  0.79950615  0.23919554  0.53343912  1
+  C  C4  1  0.81548312  0.71648045  0.81284948  1
+  C  C5  1  -0.18036452  0.45212758  0.95054966  1
+  C  C6  1  0.85195333  -0.08114624  0.24682408  1
+  C  C7  1  0.83181303  0.64081794  0.36478257  1
+  C  C8  1  0.53666431  0.70233932  0.04189324  1
+  C  C9  1  0.50501950  0.50147015  0.60805505  1
+",-154.20435600000002
+9013,C-72714-6010-16,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.83534000
+_cell_length_b   3.51759000
+_cell_length_c   3.51716000
+_cell_angle_alpha   59.99031000
+_cell_angle_beta   43.31372000
+_cell_angle_gamma   68.65695000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.53628394
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.11927355  0.17329297  -0.17507048  1
+  C  C1  1  0.78576662  0.17324315  -0.14590441  1
+  C  C2  1  0.95254670  0.40542697  0.22341949  1
+  C  C3  1  0.28573824  0.70916166  0.89042934  1
+  C  C4  1  0.61915708  0.70919903  0.25281891  1
+  C  C5  1  0.45245841  0.47708391  0.18768015  1
+",-154.40836616666667
+3018,C-13950-3719-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46512000
+_cell_length_b   3.39181000
+_cell_length_c   5.27344000
+_cell_angle_alpha   87.48178000
+_cell_angle_beta   90.00810000
+_cell_angle_gamma   68.67941000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.02891074
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.00043711  0.11520419  0.27742121  1
+  C  C1  1  1.37559708  0.36924872  0.87633224  1
+  C  C2  1  -0.14247574  0.40644891  0.75067108  1
+  C  C3  1  0.40764243  0.30078526  0.15199702  1
+  C  C4  1  0.81818065  0.47769806  0.47495170  1
+  C  C5  1  0.22472277  0.66365577  0.34991505  1
+",-154.16468016666667
+4554,C-92144-1112-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45744000
+_cell_length_b   3.40148000
+_cell_length_c   5.87772000
+_cell_angle_alpha   106.16842000
+_cell_angle_beta   114.69352000
+_cell_angle_gamma   68.95538000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.18057934
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.13427509  1.07208498  0.33883910  1
+  C  C1  1  1.27057023  -0.00470975  -0.06396505  1
+  C  C2  1  -0.09192443  0.33212619  0.74318130  1
+  C  C3  1  0.51677662  1.05508381  0.21220092  1
+  C  C4  1  0.38043374  0.13071240  0.61485031  1
+  C  C5  1  0.74228305  0.79398687  0.80780632  1
+",-154.14374883333332
+7555,C-184052-2353-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42622000
+_cell_length_b   4.22686000
+_cell_length_c   5.83703000
+_cell_angle_alpha   133.62582000
+_cell_angle_beta   89.99736000
+_cell_angle_gamma   90.02136000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.33064025
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.92845442  -0.01106815  0.29929972  1
+  C  C1  1  0.42833789  0.70129361  1.15519146  1
+  C  C2  1  0.42840687  0.41204989  0.21565235  1
+  C  C3  1  0.42868226  0.41207238  0.80569889  1
+  C  C4  1  0.92832780  0.27785528  0.23849426  1
+  C  C5  1  -0.07130814  0.27813998  0.64874741  1
+",-154.30509566666666
+9320,C-40138-885-24,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.56227000
+_cell_length_b   2.48023000
+_cell_length_c   5.71398000
+_cell_angle_alpha   102.49503000
+_cell_angle_beta   92.74866000
+_cell_angle_gamma   90.00575000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.40955171
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.93923446  0.53151843  0.97233645  1
+  C  C1  1  0.42175725  -0.12289363  0.66647675  1
+  C  C2  1  0.95458410  0.10929458  0.12691284  1
+  C  C3  1  0.42012254  0.45005968  0.81149272  1
+  C  C4  1  0.47234899  0.76267486  0.43272902  1
+  C  C5  1  0.47371506  0.19027389  0.28786053  1
+",-154.27852366666667
+2356,C-96669-7803-36,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48080000
+_cell_length_b   3.68904000
+_cell_length_c   4.83559000
+_cell_angle_alpha   68.53400000
+_cell_angle_beta   104.74718000
+_cell_angle_gamma   70.30311000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98296386
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.45939521  0.89472555  1.01853803  1
+  C  C1  1  0.14319067  0.95213042  0.44662561  1
+  C  C2  1  1.12729865  0.19131138  0.65353212  1
+  C  C3  1  0.44299869  0.13375664  0.22523027  1
+  C  C4  1  0.16856890  0.60703650  0.14939192  1
+  C  C5  1  0.41856429  0.47861802  0.52280624  1
+",-154.30963316666666
+8875,C-152583-4955-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.04771000
+_cell_length_b   4.21097000
+_cell_length_c   4.20890000
+_cell_angle_alpha   60.01597000
+_cell_angle_beta   63.34559000
+_cell_angle_gamma   76.89821000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   41.81463613
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.03117436  0.85439231  0.53040570  1
+  C  C1  1  0.02359301  0.85440489  0.19975150  1
+  C  C2  1  1.02359301  0.18773823  0.53308483  1
+  C  C3  1  1.02359301  0.52107156  0.86641816  1
+  C  C4  1  0.03117436  0.52105897  0.19707237  1
+  C  C5  1  0.03117436  0.18772564  0.86373904  1
+",-154.43337566666665
+6892,C-57152-1382-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48688000
+_cell_length_b   4.53325000
+_cell_length_c   6.31619000
+_cell_angle_alpha   86.49239000
+_cell_angle_beta   101.37043000
+_cell_angle_gamma   105.99978000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.10296783
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.01567467  0.61553017  0.36781977  1
+  C  C1  1  0.59837515  0.70964813  0.49827064  1
+  C  C2  1  -0.02643994  0.80671929  0.15949358  1
+  C  C3  1  1.10100163  0.24194613  0.97223392  1
+  C  C4  1  0.17968800  0.16445027  0.20685742  1
+  C  C5  1  1.19141817  0.53955325  0.85245081  1
+  C  C6  1  0.78708548  0.25831272  0.32797377  1
+  C  C7  1  0.79557919  0.06717744  0.53866242  1
+  C  C8  1  0.48011942  0.08232841  0.89408794  1
+  C  C9  1  1.39015810  0.78489093  1.01455445  1
+  C  C10  1  0.40233278  0.16047938  0.65961915  1
+  C  C11  1  0.60861741  0.51890467  0.70712624  1
+",-154.392005
+9148,C-184060-4400-33,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.27650000
+_cell_length_b   4.24134000
+_cell_length_c   3.63015000
+_cell_angle_alpha   89.91310000
+_cell_angle_beta   104.53783000
+_cell_angle_gamma   130.52561000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   36.21179241
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.83607780  0.40185607  0.87955866  1
+  C  C1  1  0.04949690  0.03055341  0.26067008  1
+  C  C2  1  0.62443786  0.45697801  0.49821138  1
+  C  C3  1  1.04918479  0.66941368  0.26101297  1
+  C  C4  1  0.62469891  0.81823805  0.49794409  1
+  C  C5  1  -0.16233727  0.08574008  0.87916383  1
+",-154.19743833333334
+3907,C-126136-4977-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48252000
+_cell_length_b   3.68627000
+_cell_length_c   4.89611000
+_cell_angle_alpha   66.97699000
+_cell_angle_beta   120.52421000
+_cell_angle_gamma   109.64428000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98319840
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20443598  0.21468041  0.97402692  1
+  C  C1  1  0.95266198  0.45990617  0.60026823  1
+  C  C2  1  0.91315278  0.37141634  0.10468408  1
+  C  C3  1  0.22704352  0.85723421  0.67612736  1
+  C  C4  1  0.24331445  0.30265392  0.46969632  1
+  C  C5  1  0.92949920  0.81705256  0.89826139  1
+",-154.31007116666666
+8116,C-13906-5787-34,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.74580000
+_cell_length_b   4.15588000
+_cell_length_c   4.81178000
+_cell_angle_alpha   71.51240000
+_cell_angle_beta   91.18047000
+_cell_angle_gamma   59.75329000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.88210320
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.35928992  0.10823665  0.69705116  1
+  C  C1  1  0.76512779  0.70332930  0.88917248  1
+  C  C2  1  0.41695193  1.05019050  0.19534588  1
+  C  C3  1  0.79929800  0.66835749  0.19522664  1
+  C  C4  1  0.20562974  0.26343260  0.38715889  1
+  C  C5  1  1.14742222  0.32157256  0.88877495  1
+",-154.1389335
+8519,C-53822-9555-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43028000
+_cell_length_b   2.43015000
+_cell_length_c   8.51128000
+_cell_angle_alpha   88.90137000
+_cell_angle_beta   81.86222000
+_cell_angle_gamma   59.99833000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.01540262
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.04388171  -0.03788144  0.78694714  1
+  C  C1  1  0.44499084  0.77641322  0.12036185  1
+  C  C2  1  -0.12574398  0.53782306  0.45419376  1
+  C  C3  1  0.11110241  0.44347677  0.12093189  1
+  C  C4  1  0.54077076  1.20437630  0.45429797  1
+  C  C5  1  0.71032125  0.62885719  0.78702019  1
+",-154.46787816666668
+2057,C-170356-2444-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42881000
+_cell_length_b   4.16728000
+_cell_length_c   7.96691000
+_cell_angle_alpha   63.53639000
+_cell_angle_beta   90.00330000
+_cell_angle_gamma   89.99040000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   72.18795233
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.76129172  0.50432344  0.10000077  1
+  C  C1  1  0.26007212  0.81680373  0.44429428  1
+  C  C2  1  -0.24003188  0.83462759  0.52645019  1
+  C  C3  1  1.25878211  0.21977837  0.78521186  1
+  C  C4  1  0.26108559  0.47587910  1.02057139  1
+  C  C5  1  0.75931970  0.76500284  0.72699144  1
+  C  C6  1  0.75877113  0.08411806  0.76240530  1
+  C  C7  1  0.76115919  0.62424475  0.24028086  1
+  C  C8  1  0.25944128  0.53881974  0.82064864  1
+  C  C9  1  0.26105295  0.70688929  0.30000256  1
+",-154.285714
+1196,C-170368-1522-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   4.73859000
+_cell_length_b   5.21052000
+_cell_length_c   4.43832000
+_cell_angle_alpha   70.79671000
+_cell_angle_beta   81.63038000
+_cell_angle_gamma   94.69694000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   101.39240112
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.20727458  0.50666169  0.99428066  1
+  C  C1  1  0.86406614  0.24715188  0.72936553  1
+  C  C2  1  -0.19001727  0.68686862  1.17592052  1
+  C  C3  1  0.55748068  0.26063026  0.74942789  1
+  C  C4  1  0.47495526  0.43220895  0.92498833  1
+  C  C5  1  0.72971977  0.52129942  0.00827995  1
+  C  C6  1  -0.03369482  0.41023236  0.89506281  1
+  C  C7  1  0.69069740  0.98340079  0.47512617  1
+  C  C8  1  0.30132454  0.82276132  0.30675472  1
+  C  C9  1  0.45519434  1.09763845  0.58404775  1
+  C  C10  1  1.21399932  0.99858764  0.48688255  1
+  C  C11  1  0.12025014  0.68226806  0.17522020  1
+  C  C12  1  0.61100285  0.81883256  0.30649897  1
+  C  C13  1  0.94544646  0.07086509  0.55925464  1
+",-154.14411285714286
+7141,C-96686-8751-39,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.72549000
+_cell_length_b   6.20005000
+_cell_length_c   5.13697000
+_cell_angle_alpha   133.76003000
+_cell_angle_beta   96.54215000
+_cell_angle_gamma   110.78926000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   67.82443462
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.35949454  0.81953119  0.94317536  1
+  C  C1  1  0.21840151  0.95150532  0.20872599  1
+  C  C2  1  1.05004494  0.23360097  0.08226200  1
+  C  C3  1  0.21900876  0.24924261  0.37256644  1
+  C  C4  1  1.05000213  0.79817088  0.33089906  1
+  C  C5  1  0.52796379  -0.02761834  0.82117364  1
+  C  C6  1  0.52779875  0.53724735  1.06935529  1
+  C  C7  1  0.35997212  0.52228856  0.77907076  1
+  C  C8  1  0.28928230  0.63539257  0.32615246  1
+  C  C9  1  0.28911516  0.13550338  0.82583361  1
+",-154.08349800000002
+3781,C-102903-5111-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48037000
+_cell_length_b   2.48021000
+_cell_length_c   8.29889000
+_cell_angle_alpha   81.41233000
+_cell_angle_beta   89.98861000
+_cell_angle_gamma   59.97253000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.53984083
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.00827655  0.49942650  0.05218466  1
+  C  C1  1  0.11174875  0.28941027  0.36603987  1
+  C  C2  1  0.94533207  -0.37440245  -0.13684530  1
+  C  C3  1  0.75788941  0.99766998  0.30388356  1
+  C  C4  1  0.17512997  0.16486957  0.55241625  1
+  C  C5  1  0.69530248  0.12399663  0.11491769  1
+  C  C6  1  0.52876671  0.45697921  0.61425733  1
+  C  C7  1  0.59164927  0.33418218  0.80057515  1
+",-154.52882
+331,C-170348-4384-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47079000
+_cell_length_b   3.68310000
+_cell_length_c   7.58428000
+_cell_angle_alpha   90.64907000
+_cell_angle_beta   89.97566000
+_cell_angle_gamma   89.94931000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   69.01374977
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.37680747  0.12735200  0.80968176  1
+  C  C1  1  0.87683128  0.33999944  0.06315275  1
+  C  C2  1  0.37691921  0.83760388  0.95381856  1
+  C  C3  1  0.87673648  0.64184666  0.20984361  1
+  C  C4  1  0.37666607  0.59790861  0.31112271  1
+  C  C5  1  0.87672093  0.31795360  0.54782639  1
+  C  C6  1  0.87685525  0.15833642  0.70708537  1
+  C  C7  1  -0.12321339  0.93318544  0.06622558  1
+  C  C8  1  0.37672715  0.41693289  0.46452461  1
+  C  C9  1  0.37683006  0.43094947  0.95535135  1
+",-154.215798
+295,C-34633-9015-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42713000
+_cell_length_b   5.65113000
+_cell_length_c   10.17626000
+_cell_angle_alpha   57.74194000
+_cell_angle_beta   68.89946000
+_cell_angle_gamma   77.36492000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   110.05763265
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.31357260  0.88352748  0.79858567  1
+  C  C1  1  -0.15833254  0.68952816  0.84567834  1
+  C  C2  1  0.27911879  0.25820272  0.36409180  1
+  C  C3  1  0.48361174  0.72231469  0.40714413  1
+  C  C4  1  1.27375429  -0.08289600  0.15154709  1
+  C  C5  1  0.48615924  1.07142239  0.61927777  1
+  C  C6  1  1.07651218  1.14234724  0.53555942  1
+  C  C7  1  0.07488171  0.43092685  0.10885202  1
+  C  C8  1  0.88870582  0.65656717  0.49203475  1
+  C  C9  1  0.07040358  0.56289557  0.73621341  1
+  C  C10  1  -0.33507437  0.50222907  0.02514253  1
+  C  C11  1  0.47896723  0.99708684  -0.01447526  1
+  C  C12  1  -0.12340854  0.31347773  0.28044443  1
+  C  C13  1  0.68141427  0.57696446  0.65809964  1
+  C  C14  1  0.67913202  -0.14903910  0.23643035  1
+  C  C15  1  1.08935928  1.01067913  0.90753541  1
+",-154.28518625
+6784,C-130536-5861-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47924000
+_cell_length_b   2.56388000
+_cell_length_c   5.72986000
+_cell_angle_alpha   89.75559000
+_cell_angle_beta   77.55457000
+_cell_angle_gamma   89.98650000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.56552505
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.47557730  0.01227046  0.28412653  1
+  C  C1  1  0.24688405  0.50825773  0.74421481  1
+  C  C2  1  0.89833904  1.01119888  0.43897580  1
+  C  C3  1  0.55623707  0.51295068  0.12335324  1
+  C  C4  1  1.12886427  0.51207002  -0.02078013  1
+  C  C5  1  0.81889646  0.50876773  0.59944305  1
+",-154.2883765
+8610,C-96713-4638-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48096000
+_cell_length_b   3.68915000
+_cell_length_c   4.21550000
+_cell_angle_alpha   104.75220000
+_cell_angle_beta   89.93297000
+_cell_angle_gamma   109.63837000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.98955529
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.30759869  0.26153943  0.67595397  1
+  C  C1  1  0.34722405  0.33345228  1.04114742  1
+  C  C2  1  -0.11359866  0.41885447  0.54513679  1
+  C  C3  1  0.76890919  0.17726693  0.17251420  1
+  C  C4  1  1.08601363  0.81668896  0.46961558  1
+  C  C5  1  0.56663091  0.77856202  0.24709174  1
+",-154.30784416666668
+5022,C-130507-2037-23,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48249000
+_cell_length_b   2.48259000
+_cell_length_c   10.49689000
+_cell_angle_alpha   76.30705000
+_cell_angle_beta   83.20194000
+_cell_angle_gamma   59.98600000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   54.42523190
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.02967549  0.69498173  0.21626325  1
+  C  C1  1  0.69598096  0.91090624  0.66756505  1
+  C  C2  1  1.02928191  0.29392530  0.61791302  1
+  C  C3  1  0.36354587  -0.02276441  0.26712014  1
+  C  C4  1  1.02895457  0.44381944  0.46878715  1
+  C  C5  1  0.36294921  0.82731056  0.41832009  1
+  C  C6  1  0.36180969  0.37951443  0.86601170  1
+  C  C7  1  0.02930632  0.84599564  0.06513836  1
+  C  C8  1  0.36296405  0.22918391  0.01488300  1
+  C  C9  1  0.69503484  0.76304337  0.81654263  1
+",-154.533257
+6378,C-184086-7799-30,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43060000
+_cell_length_b   3.29699000
+_cell_length_c   10.38260000
+_cell_angle_alpha   106.75139000
+_cell_angle_beta   98.06161000
+_cell_angle_gamma   66.09486000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   72.81133739
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.24004045  0.15783930  0.12501336  1
+  C  C1  1  0.69389866  0.42217323  0.25814639  1
+  C  C2  1  0.95289240  0.36670510  0.72401489  1
+  C  C3  1  1.08739774  0.83126950  0.45718133  1
+  C  C4  1  0.48568503  0.23257102  0.65695500  1
+  C  C5  1  0.88638237  -0.36726767  0.85702516  1
+  C  C6  1  0.29151559  1.02615096  0.05776638  1
+  C  C7  1  0.55235751  0.96760782  0.52396664  1
+  C  C8  1  0.35460972  -0.23443050  0.92425588  1
+  C  C9  1  0.15799962  0.55964273  0.32482227  1
+",-154.456566
+7040,C-96686-8751-54,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.36908000
+_cell_length_b   3.50760000
+_cell_length_c   7.33840000
+_cell_angle_alpha   89.67875000
+_cell_angle_beta   88.86697000
+_cell_angle_gamma   92.83678000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   86.59561018
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.51489788  0.30549974  0.35865673  1
+  C  C1  1  0.17618422  0.96657842  0.37831769  1
+  C  C2  1  0.39862331  0.56042191  0.65947119  1
+  C  C3  1  0.05644322  0.40730157  0.78069013  1
+  C  C4  1  0.55780266  0.90574236  0.76411620  1
+  C  C5  1  1.07698888  -0.09672175  0.18430462  1
+  C  C6  1  0.88754116  0.25872294  0.46623503  1
+  C  C7  1  0.30607024  0.13931749  0.07011557  1
+  C  C8  1  0.81869083  0.66313580  0.08800075  1
+  C  C9  1  0.72809880  0.25600199  0.66088049  1
+  C  C10  1  0.56387611  0.38300225  0.16002045  1
+  C  C11  1  0.89080647  0.74454420  0.88662685  1
+  C  C12  1  0.24238736  0.57977777  0.46494105  1
+  C  C13  1  0.21494475  0.06574191  0.87990665  1
+",-154.19921785714286
+9273,C-102887-506-13,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47355000
+_cell_length_b   4.30414000
+_cell_length_c   4.30368000
+_cell_angle_alpha   89.93730000
+_cell_angle_beta   90.01102000
+_cell_angle_gamma   89.98745000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.81912339
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.40237770  0.97623514  0.55907028  1
+  C  C1  1  0.40224587  0.33711217  0.55894930  1
+  C  C2  1  0.90240005  0.83722927  0.05906921  1
+  C  C3  1  0.90234211  0.47635496  0.05895989  1
+  C  C4  1  0.90245367  0.83716099  0.42002410  1
+  C  C5  1  0.40241855  0.33730024  0.91989490  1
+  C  C6  1  0.40233621  0.97636100  0.91996493  1
+  C  C7  1  0.90218012  0.47624073  0.41983810  1
+",-154.32627
+5979,C-189709-289-3,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.51864000
+_cell_length_b   4.83266000
+_cell_length_c   3.31890000
+_cell_angle_alpha   133.40165000
+_cell_angle_beta   89.97438000
+_cell_angle_gamma   111.33197000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.50421792
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.06975216  0.35741855  0.91229889  1
+  C  C1  1  0.30214992  0.12623106  0.84766041  1
+  C  C2  1  0.76526580  0.35729484  0.24542675  1
+  C  C3  1  -0.00239848  0.82125727  0.87627688  1
+  C  C4  1  0.76507234  1.05232509  0.27414358  1
+  C  C5  1  0.30189036  0.82143830  0.20912318  1
+",-154.40564316666666
+1616,C-41262-9862-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.21012000
+_cell_length_b   4.96107000
+_cell_length_c   7.50098000
+_cell_angle_alpha   84.40839000
+_cell_angle_beta   58.31563000
+_cell_angle_gamma   89.60616000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   101.03094523
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.82265690  1.05103031  0.88292386  1
+  C  C1  1  0.21371299  0.61126830  0.85214430  1
+  C  C2  1  -0.14487285  0.55876733  0.07189633  1
+  C  C3  1  0.69364527  0.05243442  0.09311100  1
+  C  C4  1  0.32957902  0.90819633  0.54942706  1
+  C  C5  1  0.72726506  0.79852826  0.18844311  1
+  C  C6  1  0.08878638  0.13505695  0.53486146  1
+  C  C7  1  0.78674556  0.52192825  0.47882213  1
+  C  C8  1  0.63470735  0.74389915  0.39783912  1
+  C  C9  1  0.56544501  0.45644156  0.70416328  1
+  C  C10  1  0.77228280  0.22230597  0.73640626  1
+  C  C11  1  0.14232383  0.32338499  0.37643013  1
+  C  C12  1  0.57751639  0.31744640  0.17549169  1
+  C  C13  1  1.14217191  0.85055300  0.76605137  1
+",-154.11877071428572
+7278,C-172919-5077-6,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.95718000
+_cell_length_b   4.72316000
+_cell_length_c   3.63988000
+_cell_angle_alpha   100.92662000
+_cell_angle_beta   108.52508000
+_cell_angle_gamma   106.19110000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.08028839
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.83954126  0.35669735  0.28037048  1
+  C  C1  1  0.54368167  1.04938457  0.01039216  1
+  C  C2  1  0.83971304  0.35765604  0.66123370  1
+  C  C3  1  0.54250773  0.04808293  0.62914631  1
+  C  C4  1  1.03577058  0.54909246  1.06638643  1
+  C  C5  1  0.34875653  0.85677785  0.22434502  1
+",-154.12863383333334
+3986,C-113036-345-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44145000
+_cell_length_b   5.20266000
+_cell_length_c   8.92110000
+_cell_angle_alpha   80.07678000
+_cell_angle_beta   105.91853000
+_cell_angle_gamma   103.71328000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   105.16377628
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.23015157  0.84007071  0.83448846  1
+  C  C1  1  0.02194659  0.15015452  -0.03474304  1
+  C  C2  1  0.21294643  0.49592726  0.48890281  1
+  C  C3  1  0.73115268  0.17181544  0.66998491  1
+  C  C4  1  0.39897254  0.30901854  0.27030633  1
+  C  C5  1  0.43504894  0.65533494  0.62454753  1
+  C  C6  1  0.73086646  0.85317353  0.33231693  1
+  C  C7  1  0.83438952  0.60202703  0.05728807  1
+  C  C8  1  0.30402866  0.68138209  0.98922341  1
+  C  C9  1  0.63289746  0.53937894  0.38812961  1
+  C  C10  1  0.29401866  -0.00499118  0.32406822  1
+  C  C11  1  0.20208996  0.25117159  0.60209371  1
+  C  C12  1  0.80643668  0.01227956  0.82429436  1
+  C  C13  1  1.02577894  0.70038662  0.69432959  1
+  C  C14  1  0.82190561  0.35513141  0.16950001  1
+  C  C15  1  0.61232990  0.19652750  1.03433988  1
+",-154.1471975
+9354,C-13663-1651-22,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51139000
+_cell_length_b   4.86367000
+_cell_length_c   6.73091000
+_cell_angle_alpha   88.89206000
+_cell_angle_beta   71.55331000
+_cell_angle_gamma   61.92177000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.98187353
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.82906075  0.06445346  0.28549736  1
+  C  C1  1  0.95323136  0.55341901  0.42044575  1
+  C  C2  1  0.95876919  -0.04898781  0.06240032  1
+  C  C3  1  -0.06104530  0.20190313  0.73256231  1
+  C  C4  1  0.68003811  1.00987450  0.66099278  1
+  C  C5  1  0.68460066  0.40692512  0.30329006  1
+  C  C6  1  -0.08399580  0.43930902  0.06495624  1
+  C  C7  1  0.80782232  0.89627929  0.43809733  1
+  C  C8  1  0.72195981  0.52159899  0.65869821  1
+  C  C9  1  -0.03879321  0.70177956  0.74933489  1
+  C  C10  1  0.69986537  0.75890073  0.99086369  1
+  C  C11  1  0.67738825  0.25914130  0.97417306  1
+",-154.2155925
+4689,C-102893-3152-7,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.42591000
+_cell_length_b   4.83942000
+_cell_length_c   6.10853000
+_cell_angle_alpha   79.38500000
+_cell_angle_beta   84.70678000
+_cell_angle_gamma   61.19746000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   87.22712990
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.94433175  0.94438194  0.19503722  1
+  C  C1  1  0.44438245  -0.05564546  0.69502020  1
+  C  C2  1  0.76708756  0.63740200  1.02370815  1
+  C  C3  1  0.13634043  0.94330963  0.38697716  1
+  C  C4  1  0.74068593  0.13418764  -0.00563897  1
+  C  C5  1  0.45858151  0.63607057  0.71613784  1
+  C  C6  1  0.66190186  0.44633749  0.91688781  1
+  C  C7  1  0.16188326  0.44634676  0.41688931  1
+  C  C8  1  0.26708613  0.63741589  0.52370792  1
+  C  C9  1  0.63637259  -0.05669323  0.88697032  1
+  C  C10  1  0.95854813  0.63608318  0.21614340  1
+  C  C11  1  0.24067580  0.13418009  0.49434975  1
+",-154.1113925
+8339,C-47666-6962-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46756000
+_cell_length_b   3.31127000
+_cell_length_c   9.46215000
+_cell_angle_alpha   99.89472000
+_cell_angle_beta   87.08671000
+_cell_angle_gamma   106.94906000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   72.85470501
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.58506663  0.09570206  0.90690168  1
+  C  C1  1  0.08276241  0.85940117  0.44451680  1
+  C  C2  1  0.37659602  0.40116894  0.24602109  1
+  C  C3  1  0.87603785  0.83048811  0.10144004  1
+  C  C4  1  0.58247914  0.01987843  0.76462866  1
+  C  C5  1  0.08612520  0.14120755  0.99333843  1
+  C  C6  1  0.26646769  0.27659529  0.56010786  1
+  C  C7  1  0.79268052  0.12785942  0.24606056  1
+  C  C8  1  0.58392962  0.81601728  0.35187149  1
+  C  C9  1  1.08119539  -0.02562381  0.67938794  1
+  C  C10  1  0.29431334  0.55664837  0.10122171  1
+  C  C11  1  -0.10304611  0.55555480  0.56020325  1
+",-154.18152666666666
+6543,C-184042-1275-45,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.53021000
+_cell_length_b   5.31244000
+_cell_length_c   4.71924000
+_cell_angle_alpha   101.41014000
+_cell_angle_beta   90.21174000
+_cell_angle_gamma   89.83973000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   62.17982096
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.58613763  0.55986764  0.63118127  1
+  C  C1  1  0.58570896  0.26474859  0.86471531  1
+  C  C2  1  0.58469050  0.28077566  0.52977055  1
+  C  C3  1  0.08644483  0.96070683  0.13201181  1
+  C  C4  1  0.58530894  0.55830023  0.91588362  1
+  C  C5  1  0.58784297  0.78104991  0.49094705  1
+  C  C6  1  0.08721379  0.10445074  0.89150263  1
+  C  C7  1  0.08772089  -0.06484915  0.59448695  1
+  C  C8  1  0.58635811  0.79065372  0.15294723  1
+  C  C9  1  0.08532618  0.13961353  0.41796438  1
+",-154.076775
+846,C-184058-8674-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51362000
+_cell_length_b   4.19351000
+_cell_length_c   4.11224000
+_cell_angle_alpha   119.39286000
+_cell_angle_beta   89.97593000
+_cell_angle_gamma   107.71082000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.39328988
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.39630428  0.71914382  0.10114933  1
+  C  C1  1  0.20466781  0.33097349  0.75691073  1
+  C  C2  1  0.20443659  0.33089779  0.42624297  1
+  C  C3  1  1.01187252  -0.05722916  0.08169758  1
+  C  C4  1  1.01195562  0.94293344  0.71333775  1
+  C  C5  1  0.39619988  0.71903204  0.47023314  1
+",-154.23535783333332
+4599,C-9608-2433-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44417000
+_cell_length_b   3.62304000
+_cell_length_c   9.06954000
+_cell_angle_alpha   78.54656000
+_cell_angle_beta   93.83575000
+_cell_angle_gamma   109.95642000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   73.98775777
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.74156639  0.25383524  0.38708889  1
+  C  C1  1  0.62177575  0.88458124  0.66054549  1
+  C  C2  1  0.22317681  0.08818096  0.66020036  1
+  C  C3  1  0.22535780  0.45032716  0.93628171  1
+  C  C4  1  0.42496928  0.52314020  0.58793473  1
+  C  C5  1  0.42687449  0.81184784  1.00924714  1
+  C  C6  1  0.11046683  1.08123457  0.21028929  1
+  C  C7  1  0.92646019  0.75951909  0.11343365  1
+  C  C8  1  0.62384556  0.24642448  0.93659381  1
+  C  C9  1  0.11079938  -0.00684201  0.38723855  1
+  C  C10  1  0.74118263  0.34212661  0.21015287  1
+  C  C11  1  0.92620019  0.57588091  0.48361321  1
+",-154.075655
+1030,C-141041-1809-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48148000
+_cell_length_b   3.84610000
+_cell_length_c   3.74347000
+_cell_angle_alpha   89.97123000
+_cell_angle_beta   89.98081000
+_cell_angle_gamma   89.93381000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.72772306
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.47895300  0.12178858  0.31963436  1
+  C  C1  1  -0.02089153  0.12188297  0.08240534  1
+  C  C2  1  0.47890104  0.71188377  0.31943542  1
+  C  C3  1  -0.02093707  0.71197284  0.08232529  1
+  C  C4  1  0.47905809  0.41698973  0.58613076  1
+  C  C5  1  0.97900087  0.41713861  0.81580682  1
+",-154.16154550000002
+8402,C-134219-5441-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48134000
+_cell_length_b   4.24930000
+_cell_length_c   7.96371000
+_cell_angle_alpha   81.21718000
+_cell_angle_beta   90.01080000
+_cell_angle_gamma   89.98719000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   82.98441689
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71136959  0.83962334  0.05184336  1
+  C  C1  1  -0.28876801  0.17356316  0.71935113  1
+  C  C2  1  0.21125673  1.00772591  0.78258440  1
+  C  C3  1  0.21132649  0.81116274  -0.03936170  1
+  C  C4  1  0.71148646  0.25871955  0.51687318  1
+  C  C5  1  0.21157539  0.65236392  0.80301043  1
+  C  C6  1  1.21127430  -0.02421231  0.29187848  1
+  C  C7  1  0.71121295  0.94616937  0.20115595  1
+  C  C8  1  0.21150902  0.13389922  0.44957766  1
+  C  C9  1  0.71161225  0.61261281  0.53301088  1
+  C  C10  1  0.71158293  0.52753936  0.73541921  1
+  C  C11  1  0.21155540  0.77863782  0.46998213  1
+",-154.17002166666666
+1549,C-172917-5417-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46466000
+_cell_length_b   5.27242000
+_cell_length_c   3.38918000
+_cell_angle_alpha   92.38312000
+_cell_angle_beta   68.71462000
+_cell_angle_gamma   89.98329000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   40.99602539
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36534811  0.51460015  0.32331475  1
+  C  C1  1  0.21283379  0.04157749  0.61966040  1
+  C  C2  1  0.18277146  0.31666461  0.68748657  1
+  C  C3  1  0.73081710  0.91506345  0.58284715  1
+  C  C4  1  0.59071342  0.44214602  0.87199085  1
+  C  C5  1  0.77208011  0.64036787  0.50942938  1
+",-154.16331116666666
+2962,C-107777-4950-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.22243000
+_cell_length_b   2.43065000
+_cell_length_c   7.69116000
+_cell_angle_alpha   90.50367000
+_cell_angle_beta   107.65003000
+_cell_angle_gamma   89.37950000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.40164620
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.71160714  0.83478993  0.92687379  1
+  C  C1  1  0.54514577  0.33479354  0.34302236  1
+  C  C2  1  1.04523318  0.83484637  0.59301831  1
+  C  C3  1  -0.28849479  -0.16517182  0.42690606  1
+  C  C4  1  0.54529644  0.33478819  0.84299800  1
+  C  C5  1  0.21145699  0.33482729  0.17690138  1
+  C  C6  1  1.04514770  -0.16517830  0.09301927  1
+  C  C7  1  0.21163146  0.33485800  0.67687952  1
+",-154.44742125
+895,C-152563-2721-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48128000
+_cell_length_b   3.68815000
+_cell_length_c   4.22079000
+_cell_angle_alpha   74.96004000
+_cell_angle_beta   90.03463000
+_cell_angle_gamma   70.32839000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.96095831
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.94950464  0.07607704  0.64673361  1
+  C  C1  1  0.69524749  0.58862480  0.07509148  1
+  C  C2  1  0.72484581  0.52268218  0.43981235  1
+  C  C3  1  0.27371759  0.43175524  0.94463763  1
+  C  C4  1  0.14648769  0.67950403  0.57027774  1
+  C  C5  1  0.47021317  1.03517092  0.86824599  1
+",-154.3107125
+7576,C-28215-4713-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.06654000
+_cell_length_b   4.42786000
+_cell_length_c   5.43920000
+_cell_angle_alpha   130.74386000
+_cell_angle_beta   129.90404000
+_cell_angle_gamma   65.48955000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.92312486
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.03532262  0.90824151  0.32236709  1
+  C  C1  1  0.70198928  0.57490818  0.65570043  1
+  C  C2  1  0.03685169  0.57559669  -0.01090497  1
+  C  C3  1  0.36865595  0.24157485  0.98903376  1
+  C  C4  1  0.70351836  0.24226335  0.32242837  1
+  C  C5  1  0.37018502  0.90893002  0.65576170  1
+",-154.44185433333334
+3916,C-107730-3141-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47572000
+_cell_length_b   4.79474000
+_cell_length_c   4.18398000
+_cell_angle_alpha   64.08893000
+_cell_angle_beta   90.00082000
+_cell_angle_gamma   90.00497000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   44.67293584
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.75333941  0.55629554  0.26967583  1
+  C  C1  1  0.25424112  0.04498493  0.39470017  1
+  C  C2  1  0.75398914  0.88983114  0.97245373  1
+  C  C3  1  0.25400704  0.04473032  1.02478091  1
+  C  C4  1  0.75334642  0.55672039  0.63895936  1
+  C  C5  1  0.25334772  0.40138183  0.84654099  1
+  C  C6  1  0.25333900  0.40107169  0.21765029  1
+  C  C7  1  0.75402845  0.89006255  0.60282552  1
+",-154.40276
+5402,C-152581-906-47,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47334000
+_cell_length_b   4.47066000
+_cell_length_c   4.91876000
+_cell_angle_alpha   53.54015000
+_cell_angle_beta   59.77832000
+_cell_angle_gamma   56.38233000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.17182681
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.68864387  0.68967414  0.71457977  1
+  C  C1  1  0.23446286  0.14426253  0.21392680  1
+  C  C2  1  0.79950091  0.30119904  0.49165663  1
+  C  C3  1  0.84572766  0.25492813  0.99240578  1
+  C  C4  1  0.28016029  1.09783881  0.71463093  1
+  C  C5  1  0.39128931  0.70946696  0.49174688  1
+",-154.29767333333334
+5322,C-157672-8945-25,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48488000
+_cell_length_b   3.92481000
+_cell_length_c   6.39359000
+_cell_angle_alpha   93.24885000
+_cell_angle_beta   78.79327000
+_cell_angle_gamma   71.55030000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   57.55203965
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.08661346  0.02248251  0.64408457  1
+  C  C1  1  0.45719707  0.84694561  0.73243115  1
+  C  C2  1  0.50195859  0.24666508  0.24140720  1
+  C  C3  1  0.87705255  0.68272369  0.05724628  1
+  C  C4  1  0.73375934  0.42661163  0.59747777  1
+  C  C5  1  0.28726287  0.45840172  0.45983975  1
+  C  C6  1  0.33296099  0.85907497  -0.03054504  1
+  C  C7  1  0.12596610  0.82702241  0.41423413  1
+  C  C8  1  0.66325353  0.87822695  0.28823587  1
+  C  C9  1  0.05411951  0.27890572  0.10472052  1
+",-154.23219
+9790,C-96705-9216-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.42715000
+_cell_length_b   4.63486000
+_cell_length_c   5.04824000
+_cell_angle_alpha   83.54353000
+_cell_angle_beta   83.63723000
+_cell_angle_gamma   53.22610000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   63.72817882
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.93141354  0.94142151  0.61371986  1
+  C  C1  1  0.67620025  0.67634648  0.31565714  1
+  C  C2  1  -0.19246623  0.34223732  0.93972977  1
+  C  C3  1  0.75973491  0.09375743  0.07783973  1
+  C  C4  1  0.15842016  0.38941232  0.45354077  1
+  C  C5  1  0.78020953  0.88277230  0.89325658  1
+  C  C6  1  0.60745303  0.03491126  0.35733817  1
+  C  C7  1  0.73102475  0.63459232  0.03007542  1
+  C  C8  1  0.37993497  0.58724313  0.51702213  1
+  C  C9  1  0.86224749  0.30008202  0.65457682  1
+",-154.067391
+3507,C-189709-289-8,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48278000
+_cell_length_b   3.74675000
+_cell_length_c   3.84307000
+_cell_angle_alpha   90.05288000
+_cell_angle_beta   89.99999000
+_cell_angle_gamma   90.00461000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.74958980
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.38656333  0.12373513  0.04033715  1
+  C  C1  1  0.88674351  0.61980195  0.74561996  1
+  C  C2  1  0.38663472  0.85637827  0.33517614  1
+  C  C3  1  0.38672112  0.85599523  0.74582598  1
+  C  C4  1  0.88661654  0.62013220  0.33498302  1
+  C  C5  1  0.88660028  0.35256312  0.03999945  1
+",-154.16285933333333
+9640,C-13669-3058-59,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48528000
+_cell_length_b   4.58433000
+_cell_length_c   6.54166000
+_cell_angle_alpha   107.82160000
+_cell_angle_beta   90.04748000
+_cell_angle_gamma   90.02775000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   70.95487801
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.37999446  0.44821834  0.01334974  1
+  C  C1  1  0.37988913  0.69897098  0.24529266  1
+  C  C2  1  0.88028508  0.42850371  0.47044864  1
+  C  C3  1  0.87979277  0.27823128  1.02017834  1
+  C  C4  1  0.37988550  0.00104448  0.21130062  1
+  C  C5  1  0.38011982  0.23636233  0.43633302  1
+  C  C6  1  0.87964993  0.05851863  0.10969748  1
+  C  C7  1  -0.11959212  0.92675218  0.61881785  1
+  C  C8  1  0.88006604  0.68441875  0.37548900  1
+  C  C9  1  0.38013641  0.50239038  0.79386651  1
+  C  C10  1  0.88020299  0.62237860  0.70786292  1
+  C  C11  1  0.38051149  0.12672065  0.63455475  1
+",-154.11571
+9532,C-72720-4972-19,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48105000
+_cell_length_b   3.69045000
+_cell_length_c   4.84295000
+_cell_angle_alpha   122.62945000
+_cell_angle_beta   104.93206000
+_cell_angle_gamma   70.28547000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.99463881
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.12155951  0.42863315  0.70156710  1
+  C  C1  1  0.54294300  0.71642917  0.83252521  1
+  C  C2  1  0.34529980  0.18976633  0.90825180  1
+  C  C3  1  0.08675805  1.13389237  0.33669308  1
+  C  C4  1  -0.13500199  0.37275335  0.13035150  1
+  C  C5  1  0.66495943  0.84627623  0.20563441  1
+",-154.3097445
+9150,C-189703-1540-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.82790000
+_cell_length_b   4.19912000
+_cell_length_c   4.20057000
+_cell_angle_alpha   60.00089000
+_cell_angle_beta   81.11627000
+_cell_angle_gamma   51.00087000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.13693515
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.60440242  0.07907727  0.41766213  1
+  C  C1  1  0.60290831  0.08003952  0.08369170  1
+  C  C2  1  0.60281061  0.74637337  0.75057604  1
+  C  C3  1  0.60335163  0.74644592  0.08388127  1
+  C  C4  1  0.60450224  0.41254908  0.75090333  1
+  C  C5  1  0.60407089  0.41243854  0.41754823  1
+",-154.41256866666666
+9169,C-157719-2936-35,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48728000
+_cell_length_b   4.30446000
+_cell_length_c   4.30427000
+_cell_angle_alpha   60.02435000
+_cell_angle_beta   73.20118000
+_cell_angle_gamma   106.78941000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   32.58516655
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.56527644  1.10313352  0.09715315  1
+  C  C1  1  0.31513625  0.35299333  0.84729334  1
+  C  C2  1  0.56527644  0.43646685  0.43048649  1
+  C  C3  1  0.56527644  0.76980019  0.76381982  1
+  C  C4  1  0.31513625  0.68632667  0.18062667  1
+  C  C5  1  0.31513625  0.01966000  0.51396001  1
+",-154.54380666666663
+5871,C-28260-8517-28,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.51330000
+_cell_length_b   4.18651000
+_cell_length_c   4.81252000
+_cell_angle_alpha   125.09282000
+_cell_angle_beta   121.33826000
+_cell_angle_gamma   72.61618000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.38789259
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.34690051  0.25572328  0.83681656  1
+  C  C1  1  0.82844117  0.86757064  1.12358410  1
+  C  C2  1  0.19677918  0.64359376  0.88044361  1
+  C  C3  1  0.82818504  0.64359553  0.51168709  1
+  C  C4  1  0.67820423  0.25573196  0.16729797  1
+  C  C5  1  0.19673396  0.86751363  0.49239886  1
+",-154.232386
+3411,C-76006-9814-42,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43220000
+_cell_length_b   3.09080000
+_cell_length_c   8.32505000
+_cell_angle_alpha   80.71261000
+_cell_angle_beta   82.88927000
+_cell_angle_gamma   69.99889000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.87860617
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.08028446  0.55810310  0.36384861  1
+  C  C1  1  0.07250059  0.90671549  0.03179537  1
+  C  C2  1  0.08266543  0.38766401  0.53030599  1
+  C  C3  1  0.07302587  0.07083371  0.86483106  1
+  C  C4  1  0.57313815  0.82094633  0.11483276  1
+  C  C5  1  0.57477729  0.15252195  0.78136668  1
+  C  C6  1  0.58123870  0.30562844  0.61372868  1
+  C  C7  1  0.57852310  0.64610907  0.28096095  1
+",-154.457425
+1758,C-47666-6962-2,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.42936000
+_cell_length_b   4.16056000
+_cell_length_c   6.17748000
+_cell_angle_alpha   70.96273000
+_cell_angle_beta   78.63349000
+_cell_angle_gamma   89.96349000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.72958174
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.55031312  0.99316295  0.87763722  1
+  C  C1  1  0.76518090  0.49008714  0.45528585  1
+  C  C2  1  1.10036109  0.94501290  -0.22093186  1
+  C  C3  1  -0.09412049  0.17263359  0.16357951  1
+  C  C4  1  0.45484199  0.12167339  1.06644934  1
+  C  C5  1  0.78416176  0.16177467  0.41216923  1
+  C  C6  1  0.22502628  0.95984575  0.52935056  1
+  C  C7  1  0.24988264  0.63078292  0.48529685  1
+",-154.23846125
+836,C-189742-1338-17,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.07335000
+_cell_length_b   4.63418000
+_cell_length_c   4.73009000
+_cell_angle_alpha   102.18023000
+_cell_angle_beta   119.11862000
+_cell_angle_gamma   117.69749000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   42.98911615
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.18623820  0.65733020  0.42821933  1
+  C  C1  1  0.85219913  0.65655320  0.09400533  1
+  C  C2  1  0.18623820  0.32399686  0.76155267  1
+  C  C3  1  0.85219913  -0.01011346  0.76067200  1
+  C  C4  1  -0.14780087  0.32321987  0.42733867  1
+  C  C5  1  0.18623820  -0.00933647  0.09488600  1
+",-154.4372495
+1450,C-9592-5537-52,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48735000
+_cell_length_b   4.69666000
+_cell_length_c   8.54961000
+_cell_angle_alpha   106.70398000
+_cell_angle_beta   106.92400000
+_cell_angle_gamma   90.05642000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C16
+_cell_volume   91.12949649
+_cell_formula_units_Z   16
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.28861019  0.66079593  0.39474242  1
+  C  C1  1  0.40133532  0.27898432  1.00789629  1
+  C  C2  1  0.00250811  0.10504935  0.60852896  1
+  C  C3  1  1.11585845  0.72273845  0.22073604  1
+  C  C4  1  0.78942090  0.16132436  0.89539786  1
+  C  C5  1  0.50253193  0.60486759  0.10796271  1
+  C  C6  1  0.62047742  0.57401098  0.72497192  1
+  C  C7  1  0.52048960  0.08822859  0.12463490  1
+  C  C8  1  0.28544890  0.31023810  0.39144148  1
+  C  C9  1  0.90063562  0.77889665  0.50740954  1
+  C  C10  1  0.78570056  0.81076801  0.89139065  1
+  C  C11  1  0.12097836  0.07337438  0.22517291  1
+  C  C12  1  -0.11422268  0.29688266  0.49222492  1
+  C  C13  1  0.02019442  0.58856923  0.62457037  1
+  C  C14  1  0.61594779  0.22314136  0.72132170  1
+  C  C15  1  0.38556921  0.79678455  0.99180003  1
+",-154.362595625
+9750,C-157711-6174-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43161000
+_cell_length_b   3.92238000
+_cell_length_c   4.74168000
+_cell_angle_alpha   95.27278000
+_cell_angle_beta   73.16902000
+_cell_angle_gamma   87.95887000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.01229281
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.49513972  0.29303712  0.39965322  1
+  C  C1  1  -0.17316464  0.96273833  0.73480752  1
+  C  C2  1  0.94086738  0.18097189  0.51039002  1
+  C  C3  1  0.16069349  0.62818125  0.06748310  1
+  C  C4  1  0.60640320  0.51627708  0.17830852  1
+  C  C5  1  1.27269875  0.85002893  0.84529472  1
+",-154.4552525
+8237,C-73645-3621-58,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.23029000
+_cell_length_b   4.27815000
+_cell_length_c   5.47454000
+_cell_angle_alpha   89.76020000
+_cell_angle_beta   75.45523000
+_cell_angle_gamma   89.77249000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   73.23067922
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.05678247  0.27466625  0.46044913  1
+  C  C1  1  1.09838483  0.77456050  0.18309502  1
+  C  C2  1  0.50481977  0.25741370  0.07060235  1
+  C  C3  1  0.57090654  1.09052655  0.62641498  1
+  C  C4  1  0.78546207  1.09002095  0.85861463  1
+  C  C5  1  0.84057828  0.60283157  0.40490143  1
+  C  C6  1  0.20072829  0.10202792  0.23874778  1
+  C  C7  1  0.53749840  0.75874639  0.57358030  1
+  C  C8  1  0.16216266  0.27206974  0.69223929  1
+  C  C9  1  0.25700874  0.58961576  0.78584371  1
+  C  C10  1  0.87991176  0.77112937  -0.04914420  1
+  C  C11  1  0.47187193  0.59009160  0.01759067  1
+",-154.14537416666667
+475,C-141033-8048-37,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48104000
+_cell_length_b   3.69001000
+_cell_length_c   4.84264000
+_cell_angle_alpha   111.53821000
+_cell_angle_beta   104.80916000
+_cell_angle_gamma   109.66843000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   35.00587217
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.11943947  0.58581205  0.58175151  1
+  C  C1  1  0.10331872  0.34699516  0.78808727  1
+  C  C2  1  0.41699800  0.40276131  0.35970735  1
+  C  C3  1  0.14171018  0.92905855  0.28393238  1
+  C  C4  1  0.39324811  1.05897329  0.65686236  1
+  C  C5  1  0.43321491  0.64160864  0.15314253  1
+",-154.31094366666667
+5756,C-130528-4330-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46778000
+_cell_length_b   3.32597000
+_cell_length_c   7.57556000
+_cell_angle_alpha   89.78640000
+_cell_angle_beta   89.99270000
+_cell_angle_gamma   79.76635000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   61.18879212
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.41574562  0.97361047  0.23955252  1
+  C  C1  1  -0.06038251  0.47526809  0.06629076  1
+  C  C2  1  0.41551663  0.97539465  0.89354157  1
+  C  C3  1  0.20108188  0.34253150  0.76133356  1
+  C  C4  1  0.98163563  0.70860868  0.89334903  1
+  C  C5  1  0.46010533  0.20637974  1.06636943  1
+  C  C6  1  0.98160923  0.70655363  0.23933786  1
+  C  C7  1  0.20153112  0.33899666  0.37292426  1
+  C  C8  1  0.70154832  0.34213040  0.65502408  1
+  C  C9  1  0.70186115  1.33952398  0.48005414  1
+",-154.145455
+7860,C-102871-6259-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.46442000
+_cell_length_b   4.65177000
+_cell_length_c   3.45704000
+_cell_angle_alpha   86.20398000
+_cell_angle_beta   85.31366000
+_cell_angle_gamma   67.10588000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   51.11628952
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.16331481  0.34421613  0.59835233  1
+  C  C1  1  0.82975422  0.33380910  0.94016977  1
+  C  C2  1  0.38863120  0.01672586  0.51568812  1
+  C  C3  1  0.79585987  0.51148468  0.31113869  1
+  C  C4  1  0.70651858  0.85518443  0.25383504  1
+  C  C5  1  -0.08117148  0.98970391  0.00135147  1
+  C  C6  1  0.46333877  0.50090968  0.65347004  1
+  C  C7  1  0.23996853  0.82731860  0.74305924  1
+",-154.10991875
+5959,C-170884-261-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44056000
+_cell_length_b   4.80800000
+_cell_length_c   8.81136000
+_cell_angle_alpha   111.82674000
+_cell_angle_beta   81.92240000
+_cell_angle_gamma   120.56235000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   82.49556088
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.64247540  0.44278019  0.56508018  1
+  C  C1  1  0.39606840  0.12743744  0.42784725  1
+  C  C2  1  0.87565728  0.93252017  0.08240636  1
+  C  C3  1  0.75863914  0.72245980  0.89270657  1
+  C  C4  1  0.24770695  0.58226801  0.63607551  1
+  C  C5  1  0.40099478  0.34566328  0.85123691  1
+  C  C6  1  0.56760212  0.14494712  0.12263417  1
+  C  C7  1  0.74083134  0.17843214  0.83489468  1
+  C  C8  1  0.88579412  0.48811619  0.17232855  1
+  C  C9  1  0.58197282  0.69706424  0.19799759  1
+  C  C10  1  0.77619200  0.97530469  0.36360074  1
+  C  C11  1  1.38666714  0.81042563  0.81252688  1
+",-154.22148333333334
+3540,C-9599-351-5,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43058000
+_cell_length_b   5.99151000
+_cell_length_c   5.69269000
+_cell_angle_alpha   79.80932000
+_cell_angle_beta   64.79438000
+_cell_angle_gamma   78.27769000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   73.06052141
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.04129602  0.09156846  0.11438139  1
+  C  C1  1  0.50931071  0.76428265  0.30852185  1
+  C  C2  1  0.22537447  -0.04150504  0.49456797  1
+  C  C3  1  0.35708257  0.15477037  0.26748164  1
+  C  C4  1  0.54670054  0.96453868  0.66943260  1
+  C  C5  1  0.44130754  0.76515847  0.87687358  1
+  C  C6  1  0.59012797  0.50784416  0.35844610  1
+  C  C7  1  0.19184230  0.39753688  0.31187814  1
+  C  C8  1  0.60347391  0.52557601  0.83587125  1
+  C  C9  1  1.21044610  0.41496844  0.78318842  1
+  C  C10  1  0.28635662  0.16521902  0.83147009  1
+  C  C11  1  0.14027285  0.83396859  0.14257197  1
+",-154.09846000000002
+9901,C-152552-1045-1,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47996000
+_cell_length_b   3.68688000
+_cell_length_c   4.21667000
+_cell_angle_alpha   104.75912000
+_cell_angle_beta   89.90572000
+_cell_angle_gamma   109.58252000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   34.97715526
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.15714388  0.23315008  0.81339498  1
+  C  C1  1  0.47505450  0.87243254  0.11053992  1
+  C  C2  1  0.35842945  0.63128201  0.73809345  1
+  C  C3  1  0.67642910  0.27080526  0.03558208  1
+  C  C4  1  0.89674245  0.71579990  0.24170702  1
+  C  C5  1  -0.06301237  0.78826960  0.60711326  1
+",-154.306049
+8242,C-53822-9555-4,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.48575000
+_cell_length_b   4.88216000
+_cell_length_c   4.76081000
+_cell_angle_alpha   92.74243000
+_cell_angle_beta   90.06423000
+_cell_angle_gamma   63.54271000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   72.43243325
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.42588155  0.46949105  0.04244956  1
+  C  C1  1  0.39540068  0.70408874  0.23984749  1
+  C  C2  1  0.08493462  1.02613510  0.25084080  1
+  C  C3  1  0.18854987  0.16483568  0.49318354  1
+  C  C4  1  0.53245584  0.94663381  0.62405644  1
+  C  C5  1  0.65096471  0.67352935  0.47211254  1
+  C  C6  1  0.75709266  0.15083380  0.05429561  1
+  C  C7  1  1.09874697  0.59409745  0.84523694  1
+  C  C8  1  0.79042417  0.91630306  0.85499436  1
+  C  C9  1  -0.00404707  0.45500906  0.60193612  1
+",-154.192581
+3861,C-13649-661-48,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48824000
+_cell_length_b   4.30484000
+_cell_length_c   4.30418000
+_cell_angle_alpha   80.43540000
+_cell_angle_beta   73.18809000
+_cell_angle_gamma   90.00071000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   43.46362453
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  -0.22081065  0.17697782  0.16980278  1
+  C  C1  1  0.84160547  0.86407280  0.04490720  1
+  C  C2  1  0.27926152  0.67696339  0.16978061  1
+  C  C3  1  0.52944502  0.42692901  0.66979236  1
+  C  C4  1  1.34156849  0.36407547  1.04490093  1
+  C  C5  1  1.02940804  0.92693168  0.66978609  1
+  C  C6  1  0.59175199  0.11404109  0.54491268  1
+  C  C7  1  1.09182416  0.61402666  0.54489051  1
+",-154.54470375
+249,C-41308-8899-21,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48712000
+_cell_length_b   4.49979000
+_cell_length_c   7.52156000
+_cell_angle_alpha   75.21034000
+_cell_angle_beta   90.00095000
+_cell_angle_gamma   106.04226000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   77.99376550
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.44535629  0.22839334  0.60387697  1
+  C  C1  1  0.44467838  0.22290727  0.23197389  1
+  C  C2  1  -0.07751974  0.18159525  0.49999550  1
+  C  C3  1  0.18109293  0.69636352  0.19596547  1
+  C  C4  1  0.27261428  -0.12123450  0.33463048  1
+  C  C5  1  1.00312122  0.34522659  -0.07336469  1
+  C  C6  1  -0.24596103  0.84346166  0.45748448  1
+  C  C7  1  0.00931161  0.35255044  0.29865592  1
+  C  C8  1  0.82829645  1.00013341  0.89604864  1
+  C  C9  1  0.52802449  0.39267640  0.03069939  1
+  C  C10  1  0.69759916  0.73112304  0.07285111  1
+  C  C11  1  1.13579198  0.61409738  0.74454075  1
+  C  C12  1  0.30665252  0.95804298  0.78601807  1
+  C  C13  1  0.61642666  0.57266271  0.63441040  1
+",-154.40842142857144
+2195,C-142779-5330-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.44725000
+_cell_length_b   6.17471000
+_cell_length_c   4.65647000
+_cell_angle_alpha   87.21315000
+_cell_angle_beta   79.32798000
+_cell_angle_gamma   91.87594000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   69.00287517
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.16683722  0.76618337  1.06069181  1
+  C  C1  1  0.21662148  0.53226612  0.99898395  1
+  C  C2  1  0.36718295  0.43339259  0.70456441  1
+  C  C3  1  1.08527518  0.93423451  0.55551376  1
+  C  C4  1  0.85985837  0.28786892  0.68903811  1
+  C  C5  1  0.68232505  0.11127528  0.93483025  1
+  C  C6  1  0.15896342  -0.03706978  0.87298568  1
+  C  C7  1  0.07410141  0.73827644  0.39474706  1
+  C  C8  1  0.63870129  0.45345721  0.17286169  1
+  C  C9  1  0.02116849  0.15302094  0.41766985  1
+  C  C10  1  0.59118691  0.21152521  0.23163151  1
+  C  C11  1  0.52829912  0.58815330  0.44252452  1
+",-154.10996833333334
+3987,C-106857-1903-32,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.50554000
+_cell_length_b   4.29058000
+_cell_length_c   6.64640000
+_cell_angle_alpha   74.32560000
+_cell_angle_beta   97.11432000
+_cell_angle_gamma   93.09881000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   68.24770428
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.36727669  0.71189331  0.28495799  1
+  C  C1  1  0.88320074  0.20902084  0.29591570  1
+  C  C2  1  0.57778540  0.34240225  0.61157084  1
+  C  C3  1  0.09830907  0.17661732  0.72813915  1
+  C  C4  1  0.79044618  0.67926968  0.97002800  1
+  C  C5  1  -0.11175679  0.82874857  0.74650131  1
+  C  C6  1  0.30481702  0.80919726  0.05452207  1
+  C  C7  1  0.24860603  0.17257284  0.96569904  1
+  C  C8  1  0.42569405  0.34851720  0.37339461  1
+  C  C9  1  0.78477008  0.68964936  0.59326958  1
+  C  C10  1  0.79052911  0.31131023  0.04397201  1
+  C  C11  1  0.88174481  0.84139253  0.36967890  1
+",-154.19310333333334
+8535,C-141047-6434-14,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.21372000
+_cell_length_b   4.22471000
+_cell_length_c   4.15598000
+_cell_angle_alpha   109.73473000
+_cell_angle_beta   99.22343000
+_cell_angle_gamma   56.36181000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   44.19252499
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.42245931  0.42033161  0.97462703  1
+  C  C1  1  0.36480275  0.98085489  0.47371040  1
+  C  C2  1  1.01813952  0.63368973  0.78230758  1
+  C  C3  1  0.57786296  0.57638341  0.28259672  1
+  C  C4  1  0.63534791  0.01580168  0.78356193  1
+  C  C5  1  -0.01807386  0.36291687  0.47498265  1
+",-154.1119125
+6454,C-79936-3117-59,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.46011000
+_cell_length_b   6.05196000
+_cell_length_c   7.62310000
+_cell_angle_alpha   91.72775000
+_cell_angle_beta   115.88297000
+_cell_angle_gamma   86.70045000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C18
+_cell_volume   101.94045660
+_cell_formula_units_Z   18
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  1.07020864  0.53752284  0.96936779  1
+  C  C1  1  -0.08272164  0.79663135  0.28065065  1
+  C  C2  1  0.25812188  1.21393091  0.16975950  1
+  C  C3  1  0.00586514  1.04575586  0.01736133  1
+  C  C4  1  0.20509235  0.44455159  0.50123477  1
+  C  C5  1  0.55076182  0.88623037  0.38085257  1
+  C  C6  1  0.59716269  0.89074136  1.05296644  1
+  C  C7  1  -0.13441988  0.48998905  0.62774996  1
+  C  C8  1  0.62830618  0.18663918  0.82834607  1
+  C  C9  1  0.15818326  0.20220673  0.46986659  1
+  C  C10  1  0.51592516  0.13004908  0.36039854  1
+  C  C11  1  1.06175745  0.34221840  0.81861778  1
+  C  C12  1  0.05836176  0.70765714  0.71620882  1
+  C  C13  1  0.87109028  -0.09309959  0.60813035  1
+  C  C14  1  0.93517288  0.54420939  0.28831137  1
+  C  C15  1  0.46668107  0.68275348  0.92590645  1
+  C  C16  1  0.29761224  0.45532635  0.17530392  1
+  C  C17  1  0.39375152  0.05274432  0.64403679  1
+",-154.1743577777778
+5831,C-13902-2321-18,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.45476000
+_cell_length_b   6.22073000
+_cell_length_c   7.71608000
+_cell_angle_alpha   60.50928000
+_cell_angle_beta   71.43229000
+_cell_angle_gamma   78.66321000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C14
+_cell_volume   97.10953341
+_cell_formula_units_Z   14
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.91585211  0.57146870  0.68659004  1
+  C  C1  1  0.12669250  0.57994921  0.47195626  1
+  C  C2  1  0.85532775  0.27978838  0.39573626  1
+  C  C3  1  0.65071090  0.23947475  0.11559258  1
+  C  C4  1  0.37374548  0.84676432  0.08975319  1
+  C  C5  1  1.16870139  0.84774724  0.29642153  1
+  C  C6  1  0.59960227  0.98336551  0.29836049  1
+  C  C7  1  0.75770020  0.79613712  0.73144207  1
+  C  C8  1  0.36826298  0.44501353  0.79735091  1
+  C  C9  1  1.22796418  0.31194996  1.00197822  1
+  C  C10  1  -0.03555122  0.85530227  -0.00628859  1
+  C  C11  1  0.70758538  0.45845550  0.45207667  1
+  C  C12  1  0.44900365  0.19759220  0.34285100  1
+  C  C13  1  0.16313422  0.84179700  0.80250856  1
+",-154.11459214285716
+3569,C-113086-7302-38,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.04555000
+_cell_length_b   4.85812000
+_cell_length_c   4.20677000
+_cell_angle_alpha   90.02330000
+_cell_angle_beta   78.21850000
+_cell_angle_gamma   110.73703000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   56.80734028
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.35999344  0.87613357  0.62857263  1
+  C  C1  1  0.35999344  0.62613357  0.12857263  1
+  C  C2  1  0.35528761  0.12497575  0.46286264  1
+  C  C3  1  0.35999344  0.12613357  0.12857263  1
+  C  C4  1  1.35528761  0.62497575  0.46286264  1
+  C  C5  1  0.35528761  0.37497575  0.96286264  1
+  C  C6  1  0.35528761  0.87497575  0.96286264  1
+  C  C7  1  0.35999344  0.37613357  0.62857263  1
+",-154.4378475
+3888,C-176656-6648-43,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.06591000
+_cell_length_b   4.50405000
+_cell_length_c   3.63471000
+_cell_angle_alpha   80.39281000
+_cell_angle_beta   69.22358000
+_cell_angle_gamma   103.34857000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   43.91936754
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.54013188  0.62836374  0.04792610  1
+  C  C1  1  0.03244659  0.13022967  0.61120758  1
+  C  C2  1  0.54125015  0.63064931  0.66582597  1
+  C  C3  1  0.35003680  0.43870618  0.45105061  1
+  C  C4  1  0.84023572  0.94057575  1.01441760  1
+  C  C5  1  0.83922797  0.93871715  0.39662085  1
+",-154.12491616666668
+8633,C-56501-2516-46,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43219000
+_cell_length_b   3.99503000
+_cell_length_c   6.24724000
+_cell_angle_alpha   108.46359000
+_cell_angle_beta   90.05385000
+_cell_angle_gamma   90.08192000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   57.57761229
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.25608071  1.08881676  0.83184779  1
+  C  C1  1  0.75604375  1.00489791  0.91521297  1
+  C  C2  1  0.75648024  0.34102889  0.58287494  1
+  C  C3  1  0.25655162  0.25519091  0.66504153  1
+  C  C4  1  -0.24375787  0.84148145  0.08320410  1
+  C  C5  1  0.25651929  0.59286219  0.33405827  1
+  C  C6  1  0.25635786  0.75791587  0.16658563  1
+  C  C7  1  0.75646850  0.50787782  0.41669777  1
+",-154.47846125
+7761,C-193936-350-29,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.43094000
+_cell_length_b   5.61479000
+_cell_length_c   6.54534000
+_cell_angle_alpha   67.14435000
+_cell_angle_beta   63.01930000
+_cell_angle_gamma   80.86713000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C10
+_cell_volume   73.34756365
+_cell_formula_units_Z   10
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.68925381  0.17367917  0.50961229  1
+  C  C1  1  0.02450292  0.50709037  0.84274190  1
+  C  C2  1  0.82067452  0.70843350  0.24338180  1
+  C  C3  1  1.09331863  0.77298707  0.70725855  1
+  C  C4  1  0.22031977  0.30828195  0.44449270  1
+  C  C5  1  0.88722669  -0.02528805  0.11000421  1
+  C  C6  1  0.48872565  0.37412426  0.91004709  1
+  C  C7  1  0.62497366  -0.09283993  0.64224293  1
+  C  C8  1  0.28817381  0.57435301  0.30926827  1
+  C  C9  1  0.42007063  1.10813624  1.04471918  1
+",-154.46633500000002
+7197,C-57133-9728-26,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48488000
+_cell_length_b   4.67971000
+_cell_length_c   4.08739000
+_cell_angle_alpha   83.31500000
+_cell_angle_beta   89.99632000
+_cell_angle_gamma   74.53858000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C8
+_cell_volume   45.47490108
+_cell_formula_units_Z   8
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.63794098  0.03927755  0.18085108  1
+  C  C1  1  0.86885079  0.58337313  0.46953543  1
+  C  C2  1  0.52610559  0.27075389  0.87495969  1
+  C  C3  1  0.81041962  0.69753627  0.11396599  1
+  C  C4  1  0.02698169  0.26906484  0.64912327  1
+  C  C5  1  0.13679754  0.04191457  0.40738320  1
+  C  C6  1  0.29569931  0.72784076  0.58745654  1
+  C  C7  1  0.35465857  0.61147529  0.94326880  1
+",-154.36982
+4509,C-106853-7201-27,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.47167000
+_cell_length_b   4.77572000
+_cell_length_c   6.09221000
+_cell_angle_alpha   72.19268000
+_cell_angle_beta   81.74181000
+_cell_angle_gamma   94.76660000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   67.13867611
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.10801679  0.70931280  0.24835711  1
+  C  C1  1  0.47197295  0.48946007  0.61945959  1
+  C  C2  1  0.86969285  1.06378798  0.92637951  1
+  C  C3  1  0.86156541  0.81102462  0.79645154  1
+  C  C4  1  0.45152044  0.26591030  0.86184706  1
+  C  C5  1  0.64231228  0.49987298  0.98475000  1
+  C  C6  1  0.10326449  0.47802585  0.12859195  1
+  C  C7  1  1.05210055  0.23236649  0.36406157  1
+  C  C8  1  0.53192087  0.04479026  0.39593324  1
+  C  C9  1  0.02164889  0.47016887  0.48567553  1
+  C  C10  1  0.42893323  0.80633748  0.64752310  1
+  C  C11  1  0.65267393  0.89562771  0.20039919  1
+",-154.19442333333333
+5470,C-13946-920-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.23389000
+_cell_length_b   2.46933000
+_cell_length_c   5.18010000
+_cell_angle_alpha   89.99936000
+_cell_angle_beta   92.09615000
+_cell_angle_gamma   112.45907000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C6
+_cell_volume   38.19846440
+_cell_formula_units_Z   6
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.03454097  0.68775861  0.79826245  1
+  C  C1  1  0.31103248  0.32505928  0.79601633  1
+  C  C2  1  0.65878379  0.99972597  0.42525248  1
+  C  C3  1  0.65753820  0.49872478  0.57816872  1
+  C  C4  1  0.68841616  0.51717425  0.01706286  1
+  C  C5  1  0.68726470  0.01667891  0.16990346  1
+",-154.2514825
+9936,C-148254-5891-31,"# generated using pymatgen
+data_C
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   2.48607000
+_cell_length_b   4.97593000
+_cell_length_c   5.85878000
+_cell_angle_alpha   75.08076000
+_cell_angle_beta   89.99800000
+_cell_angle_gamma   90.00252000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   C
+_chemical_formula_sum   C12
+_cell_volume   70.03290564
+_cell_formula_units_Z   12
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  C  C0  1  0.24523008  1.09024602  0.34687517  1
+  C  C1  1  0.24527239  0.85600894  0.20643574  1
+  C  C2  1  0.24517628  0.86349756  0.60297194  1
+  C  C3  1  0.74547191  0.49659202  0.08033512  1
+  C  C4  1  0.24516846  0.63078870  0.46074227  1
+  C  C5  1  0.24550333  0.44015974  -0.02607617  1
+  C  C6  1  0.74528419  0.27428896  0.31612846  1
+  C  C7  1  0.74523183  0.44565866  0.49125622  1
+  C  C8  1  0.74546412  0.22441805  0.72715119  1
+  C  C9  1  0.74532018  0.80306274  0.06903737  1
+  C  C10  1  0.24550039  0.27907768  0.83450425  1
+  C  C11  1  0.74517913  0.91814072  0.73978123  1
+",-154.071055


### PR DESCRIPTION
Added a preprocess step which converts from small OCP arrow file (712 examples like mini) into a `CrystDataset`, and an experiment `ocp` which will use it.

Data loading takes significantly longer, I assume because there's a much larger number of atoms per grid in this case